### PR TITLE
Add --target support for backfills

### DIFF
--- a/bigquery_etl/backfill/utils.py
+++ b/bigquery_etl/backfill/utils.py
@@ -104,21 +104,36 @@ def get_backfill_file_from_qualified_table_name(sql_dir, qualified_table_name) -
     return backfill_file
 
 
-# TODO: It would be better to take in a backfill object.
-def get_backfill_staging_qualified_table_name(qualified_table_name, entry_date) -> str:
-    """Return full table name where processed backfills are stored."""
+def get_backfill_staging_qualified_table_name(
+    qualified_table_name, entry_date, destination_project: Optional[str] = None
+) -> str:
+    """Return full table name where processed backfills are stored.
+
+    When a target environment is active, destination_project points the staging
+    table at the target project (e.g. a dev sandbox) instead of production.
+    """
     _, dataset, table = qualified_table_name_matching(qualified_table_name)
     backfill_table_id = f"{dataset}__{table}_{entry_date}".replace("-", "_")
+    project = destination_project or BACKFILL_DESTINATION_PROJECT
 
-    return f"{BACKFILL_DESTINATION_PROJECT}.{BACKFILL_DESTINATION_DATASET}.{backfill_table_id}"
+    return f"{project}.{BACKFILL_DESTINATION_DATASET}.{backfill_table_id}"
 
 
-def get_backfill_backup_table_name(qualified_table_name: str, entry_date: date) -> str:
-    """Return full table name where backup of production table is stored."""
+def get_backfill_backup_table_name(
+    qualified_table_name: str,
+    entry_date: date,
+    destination_project: Optional[str] = None,
+) -> str:
+    """Return full table name where backup of production table is stored.
+
+    When a target environment is active, destination_project points the backup
+    table at the target project (e.g. a dev sandbox) instead of production.
+    """
     _, dataset, table = qualified_table_name_matching(qualified_table_name)
     cloned_table_id = f"{dataset}__{table}_backup_{entry_date}".replace("-", "_")
+    project = destination_project or BACKFILL_DESTINATION_PROJECT
 
-    return f"{BACKFILL_DESTINATION_PROJECT}.{BACKFILL_DESTINATION_DATASET}.{cloned_table_id}"
+    return f"{project}.{BACKFILL_DESTINATION_DATASET}.{cloned_table_id}"
 
 
 def validate_table_metadata(
@@ -210,9 +225,15 @@ def get_scheduled_backfills(
     status: Optional[str] = None,
     ignore_old_entries: bool = False,
     ignore_missing_metadata: bool = False,
+    destination_project: Optional[str] = None,
 ) -> Dict[str, Backfill]:
-    """Return backfill entries to initiate or complete."""
-    client = bigquery.Client(project=project)
+    """Return backfill entries to initiate or complete.
+
+    When a target environment is active, destination_project is where the staging
+    and backup tables live (the target project), which is checked for existence
+    instead of the production backfill project.
+    """
+    client = bigquery.Client(project=destination_project or project)
 
     if qualified_table_name:
         backfills_dict = {
@@ -265,10 +286,14 @@ def get_scheduled_backfills(
 
         if (
             BackfillStatus.INITIATE.value == status
-            and _should_initiate(client, entry_to_process, qualified_table_name)
+            and _should_initiate(
+                client, entry_to_process, qualified_table_name, destination_project
+            )
         ) or (
             BackfillStatus.COMPLETE.value == status
-            and _should_complete(client, entry_to_process, qualified_table_name)
+            and _should_complete(
+                client, entry_to_process, qualified_table_name, destination_project
+            )
         ):
             backfills_to_process_dict[qualified_table_name] = entry_to_process
 
@@ -276,7 +301,10 @@ def get_scheduled_backfills(
 
 
 def _should_initiate(
-    client: bigquery.Client, backfill: Backfill, qualified_table_name: str
+    client: bigquery.Client,
+    backfill: Backfill,
+    qualified_table_name: str,
+    destination_project: Optional[str] = None,
 ) -> bool:
     """Determine whether a backfill should be initiated.
 
@@ -286,7 +314,7 @@ def _should_initiate(
         return False
 
     staging_table = get_backfill_staging_qualified_table_name(
-        qualified_table_name, backfill.entry_date
+        qualified_table_name, backfill.entry_date, destination_project
     )
 
     if _table_exists(client, staging_table):
@@ -296,7 +324,10 @@ def _should_initiate(
 
 
 def _should_complete(
-    client: bigquery.Client, backfill: Backfill, qualified_table_name: str
+    client: bigquery.Client,
+    backfill: Backfill,
+    qualified_table_name: str,
+    destination_project: Optional[str] = None,
 ) -> bool:
     """Determine whether a backfill should be completed.
 
@@ -306,14 +337,14 @@ def _should_complete(
         return False
 
     staging_table = get_backfill_staging_qualified_table_name(
-        qualified_table_name, backfill.entry_date
+        qualified_table_name, backfill.entry_date, destination_project
     )
     if not _table_exists(client, staging_table):
         click.echo(f"Backfill staging table does not exist: {staging_table}")
         return False
 
     backup_table_name = get_backfill_backup_table_name(
-        qualified_table_name, backfill.entry_date
+        qualified_table_name, backfill.entry_date, destination_project
     )
     if _table_exists(client, backup_table_name):
         click.echo(f"Backfill backup table already exists: {backup_table_name}")

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -81,6 +81,18 @@ def _get_target(ctx) -> Optional[Target]:
     return ctx.obj.get("target") if ctx.obj else None
 
 
+def _destination_project(
+    target: Optional[Target], default: Optional[str]
+) -> Optional[str]:
+    """Return the project backfills act in: the target project, else the default.
+
+    Pass default=None when used for the staging/backup destination_project (None
+    falls back to the production backfill project); pass the prod project_id when
+    used to pick the BigQuery client project.
+    """
+    return target.project_id if target else default
+
+
 def _resolve_backfill_table(
     target: Optional[Target], source_qualified_table_name: str
 ) -> Tuple[str, Optional[str]]:
@@ -560,7 +572,7 @@ def scheduled(
         status=status,
         ignore_old_entries=ignore_old_entries,
         ignore_missing_metadata=ignore_missing_metadata,
-        destination_project=target.project_id if target else None,
+        destination_project=_destination_project(target, None),
     )
 
     for qualified_table_name, entry in backfills.items():
@@ -629,7 +641,7 @@ def initiate(
         project_id,
         qualified_table_name,
         status=BackfillStatus.INITIATE.value,
-        destination_project=target.project_id if target else None,
+        destination_project=_destination_project(target, None),
     )
 
     if not backfills_to_process_dict:
@@ -652,6 +664,18 @@ def initiate(
 
     project, dataset, table = qualified_table_name_matching(qualified_table_name)
     is_python_script = (Path(sql_dir) / project / dataset / table / "query.py").exists()
+
+    # Python-script backfills aren't redirected under --target: the script's destination is baked
+    # into query_script_args at create time (pointing at the production staging project) and
+    # skip_target_resolution prevents any rewrite, so the script would write to the production
+    # staging table. Reject the combination rather than silently target the wrong project.
+    # Limitation tracked in https://mozilla-hub.atlassian.net/browse/DENG-10054
+    if target is not None and is_python_script:
+        raise click.UsageError(
+            "--target is not supported for query.py (python script) backfills. "
+            "Run the script directly against the target."
+        )
+
     query_path = (
         Path(sql_dir)
         / project
@@ -660,7 +684,7 @@ def initiate(
         / ("query.py" if is_python_script else "query.sql")
     )
 
-    effective_project = target.project_id if target else project_id
+    effective_project = _destination_project(target, project_id)
     client = bigquery.Client(project=effective_project)
 
     if target is not None:
@@ -697,7 +721,7 @@ def initiate(
         try:
             copy_permissions_to_staging_table(
                 client,
-                qualified_table_name,
+                effective_table_name,
                 backfill_staging_qualified_table_name,
             )
         except Exception as e:
@@ -905,6 +929,9 @@ def _initiate_backfill(
 
         custom_query_path = replaced_ref_query
 
+        # Seed the previous partition from effective_table_name (the --target table).
+        # The query reads production source tables for the new partitions, so under --target,
+        # the staging result intentionally mixes a target base partition with production partitions.
         _initialize_previous_partition(
             client,
             effective_table_name,
@@ -1053,7 +1080,7 @@ def complete(ctx, qualified_table_name, copy_table_permissions, sql_dir, project
         sys.exit(1)
 
     target = _get_target(ctx)
-    effective_project = target.project_id if target else project_id
+    effective_project = _destination_project(target, project_id)
     client = bigquery.Client(project=effective_project)
 
     click.echo("Backfill processing (complete) started....")
@@ -1063,7 +1090,7 @@ def complete(ctx, qualified_table_name, copy_table_permissions, sql_dir, project
         project_id,
         qualified_table_name,
         status=BackfillStatus.COMPLETE.value,
-        destination_project=target.project_id if target else None,
+        destination_project=_destination_project(target, None),
     )
 
     if not backfills_to_process_dict:

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -70,11 +70,7 @@ from ..metadata.validate_metadata import (
 )
 from ..schema import SCHEMA_FILE, Schema
 from ..util.common import block_coding_agents
-from ..util.target import (
-    Target,
-    _target_ref_for_source,
-    ensure_dataset_exists,
-)
+from ..util.target import Target, ensure_dataset_exists, target_ref_for_source
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -103,7 +99,7 @@ def _resolve_backfill_table(
     src_project, src_dataset, src_table = qualified_table_name_matching(
         source_qualified_table_name
     )
-    tgt_project, tgt_dataset, tgt_table = _target_ref_for_source(
+    tgt_project, tgt_dataset, tgt_table = target_ref_for_source(
         target,
         target.project_id or src_project,
         src_project,

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -8,6 +8,7 @@ import tempfile
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
 from pathlib import Path
+from typing import Optional, Tuple
 
 import rich_click as click
 import yaml
@@ -32,6 +33,7 @@ from ..backfill.shredder_mitigation import (
     generate_query_with_shredder_mitigation,
 )
 from ..backfill.utils import (
+    BACKFILL_DESTINATION_DATASET,
     MAX_BACKFILL_ENTRY_AGE_DAYS,
     copy_permissions_to_staging_table,
     get_backfill_backup_table_name,
@@ -68,9 +70,48 @@ from ..metadata.validate_metadata import (
 )
 from ..schema import SCHEMA_FILE, Schema
 from ..util.common import block_coding_agents
+from ..util.target import (
+    Target,
+    _target_ref_for_source,
+    ensure_dataset_exists,
+)
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
+
+
+def _get_target(ctx) -> Optional[Target]:
+    """Return the active target from the click context, or None."""
+    return ctx.obj.get("target") if ctx.obj else None
+
+
+def _resolve_backfill_table(
+    target: Optional[Target], source_qualified_table_name: str
+) -> Tuple[str, Optional[str]]:
+    """Resolve the table a backfill operates on and where its staging table lives.
+
+    Without a target this is a no-op: returns the source (production) table and
+    None (staging/backup default to the production backfill project).
+
+    With a target, the backfill is redirected into the target environment: the
+    table being backfilled is the target-deployed equivalent, and staging/backup
+    tables live in the target project (so production write access isn't required).
+    """
+    if target is None:
+        return source_qualified_table_name, None
+
+    src_project, src_dataset, src_table = qualified_table_name_matching(
+        source_qualified_table_name
+    )
+    tgt_project, tgt_dataset, tgt_table = _target_ref_for_source(
+        target,
+        target.project_id or src_project,
+        src_project,
+        src_dataset,
+        src_table,
+    )
+    return f"{tgt_project}.{tgt_dataset}.{tgt_table}", target.project_id
+
 
 ignore_missing_metadata_option = click.option(
     "--ignore-missing-metadata",
@@ -515,6 +556,7 @@ def scheduled(
     ignore_missing_metadata,
 ):
     """Return list of backfill(s) that require processing."""
+    target = _get_target(ctx)
     backfills = get_scheduled_backfills(
         sql_dir,
         project_id,
@@ -522,6 +564,7 @@ def scheduled(
         status=status,
         ignore_old_entries=ignore_old_entries,
         ignore_missing_metadata=ignore_missing_metadata,
+        destination_project=target.project_id if target else None,
     )
 
     for qualified_table_name, entry in backfills.items():
@@ -583,8 +626,14 @@ def initiate(
     """Process backfill entry with initiate status in backfill.yaml file(s)."""
     click.echo("Backfill processing (initiate) started....")
 
+    target = _get_target(ctx)
+
     backfills_to_process_dict = get_scheduled_backfills(
-        sql_dir, project_id, qualified_table_name, status=BackfillStatus.INITIATE.value
+        sql_dir,
+        project_id,
+        qualified_table_name,
+        status=BackfillStatus.INITIATE.value,
+        destination_project=target.project_id if target else None,
     )
 
     if not backfills_to_process_dict:
@@ -593,8 +642,16 @@ def initiate(
 
     entry_to_initiate = backfills_to_process_dict[qualified_table_name]
 
+    # When a target is active, the backfill is redirected into the target
+    # environment: it operates on the target-deployed table and stages into the target project
+    effective_table_name, staging_destination_project = _resolve_backfill_table(
+        target, qualified_table_name
+    )
+
     backfill_staging_qualified_table_name = get_backfill_staging_qualified_table_name(
-        qualified_table_name, entry_to_initiate.entry_date
+        qualified_table_name,
+        entry_to_initiate.entry_date,
+        destination_project=staging_destination_project,
     )
 
     project, dataset, table = qualified_table_name_matching(qualified_table_name)
@@ -607,14 +664,24 @@ def initiate(
         / ("query.py" if is_python_script else "query.sql")
     )
 
-    client = bigquery.Client(project=project_id)
+    effective_project = target.project_id if target else project_id
+    client = bigquery.Client(project=effective_project)
+
+    if target is not None:
+        # Permission mirroring from the production table is meaningless in a dev
+        # target; make sure the target staging dataset exists instead.
+        copy_table_permissions = False
+        ensure_dataset_exists(
+            client,
+            f"{staging_destination_project}.{BACKFILL_DESTINATION_DATASET}",
+        )
 
     if copy_table_permissions:
         try:
-            client.get_table(qualified_table_name)
+            client.get_table(effective_table_name)
         except NotFound:
             raise RuntimeError(
-                f"Cannot use --copy-table-permissions since {qualified_table_name} does not exist."
+                f"Cannot use --copy-table-permissions since {effective_table_name} does not exist."
             ) from None
 
     # create schema before deploying staging table if it does not exist
@@ -673,15 +740,19 @@ def initiate(
         if copy_table_permissions and not is_python_script:
             _copy_permissions_with_cleanup()
 
-    billing_project = DEFAULT_BILLING_PROJECT
+    if target is not None:
+        # Dev backfills bill to the target project, not the production backfill slots.
+        billing_project = entry_to_initiate.billing_project or target.project_id
+    else:
+        billing_project = DEFAULT_BILLING_PROJECT
 
-    # override with billing project from backfill entry
-    if entry_to_initiate.billing_project is not None:
-        billing_project = entry_to_initiate.billing_project
-    elif not billing_project.startswith("moz-fx-data-backfill-"):
-        raise ValueError(
-            f"Invalid billing project: {billing_project}.  Please use one of the projects assigned to backfills."
-        )
+        # override with billing project from backfill entry
+        if entry_to_initiate.billing_project is not None:
+            billing_project = entry_to_initiate.billing_project
+        elif not billing_project.startswith("moz-fx-data-backfill-"):
+            raise ValueError(
+                f"Invalid billing project: {billing_project}.  Please use one of the projects assigned to backfills."
+            )
 
     if not is_python_script or entry_to_initiate.query_script_dry_run_arg:
         click.echo(
@@ -698,6 +769,7 @@ def initiate(
             billing_project=billing_project,
             is_python_script=is_python_script,
             query_script_dry_run_arg=entry_to_initiate.query_script_dry_run_arg,
+            effective_table_name=effective_table_name,
         )
 
     click.echo(
@@ -711,6 +783,7 @@ def initiate(
         parallelism,
         billing_project=billing_project,
         is_python_script=is_python_script,
+        effective_table_name=effective_table_name,
     )
 
     if copy_table_permissions and is_python_script:
@@ -731,6 +804,7 @@ def _initiate_backfill(
     billing_project=DEFAULT_BILLING_PROJECT,
     is_python_script=False,
     query_script_dry_run_arg=None,
+    effective_table_name: Optional[str] = None,
 ):
     if not is_authenticated():
         click.echo(
@@ -738,6 +812,11 @@ def _initiate_backfill(
             "and check that the project is set correctly."
         )
         sys.exit(1)
+
+    # qualified_table_name keys the repo path + the production reference inside the
+    # query; effective_table_name is the table actually read/written, which differs
+    # under a target environment.
+    effective_table_name = effective_table_name or qualified_table_name
 
     project, dataset, table = qualified_table_name_matching(qualified_table_name)
 
@@ -775,7 +854,8 @@ def _initiate_backfill(
         )
         sys.exit(1)
 
-    client = bigquery.Client(project=project)
+    effective_project, _, _ = qualified_table_name_matching(effective_table_name)
+    client = bigquery.Client(project=effective_project)
 
     if entry.shredder_mitigation is True:
         click.echo(
@@ -831,7 +911,7 @@ def _initiate_backfill(
 
         _initialize_previous_partition(
             client,
-            qualified_table_name,
+            effective_table_name,
             backfill_staging_qualified_table_name,
             metadata,
             entry,
@@ -876,6 +956,9 @@ def _initiate_backfill(
             billing_project=billing_project,
             scheduling_overrides=scheduling_overrides,
             override_retention_range_limit=override_retention_limit,
+            # initiate already resolved the staging destination for the active target;
+            # don't let query backfill re-apply target redirection.
+            skip_target_resolution=True,
         )
     except subprocess.CalledProcessError as e:
         raise ValueError(
@@ -972,12 +1055,19 @@ def complete(ctx, qualified_table_name, copy_table_permissions, sql_dir, project
             "and check that the project is set correctly."
         )
         sys.exit(1)
-    client = bigquery.Client(project=project_id)
+
+    target = _get_target(ctx)
+    effective_project = target.project_id if target else project_id
+    client = bigquery.Client(project=effective_project)
 
     click.echo("Backfill processing (complete) started....")
 
     backfills_to_process_dict = get_scheduled_backfills(
-        sql_dir, project_id, qualified_table_name, status=BackfillStatus.COMPLETE.value
+        sql_dir,
+        project_id,
+        qualified_table_name,
+        status=BackfillStatus.COMPLETE.value,
+        destination_project=target.project_id if target else None,
     )
 
     if not backfills_to_process_dict:
@@ -990,20 +1080,32 @@ def complete(ctx, qualified_table_name, copy_table_permissions, sql_dir, project
         f"Completing backfill for {qualified_table_name} with entry date {entry_to_complete.entry_date}:"
     )
 
+    # Under a target, swap into the target-deployed table and use target-project
+    # staging/backup tables.
+    effective_table_name, staging_destination_project = _resolve_backfill_table(
+        target, qualified_table_name
+    )
+    if target is not None:
+        copy_table_permissions = False
+
     backfill_staging_qualified_table_name = get_backfill_staging_qualified_table_name(
-        qualified_table_name, entry_to_complete.entry_date
+        qualified_table_name,
+        entry_to_complete.entry_date,
+        destination_project=staging_destination_project,
     )
 
     # clone production table
     cloned_table_full_name = get_backfill_backup_table_name(
-        qualified_table_name, entry_to_complete.entry_date
+        qualified_table_name,
+        entry_to_complete.entry_date,
+        destination_project=staging_destination_project,
     )
-    _copy_table(qualified_table_name, cloned_table_full_name, client, clone=True)
+    _copy_table(effective_table_name, cloned_table_full_name, client, clone=True)
 
     if copy_table_permissions:
         copy_permissions_to_staging_table(
             client,
-            qualified_table_name,
+            effective_table_name,
             cloned_table_full_name,
         )
 
@@ -1014,10 +1116,11 @@ def complete(ctx, qualified_table_name, copy_table_permissions, sql_dir, project
 
     _copy_backfill_staging_to_prod(
         backfill_staging_qualified_table_name,
-        qualified_table_name,
+        effective_table_name,
         client,
         entry_to_complete,
         table_metadata,
+        skip_public_redirect=target is not None,
     )
 
     # delete backfill staging table
@@ -1037,15 +1140,19 @@ def _copy_backfill_staging_to_prod(
     client: bigquery.Client,
     entry: Backfill,
     table_metadata: Metadata,
+    skip_public_redirect: bool = False,
 ):
     """Copy backfill staging table to prod based on table metadata and backfill config.
+
+    skip_public_redirect keeps the destination as given (used by target environments,
+    where the public-project redirect doesn't apply).
 
     If table is
        un-partitioned: copy the entire staging table to production.
        partitioned: determine and copy each partition from staging to production.
     """
     # If this is a public dataset, change the destination to the public project
-    if table_metadata.is_public_bigquery():
+    if not skip_public_redirect and table_metadata.is_public_bigquery():
         project, dataset, table = qualified_table_name_matching(qualified_table_name)
         public_project_id = ConfigLoader.get(
             "default", "public_project", fallback="mozilla-public-data"

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -782,9 +782,13 @@ def backfill(
             f"Found multiple query source files to backfill: {query_files}"
         )
 
-    # The managed backfill flow (bqetl backfill initiate) drives this command with a
+    # The managed backfill flow (bqetl backfill initiate) calls this command with a
     # destination already resolved for the active target, so it opts out of target
     # redirection here to avoid double-handling.
+    #
+    # NOTE: any internal caller that passes --destination-table together with an active
+    # ctx target MUST also pass skip_target_resolution=True; otherwise the
+    # mutual-exclusivity check below raises.
     target = (
         None if skip_target_resolution else (ctx.obj.get("target") if ctx.obj else None)
     )

--- a/bigquery_etl/cli/query.py
+++ b/bigquery_etl/cli/query.py
@@ -710,6 +710,16 @@ def _backfill_script(
 @backfill_options.query_script_entrypoint()
 @backfill_options.query_script_date_arg()
 @backfill_options.query_script_arg()
+@defer_option()
+@click.option(
+    "--skip-target-resolution",
+    "--skip_target_resolution",
+    is_flag=True,
+    default=False,
+    hidden=True,
+    help="Internal: skip --target redirection because the caller (managed backfill) "
+    "has already resolved the destination table.",
+)
 @click.pass_context
 def backfill(
     ctx,
@@ -732,6 +742,8 @@ def backfill(
     query_script_entrypoint,
     query_script_date_arg,
     query_script_arg,
+    defer_to_target,
+    skip_target_resolution,
 ):
     """Run a backfill."""
     if not is_authenticated():
@@ -769,6 +781,32 @@ def backfill(
         raise click.ClickException(
             f"Found multiple query source files to backfill: {query_files}"
         )
+
+    # The managed backfill flow (bqetl backfill initiate) drives this command with a
+    # destination already resolved for the active target, so it opts out of target
+    # redirection here to avoid double-handling.
+    target = (
+        None if skip_target_resolution else (ctx.obj.get("target") if ctx.obj else None)
+    )
+
+    if target and destination_table:
+        raise click.UsageError(
+            "--destination-table and --target are mutually exclusive."
+        )
+
+    # prepare target directories if using --target; the backfill then reads the
+    # target-copied query, runs in the target project, and writes to the target table
+    if target and target.project_id != project_id:
+        query_files = prepare_target_files(
+            query_files,
+            sql_dir,
+            project_id,
+            target,
+            defer_to_target,
+            isolated=False,
+            auto_deploy=True,
+        )
+        project_id = target.project_id
 
     query_file = query_files[0]
     query_file_path = Path(query_file)

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -663,7 +663,7 @@ def _create_target_stub(
     """
     is_wildcard = "*" in name
     stub_name = name.replace("*", "wildcard") if is_wildcard else name
-    tgt_project, tgt_dataset, tgt_table = _target_ref_for_source(
+    tgt_project, tgt_dataset, tgt_table = target_ref_for_source(
         target, target.project_id, project, dataset, stub_name
     )
     stub_path = Path(sql_dir) / tgt_project / tgt_dataset / tgt_table
@@ -850,7 +850,7 @@ def collect_target_dependencies(
     return artifact_dependencies
 
 
-def _target_ref_for_source(
+def target_ref_for_source(
     target: "Target",
     target_project: str,
     src_project: str,
@@ -961,7 +961,7 @@ def rewrite_for_isolated(
         sql = _substitute_3part_ref(
             sql,
             (src_project, src_dataset, src_table),
-            _target_ref_for_source(
+            target_ref_for_source(
                 target, target_project, src_project, src_dataset, src_table
             ),
         )
@@ -980,7 +980,7 @@ def rewrite_for_isolated(
         src_dataset, src_name = routine_name.split(".")
         if not _is_deployed(routine.project, src_dataset, src_name):
             continue
-        tgt = _target_ref_for_source(
+        tgt = target_ref_for_source(
             target, target_project, routine.project, src_dataset, src_name
         )
         udf_pattern = routine_usage_pattern(routine_name, routine.project)
@@ -1016,7 +1016,7 @@ def rewrite_for_defer(
         """
         if not (info.source_project and info.source_dataset and info.source_table):
             return None
-        _, expected_ds, _ = _target_ref_for_source(
+        _, expected_ds, _ = target_ref_for_source(
             target,
             target_project,
             info.source_project,
@@ -1089,7 +1089,7 @@ def prepare_target_directory(
 ) -> Path:
     """Prepare target directory for query execution with --target."""
     source_project, source_dataset, source_table = extract_from_query_path(query_file)
-    effective_project, effective_dataset, effective_table = _target_ref_for_source(
+    effective_project, effective_dataset, effective_table = target_ref_for_source(
         target,
         target.project_id or source_project,
         source_project,
@@ -1175,7 +1175,7 @@ def prepare_target_directory(
         for match in PERSISTENT_UDF_RE.finditer(sql):
             src_ds = match.group("dataset")
             src_nm = match.group("name")
-            _, tgt_ds, tgt_nm = _target_ref_for_source(
+            _, tgt_ds, tgt_nm = target_ref_for_source(
                 target,
                 effective_project,
                 source_project,

--- a/docs/cookbooks/backfilling_a_table.md
+++ b/docs/cookbooks/backfilling_a_table.md
@@ -25,6 +25,32 @@ The managed backfill workflow (`bqetl backfill create` / `initiate`) validates a
 
 The hard rejections (no override) are enforced by [`validate_table_metadata`](https://github.com/mozilla/bigquery-etl/tree/main/bigquery_etl/backfill/utils.py) in `bigquery_etl/backfill/utils.py`; the date/retention/duplicate checks live in [`bigquery_etl/backfill/validate.py`](https://github.com/mozilla/bigquery-etl/tree/main/bigquery_etl/backfill/validate.py).
 
+## Testing a backfill in a dev environment
+
+Before running a managed backfill against production, you can exercise the full
+`initiate` and `complete` flow against a [development target](development_workflows.md) by
+passing the global `--target` flag. With a target active, the backfill operates on the
+target-deployed table and stages into the target project (e.g. your sandbox).
+The query does not change, so it will still read from production tables:
+
+```bash
+# Deploy the table into your dev target first (see Development Workflows), then:
+./bqetl --target dev backfill initiate moz-fx-data-shared-prod.monitoring_derived.shredder_per_job_stats_v1
+# validate the staged data, then:
+./bqetl --target dev backfill complete moz-fx-data-shared-prod.monitoring_derived.shredder_per_job_stats_v1
+```
+
+What changes under `--target`:
+
+- Staging and backup tables are created in the **target project**'s
+  `backfills_staging_derived` dataset instead of production's.
+- The table that gets backed up and swapped is the **target-deployed** copy of the table,
+  not the production table.
+- Queries bill to the target project, and production IAM mirroring is skipped.
+
+The `backfill.yaml` entry is still read from the repo as usual; only the BigQuery
+locations are redirected. Without `--target`, behavior is unchanged (production backfill).
+
 ## Initiating the backfill:
 
 1. Create a backfill schedule entry to (re)-process data in your table:

--- a/docs/cookbooks/backfilling_a_table.md
+++ b/docs/cookbooks/backfilling_a_table.md
@@ -27,6 +27,12 @@ The hard rejections (no override) are enforced by [`validate_table_metadata`](ht
 
 ## Testing a backfill in a dev environment
 
+We can't create tables in `moz-fx-data-shared-prod.backfills_staging_derived`, so running
+the full managed backfill workflow locally is only possible with `--target`, which stages into 
+a test project. We can write to tables that already exist in
+`moz-fx-data-shared-prod.backfills_staging_derived`, so an active backfill can be
+amended by writing to its existing staging table.
+
 Before running a managed backfill against production, you can exercise the full
 `initiate` and `complete` flow against a [development target](development_workflows.md) by
 passing the global `--target` flag. With a target active, the backfill operates on the

--- a/docs/cookbooks/backfilling_a_table.md
+++ b/docs/cookbooks/backfilling_a_table.md
@@ -51,6 +51,11 @@ What changes under `--target`:
 The `backfill.yaml` entry is still read from the repo as usual; only the BigQuery
 locations are redirected. Without `--target`, behavior is unchanged (production backfill).
 
+`query.py` (python script) backfills do not support `--target`. A python-script backfill's
+destination is baked into the entry's `query_script_args` at create time and is not redirected, 
+so running one under `--target` is rejected to avoid writing to the production staging table. 
+This limitation is tracked in https://mozilla-hub.atlassian.net/browse/DENG-10054.
+
 ## Initiating the backfill:
 
 1. Create a backfill schedule entry to (re)-process data in your table:

--- a/docs/cookbooks/development_workflows.md
+++ b/docs/cookbooks/development_workflows.md
@@ -131,13 +131,24 @@ Without `--defer-to-target` (default): no rewrites — all references stay point
 Supports `--defer-to-target` (same as `query run`) and `--dry-run` to preview
 without making changes.
 
-### 4. Backfill testing  _(future)_
+### 4. Backfill testing
+
+Both the lower-level `query backfill` and the managed `backfill initiate`/`complete`
+commands support `--target`, running into the target-deployed table and (for managed
+backfills) staging into the target project so you can rehearse a backfill without
+production write access. See
+[Testing a backfill in a dev environment](backfilling_a_table.md#testing-a-backfill-in-a-dev-environment).
 
 ```bash
 ./bqetl --target dev query backfill --defer-to-target \
   --start-date 2024-01-01 \
   --end-date 2024-01-07 \
   telemetry_derived.clients_daily_v6
+```
+Managed backfill:
+```bash
+./bqetl --target dev backfill initiate moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6
+./bqetl --target dev backfill complete moz-fx-data-shared-prod.telemetry_derived.clients_daily_v6
 ```
 
 ### 5. Share with teammates

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -2171,13 +2171,9 @@ class TestBackfill:
 
     @patch("google.cloud.bigquery.Client")
     def test_initiate_backfill_skips_query_target_resolution(self, mock_client, runner):
-        """Initiate drives query backfill with the staging destination and opts out of
-        the query command's own --target redirection (would otherwise raise
-        "--destination-table and --target are mutually exclusive")."""
+        """When initiate calls query.backfill, the original --target should be used, not overidden by query.backfill."""
         prod_table_name = "moz-fx-data-shared-prod.test.test_query_v1"
-        staging = (
-            "benwubenwutest.backfills_staging_derived.test__test_query_v1_2026_01_01"
-        )
+        staging = "sandbox.backfills_staging_derived.test__test_query_v1_2026_01_01"
         entry = Backfill(
             entry_date=date(2026, 1, 1),
             start_date=date(2026, 1, 1),
@@ -2194,7 +2190,7 @@ class TestBackfill:
             qualified_table_name=prod_table_name,
             backfill_staging_qualified_table_name=staging,
             entry=entry,
-            effective_table_name="benwubenwutest.dev_test.test_query_v1",
+            effective_table_name="sandbox.dev_test.test_query_v1",
         )
 
         call_kwargs = mock_context.invoke.call_args[1]
@@ -2897,56 +2893,61 @@ class TestCopyPermissionsToStagingTable:
 
 
 class TestBackfillTargetSupport:
-    """Backfill name resolution honors the active --target."""
+    """Backfill commands should redirect into the target environment when --target is set."""
 
-    PROD_TABLE = "moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v3"
+    PROD_TABLE = "moz-fx-data-shared-prod.test_derived.test_table_v1"
 
     def _target(self):
         return Target(
             name="dev",
-            project_id="benwubenwutest",
+            project_id="sandbox",
             dataset_prefix="dev_mybranch__{{ artifact.project_id }}__",
         )
 
-    def test_resolve_backfill_table_no_target_passthrough(self):
+    def test_resolve_backfill_table_without_target_should_return_source_unchanged(self):
+        """_resolve_backfill_table without a target should return the source table and no destination project."""
         table, dest_project = _resolve_backfill_table(None, self.PROD_TABLE)
         assert table == self.PROD_TABLE
         assert dest_project is None
 
-    def test_resolve_backfill_table_with_target(self):
+    def test_resolve_backfill_table_with_target_should_map_to_target_table(self):
+        """_resolve_backfill_table with a target should map the source to the target-deployed table and project."""
         table, dest_project = _resolve_backfill_table(self._target(), self.PROD_TABLE)
         # dataset_prefix renders artifact.project_id (sanitized) and prefixes the
         # dataset; table name is unchanged (no artifact_prefix configured).
         assert table == (
-            "benwubenwutest."
-            "dev_mybranch__moz_fx_data_shared_prod__telemetry_derived."
-            "clients_first_seen_v3"
+            "sandbox."
+            "dev_mybranch__moz_fx_data_shared_prod__test_derived."
+            "test_table_v1"
         )
-        assert dest_project == "benwubenwutest"
+        assert dest_project == "sandbox"
 
-    def test_staging_name_honors_destination_project(self):
+    def test_staging_name_with_destination_project_should_use_target_project(self):
+        """get_backfill_staging_qualified_table_name should place staging in the destination project."""
         name = get_backfill_staging_qualified_table_name(
             self.PROD_TABLE,
             date(2021, 5, 3),
-            destination_project="benwubenwutest",
+            destination_project="sandbox",
         )
         assert name == (
-            "benwubenwutest.backfills_staging_derived."
-            "telemetry_derived__clients_first_seen_v3_2021_05_03"
+            "sandbox.backfills_staging_derived."
+            "test_derived__test_table_v1_2021_05_03"
         )
 
-    def test_backup_name_honors_destination_project(self):
+    def test_backup_name_with_destination_project_should_use_target_project(self):
+        """get_backfill_backup_table_name should place the backup in the destination project."""
         name = get_backfill_backup_table_name(
             self.PROD_TABLE,
             date(2021, 5, 3),
-            destination_project="benwubenwutest",
+            destination_project="sandbox",
         )
         assert name == (
-            "benwubenwutest.backfills_staging_derived."
-            "telemetry_derived__clients_first_seen_v3_backup_2021_05_03"
+            "sandbox.backfills_staging_derived."
+            "test_derived__test_table_v1_backup_2021_05_03"
         )
 
-    def test_staging_name_defaults_to_prod_without_destination(self):
+    def test_staging_name_without_destination_project_should_default_to_prod(self):
+        """get_backfill_staging_qualified_table_name without a destination should default to the prod backfill project."""
         name = get_backfill_staging_qualified_table_name(
             self.PROD_TABLE, date(2021, 5, 3)
         )
@@ -2955,8 +2956,10 @@ class TestBackfillTargetSupport:
         )
 
     @patch("bigquery_etl.cli.backfill._copy_table")
-    def test_copy_backfill_staging_to_prod_skip_public_redirect(self, mock_copy_table):
-        """A target swap keeps the destination as the (target) table, not the public one."""
+    def test_copy_backfill_staging_to_prod_with_skip_public_redirect_should_keep_target_destination(
+        self, mock_copy_table
+    ):
+        """_copy_backfill_staging_to_prod with skip_public_redirect should keep the target table as the destination."""
         public_metadata = {
             "friendly_name": "test",
             "description": "test",
@@ -2966,9 +2969,11 @@ class TestBackfillTargetSupport:
                 "time_partitioning": {"type": "day", "field": "submission_date"}
             },
         }
-        with open(METADATA_FILE, "w") as f:
-            f.write(yaml.dump(public_metadata))
-        metadata = Metadata.from_file(METADATA_FILE)
+        # isolate the filesystem so the temporary metadata.yaml isn't written to cwd
+        with CliRunner().isolated_filesystem():
+            with open(METADATA_FILE, "w") as f:
+                f.write(yaml.dump(public_metadata))
+            metadata = Metadata.from_file(METADATA_FILE)
 
         entry = Backfill(
             entry_date=date(2021, 5, 3),
@@ -2981,8 +2986,8 @@ class TestBackfillTargetSupport:
         )
 
         _copy_backfill_staging_to_prod(
-            backfill_staging_table="benwubenwutest.backfills_staging_derived.tbl",
-            qualified_table_name="benwubenwutest.dev_ds.tbl",
+            backfill_staging_table="sandbox.backfills_staging_derived.tbl",
+            qualified_table_name="sandbox.dev_ds.tbl",
             client=None,
             entry=entry,
             table_metadata=metadata,
@@ -2992,15 +2997,15 @@ class TestBackfillTargetSupport:
         # destination stays the target table; no redirect to mozilla-public-data
         assert mock_copy_table.call_count == 1
         staging_arg, prod_arg = mock_copy_table.call_args.args[:2]
-        assert prod_arg.startswith("benwubenwutest.dev_ds.tbl$")
+        assert prod_arg.startswith("sandbox.dev_ds.tbl$")
         assert "mozilla-public-data" not in prod_arg
 
     @patch("bigquery_etl.backfill.utils._table_exists")
     @patch("google.cloud.bigquery.Client", autospec=True)
-    def test_get_scheduled_backfills_checks_target_staging_project(
+    def test_get_scheduled_backfills_with_destination_project_should_check_target_staging(
         self, mock_client, mock_table_exists
     ):
-        """With a destination_project, staging existence is checked in the target project."""
+        """get_scheduled_backfills with a destination_project should check staging existence in the target project."""
         with CliRunner().isolated_filesystem():
             table_dir = "sql/moz-fx-data-shared-prod/test/test_query_v1"
             os.makedirs(table_dir)
@@ -3029,12 +3034,10 @@ class TestBackfillTargetSupport:
                 "moz-fx-data-shared-prod",
                 "moz-fx-data-shared-prod.test.test_query_v1",
                 status=BackfillStatus.COMPLETE.value,
-                destination_project="benwubenwutest",
+                destination_project="sandbox",
             )
 
             assert "moz-fx-data-shared-prod.test.test_query_v1" in result
             # the staging existence check used the target project, not prod
             checked_staging = mock_table_exists.call_args_list[0].args[1]
-            assert checked_staging.startswith(
-                "benwubenwutest.backfills_staging_derived."
-            )
+            assert checked_staging.startswith("sandbox.backfills_staging_derived.")

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -2197,6 +2197,38 @@ class TestBackfill:
         assert call_kwargs["destination_table"] == staging
         assert call_kwargs["skip_target_resolution"] is True
 
+    @patch("bigquery_etl.backfill.utils._should_initiate")
+    @patch("google.cloud.bigquery.Client")
+    def test_initiate_python_script_with_target_should_be_rejected(
+        self, mock_client, mock_should_initiate, runner
+    ):
+        """initiate for a query.py backfill under --target should be rejected, not silently target prod staging."""
+        mock_should_initiate.return_value = True
+        sql_file = Path(QUERY_DIR) / "query.sql"
+        sql_file.rename(sql_file.with_suffix(".py"))
+
+        backfill_file = Path(QUERY_DIR) / BACKFILL_FILE
+        backfill_file.write_text(
+            "2021-05-03:\n"
+            "  start_date: 2021-01-03\n"
+            "  end_date: 2021-01-03\n"
+            "  reason: test_reason\n"
+            "  watchers:\n"
+            "  - test@example.org\n"
+            "  status: Initiate\n"
+            "  query_script_entrypoint: main\n"
+            "  query_script_date_arg: date\n"
+        )
+
+        result = runner.invoke(
+            initiate,
+            ["moz-fx-data-shared-prod.test.test_query_v1", "--parallelism=0"],
+            obj={"target": Target(name="dev", project_id="sandbox")},
+        )
+
+        assert result.exit_code != 0
+        assert "not supported for query.py" in result.output
+
     @patch("google.cloud.bigquery.Client")
     @patch("bigquery_etl.cli.backfill._initialize_previous_partition")
     def test_initiate_backfill_script_skips_depends_on_past(

--- a/tests/cli/test_cli_backfill.py
+++ b/tests/cli/test_cli_backfill.py
@@ -32,6 +32,7 @@ from bigquery_etl.cli.backfill import (
     _copy_backfill_staging_to_prod,
     _initialize_previous_partition,
     _initiate_backfill,
+    _resolve_backfill_table,
     complete,
     create,
     info,
@@ -44,6 +45,7 @@ from bigquery_etl.cli.stage import QUERY_FILE
 from bigquery_etl.deploy import FailedDeployException, SkippedDeployException
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.metadata.parse_metadata import METADATA_FILE, Metadata
+from bigquery_etl.util.target import Target
 
 DEFAULT_STATUS = BackfillStatus.INITIATE
 VALID_REASON = "test_reason"
@@ -2168,6 +2170,38 @@ class TestBackfill:
         assert call_kwargs["query_script_arg"] == ["--dataset=staging"]
 
     @patch("google.cloud.bigquery.Client")
+    def test_initiate_backfill_skips_query_target_resolution(self, mock_client, runner):
+        """Initiate drives query backfill with the staging destination and opts out of
+        the query command's own --target redirection (would otherwise raise
+        "--destination-table and --target are mutually exclusive")."""
+        prod_table_name = "moz-fx-data-shared-prod.test.test_query_v1"
+        staging = (
+            "benwubenwutest.backfills_staging_derived.test__test_query_v1_2026_01_01"
+        )
+        entry = Backfill(
+            entry_date=date(2026, 1, 1),
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 1, 1),
+            excluded_dates=[],
+            reason=VALID_REASON,
+            watchers=[VALID_WATCHER],
+            status=DEFAULT_STATUS,
+        )
+        mock_context = MagicMock()
+
+        _initiate_backfill(
+            ctx=mock_context,
+            qualified_table_name=prod_table_name,
+            backfill_staging_qualified_table_name=staging,
+            entry=entry,
+            effective_table_name="benwubenwutest.dev_test.test_query_v1",
+        )
+
+        call_kwargs = mock_context.invoke.call_args[1]
+        assert call_kwargs["destination_table"] == staging
+        assert call_kwargs["skip_target_resolution"] is True
+
+    @patch("google.cloud.bigquery.Client")
     @patch("bigquery_etl.cli.backfill._initialize_previous_partition")
     def test_initiate_backfill_script_skips_depends_on_past(
         self, mock_initialize_partition, mock_client, runner
@@ -2860,3 +2894,147 @@ class TestCopyPermissionsToStagingTable:
                 "serviceAccount:123-compute@developer.gserviceaccount.com",
             },
         }
+
+
+class TestBackfillTargetSupport:
+    """Backfill name resolution honors the active --target."""
+
+    PROD_TABLE = "moz-fx-data-shared-prod.telemetry_derived.clients_first_seen_v3"
+
+    def _target(self):
+        return Target(
+            name="dev",
+            project_id="benwubenwutest",
+            dataset_prefix="dev_mybranch__{{ artifact.project_id }}__",
+        )
+
+    def test_resolve_backfill_table_no_target_passthrough(self):
+        table, dest_project = _resolve_backfill_table(None, self.PROD_TABLE)
+        assert table == self.PROD_TABLE
+        assert dest_project is None
+
+    def test_resolve_backfill_table_with_target(self):
+        table, dest_project = _resolve_backfill_table(self._target(), self.PROD_TABLE)
+        # dataset_prefix renders artifact.project_id (sanitized) and prefixes the
+        # dataset; table name is unchanged (no artifact_prefix configured).
+        assert table == (
+            "benwubenwutest."
+            "dev_mybranch__moz_fx_data_shared_prod__telemetry_derived."
+            "clients_first_seen_v3"
+        )
+        assert dest_project == "benwubenwutest"
+
+    def test_staging_name_honors_destination_project(self):
+        name = get_backfill_staging_qualified_table_name(
+            self.PROD_TABLE,
+            date(2021, 5, 3),
+            destination_project="benwubenwutest",
+        )
+        assert name == (
+            "benwubenwutest.backfills_staging_derived."
+            "telemetry_derived__clients_first_seen_v3_2021_05_03"
+        )
+
+    def test_backup_name_honors_destination_project(self):
+        name = get_backfill_backup_table_name(
+            self.PROD_TABLE,
+            date(2021, 5, 3),
+            destination_project="benwubenwutest",
+        )
+        assert name == (
+            "benwubenwutest.backfills_staging_derived."
+            "telemetry_derived__clients_first_seen_v3_backup_2021_05_03"
+        )
+
+    def test_staging_name_defaults_to_prod_without_destination(self):
+        name = get_backfill_staging_qualified_table_name(
+            self.PROD_TABLE, date(2021, 5, 3)
+        )
+        assert name.startswith(
+            f"{BACKFILL_DESTINATION_PROJECT}.{BACKFILL_DESTINATION_DATASET}."
+        )
+
+    @patch("bigquery_etl.cli.backfill._copy_table")
+    def test_copy_backfill_staging_to_prod_skip_public_redirect(self, mock_copy_table):
+        """A target swap keeps the destination as the (target) table, not the public one."""
+        public_metadata = {
+            "friendly_name": "test",
+            "description": "test",
+            "owners": ["test@example.org"],
+            "labels": {"public_bigquery": True, "review_bugs": [222222]},
+            "bigquery": {
+                "time_partitioning": {"type": "day", "field": "submission_date"}
+            },
+        }
+        with open(METADATA_FILE, "w") as f:
+            f.write(yaml.dump(public_metadata))
+        metadata = Metadata.from_file(METADATA_FILE)
+
+        entry = Backfill(
+            entry_date=date(2021, 5, 3),
+            start_date=date(2021, 1, 3),
+            end_date=date(2021, 1, 3),  # single day
+            excluded_dates=[],
+            reason=VALID_REASON,
+            watchers=[VALID_WATCHER],
+            status=BackfillStatus.COMPLETE,
+        )
+
+        _copy_backfill_staging_to_prod(
+            backfill_staging_table="benwubenwutest.backfills_staging_derived.tbl",
+            qualified_table_name="benwubenwutest.dev_ds.tbl",
+            client=None,
+            entry=entry,
+            table_metadata=metadata,
+            skip_public_redirect=True,
+        )
+
+        # destination stays the target table; no redirect to mozilla-public-data
+        assert mock_copy_table.call_count == 1
+        staging_arg, prod_arg = mock_copy_table.call_args.args[:2]
+        assert prod_arg.startswith("benwubenwutest.dev_ds.tbl$")
+        assert "mozilla-public-data" not in prod_arg
+
+    @patch("bigquery_etl.backfill.utils._table_exists")
+    @patch("google.cloud.bigquery.Client", autospec=True)
+    def test_get_scheduled_backfills_checks_target_staging_project(
+        self, mock_client, mock_table_exists
+    ):
+        """With a destination_project, staging existence is checked in the target project."""
+        with CliRunner().isolated_filesystem():
+            table_dir = "sql/moz-fx-data-shared-prod/test/test_query_v1"
+            os.makedirs(table_dir)
+            with open(f"{table_dir}/query.sql", "w") as f:
+                f.write("SELECT 1")
+            with open(f"{table_dir}/metadata.yaml", "w") as f:
+                f.write(yaml.dump(TABLE_METADATA_CONF))
+            with open(f"{table_dir}/{BACKFILL_FILE}", "w") as f:
+                f.write(
+                    "2021-05-03:\n"
+                    "  start_date: 2021-01-03\n"
+                    "  end_date: 2021-01-03\n"
+                    "  reason: test_reason\n"
+                    "  watchers:\n"
+                    "  - test@example.org\n"
+                    "  status: Complete\n"
+                )
+
+            # staging exists, backup does not -> eligible to complete
+            mock_table_exists.side_effect = [True, False]
+
+            from bigquery_etl.backfill.utils import get_scheduled_backfills
+
+            result = get_scheduled_backfills(
+                "sql",
+                "moz-fx-data-shared-prod",
+                "moz-fx-data-shared-prod.test.test_query_v1",
+                status=BackfillStatus.COMPLETE.value,
+                destination_project="benwubenwutest",
+            )
+
+            assert "moz-fx-data-shared-prod.test.test_query_v1" in result
+            # the staging existence check used the target project, not prod
+            checked_staging = mock_table_exists.call_args_list[0].args[1]
+            assert checked_staging.startswith(
+                "benwubenwutest.backfills_staging_derived."
+            )

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -25,6 +25,7 @@ from bigquery_etl.cli.query import (
 )
 from bigquery_etl.metadata.publish_metadata import attach_metadata
 from bigquery_etl.schema import Schema
+from bigquery_etl.util.target import Target
 
 DEFAULT_SAMPLING_BATCH_SIZE = 4
 TOTAL_SAMPLE_ID_COUNT = 100
@@ -571,6 +572,167 @@ class TestQuery:
                 ]
                 assert len(submission_date_params) == 1
                 assert submission_date_params[0] in expected_submission_date_params
+
+    def test_query_backfill_with_target(self, runner):
+        """With --target, the backfill prepares target files and runs in the target project."""
+        with (
+            runner.isolated_filesystem(),
+            patch("google.cloud.bigquery.Client", autospec=True),
+            patch("subprocess.check_call", autospec=True) as check_call,
+            patch(
+                "bigquery_etl.cli.query.prepare_target_files", autospec=True
+            ) as prepare_target_files,
+        ):
+            src_dir = "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1"
+            os.makedirs(src_dir)
+            with open(f"{src_dir}/query.sql", "w") as f:
+                f.write(
+                    "SELECT DATE('2021-01-01') as submission_date "
+                    "WHERE submission_date = @submission_date"
+                )
+            metadata_conf = {
+                "friendly_name": "test",
+                "description": "test",
+                "owners": ["test@example.org"],
+                "scheduling": {"dag_name": "bqetl_test"},
+                "bigquery": {"time_partitioning": {"type": "day"}},
+            }
+            with open(f"{src_dir}/metadata.yaml", "w") as f:
+                f.write(yaml.dump(metadata_conf))
+
+            # the target-prepared query lives under the target project tree
+            target_dir = "sql/benwubenwutest/dev_telemetry_derived/query_v1"
+            os.makedirs(target_dir)
+            with open(f"{target_dir}/query.sql", "w") as f:
+                f.write(
+                    "SELECT DATE('2021-01-01') as submission_date "
+                    "WHERE submission_date = @submission_date"
+                )
+            with open(f"{target_dir}/metadata.yaml", "w") as f:
+                f.write(yaml.dump(metadata_conf))
+            prepare_target_files.return_value = [Path(f"{target_dir}/query.sql")]
+
+            target = Target(name="dev", project_id="benwubenwutest")
+
+            result = runner.invoke(
+                backfill,
+                [
+                    "telemetry_derived.query_v1",
+                    "--project_id=moz-fx-data-shared-prod",
+                    "--start_date=2021-01-05",
+                    "--end_date=2021-01-05",
+                    "--parallelism=0",
+                    "--override-retention-range-limit",
+                ],
+                obj={"target": target},
+            )
+
+            assert result.exit_code == 0
+            # target files were prepared and the query ran in the target project
+            assert prepare_target_files.call_count == 1
+            assert check_call.call_count == 1
+            args = check_call.call_args.args[0]
+            assert "--project_id=benwubenwutest" in args
+            destination = [a for a in args if a.startswith("--destination_table=")]
+            assert destination and "benwubenwutest" in destination[0]
+
+    def test_query_backfill_target_and_destination_table_mutually_exclusive(
+        self, runner
+    ):
+        """--target and --destination-table cannot be combined."""
+        with runner.isolated_filesystem():
+            src_dir = "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1"
+            os.makedirs(src_dir)
+            with open(f"{src_dir}/query.sql", "w") as f:
+                f.write("SELECT 1")
+            with open(f"{src_dir}/metadata.yaml", "w") as f:
+                f.write(
+                    yaml.dump(
+                        {
+                            "friendly_name": "t",
+                            "description": "t",
+                            "owners": ["t@example.org"],
+                            "scheduling": {"dag_name": "bqetl_test"},
+                            "bigquery": {"time_partitioning": {"type": "day"}},
+                        }
+                    )
+                )
+
+            result = runner.invoke(
+                backfill,
+                [
+                    "telemetry_derived.query_v1",
+                    "--project_id=moz-fx-data-shared-prod",
+                    "--start_date=2021-01-05",
+                    "--end_date=2021-01-05",
+                    "--destination_table=p.d.t",
+                    "--override-retention-range-limit",
+                ],
+                obj={"target": Target(name="dev", project_id="benwubenwutest")},
+            )
+            assert result.exit_code != 0
+            assert "mutually exclusive" in result.output
+
+    def test_query_backfill_skip_target_resolution_allows_destination(self, runner):
+        """--skip-target-resolution (used by managed backfill) lets a target coexist with
+        an explicit --destination-table and runs in the given project."""
+        with (
+            runner.isolated_filesystem(),
+            patch("google.cloud.bigquery.Client", autospec=True),
+            patch("subprocess.check_call", autospec=True) as check_call,
+            patch(
+                "bigquery_etl.cli.query.prepare_target_files", autospec=True
+            ) as prepare_target_files,
+        ):
+            src_dir = "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1"
+            os.makedirs(src_dir)
+            with open(f"{src_dir}/query.sql", "w") as f:
+                f.write(
+                    "SELECT DATE('2021-01-01') as submission_date "
+                    "WHERE submission_date = @submission_date"
+                )
+            with open(f"{src_dir}/metadata.yaml", "w") as f:
+                f.write(
+                    yaml.dump(
+                        {
+                            "friendly_name": "t",
+                            "description": "t",
+                            "owners": ["t@example.org"],
+                            "scheduling": {"dag_name": "bqetl_test"},
+                            "bigquery": {"time_partitioning": {"type": "day"}},
+                        }
+                    )
+                )
+
+            staging = "benwubenwutest.backfills_staging_derived.t_2021_01_05"
+            result = runner.invoke(
+                backfill,
+                [
+                    "telemetry_derived.query_v1",
+                    "--project_id=moz-fx-data-shared-prod",
+                    "--start_date=2021-01-05",
+                    "--end_date=2021-01-05",
+                    f"--destination_table={staging}",
+                    "--parallelism=0",
+                    "--override-retention-range-limit",
+                    "--skip-target-resolution",
+                ],
+                obj={"target": Target(name="dev", project_id="benwubenwutest")},
+            )
+
+            # no mutual-exclusivity error, no target file prep, writes to the given staging table
+            assert result.exit_code == 0, result.output
+            assert prepare_target_files.call_count == 0
+            assert check_call.call_count == 1
+            args = check_call.call_args.args[0]
+            # project is not redirected to the target; destination is the given staging
+            # table (bq uses the project:dataset.table form, with a partition suffix)
+            assert "--project_id=moz-fx-data-shared-prod" in args
+            destination = [a for a in args if a.startswith("--destination_table=")]
+            assert destination and (
+                "benwubenwutest:backfills_staging_derived.t_2021_01_05"
+                in destination[0]
+            )
 
     def test_query_backfill_with_scheduling_overrides(self, runner):
         with (

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -574,7 +574,7 @@ class TestQuery:
                 assert submission_date_params[0] in expected_submission_date_params
 
     def test_query_backfill_with_target(self, runner):
-        """With --target, the backfill prepares target files and runs in the target project."""
+        """Backfill with --target should prepare target files and run in the target project."""
         with (
             runner.isolated_filesystem(),
             patch("google.cloud.bigquery.Client", autospec=True),
@@ -601,7 +601,7 @@ class TestQuery:
                 f.write(yaml.dump(metadata_conf))
 
             # the target-prepared query lives under the target project tree
-            target_dir = "sql/benwubenwutest/dev_telemetry_derived/query_v1"
+            target_dir = "sql/sandbox/dev_telemetry_derived/query_v1"
             os.makedirs(target_dir)
             with open(f"{target_dir}/query.sql", "w") as f:
                 f.write(
@@ -612,7 +612,7 @@ class TestQuery:
                 f.write(yaml.dump(metadata_conf))
             prepare_target_files.return_value = [Path(f"{target_dir}/query.sql")]
 
-            target = Target(name="dev", project_id="benwubenwutest")
+            target = Target(name="dev", project_id="sandbox")
 
             result = runner.invoke(
                 backfill,
@@ -632,50 +632,13 @@ class TestQuery:
             assert prepare_target_files.call_count == 1
             assert check_call.call_count == 1
             args = check_call.call_args.args[0]
-            assert "--project_id=benwubenwutest" in args
+            assert "--project_id=sandbox" in args
             destination = [a for a in args if a.startswith("--destination_table=")]
-            assert destination and "benwubenwutest" in destination[0]
-
-    def test_query_backfill_target_and_destination_table_mutually_exclusive(
-        self, runner
-    ):
-        """--target and --destination-table cannot be combined."""
-        with runner.isolated_filesystem():
-            src_dir = "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1"
-            os.makedirs(src_dir)
-            with open(f"{src_dir}/query.sql", "w") as f:
-                f.write("SELECT 1")
-            with open(f"{src_dir}/metadata.yaml", "w") as f:
-                f.write(
-                    yaml.dump(
-                        {
-                            "friendly_name": "t",
-                            "description": "t",
-                            "owners": ["t@example.org"],
-                            "scheduling": {"dag_name": "bqetl_test"},
-                            "bigquery": {"time_partitioning": {"type": "day"}},
-                        }
-                    )
-                )
-
-            result = runner.invoke(
-                backfill,
-                [
-                    "telemetry_derived.query_v1",
-                    "--project_id=moz-fx-data-shared-prod",
-                    "--start_date=2021-01-05",
-                    "--end_date=2021-01-05",
-                    "--destination_table=p.d.t",
-                    "--override-retention-range-limit",
-                ],
-                obj={"target": Target(name="dev", project_id="benwubenwutest")},
-            )
-            assert result.exit_code != 0
-            assert "mutually exclusive" in result.output
+            assert destination and "sandbox" in destination[0]
 
     def test_query_backfill_skip_target_resolution_allows_destination(self, runner):
-        """--skip-target-resolution (used by managed backfill) lets a target coexist with
-        an explicit --destination-table and runs in the given project."""
+        """--skip-target-resolution (used by managed backfill) should let a target coexist with
+        an explicit --destination-table and run in the given project."""
         with (
             runner.isolated_filesystem(),
             patch("google.cloud.bigquery.Client", autospec=True),
@@ -704,7 +667,7 @@ class TestQuery:
                     )
                 )
 
-            staging = "benwubenwutest.backfills_staging_derived.t_2021_01_05"
+            staging = "sandbox.backfills_staging_derived.t_2021_01_05"
             result = runner.invoke(
                 backfill,
                 [
@@ -717,7 +680,7 @@ class TestQuery:
                     "--override-retention-range-limit",
                     "--skip-target-resolution",
                 ],
-                obj={"target": Target(name="dev", project_id="benwubenwutest")},
+                obj={"target": Target(name="dev", project_id="sandbox")},
             )
 
             # no mutual-exclusivity error, no target file prep, writes to the given staging table
@@ -730,7 +693,7 @@ class TestQuery:
             assert "--project_id=moz-fx-data-shared-prod" in args
             destination = [a for a in args if a.startswith("--destination_table=")]
             assert destination and (
-                "benwubenwutest:backfills_staging_derived.t_2021_01_05"
+                "sandbox:backfills_staging_derived.t_2021_01_05"
                 in destination[0]
             )
 

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -693,8 +693,7 @@ class TestQuery:
             assert "--project_id=moz-fx-data-shared-prod" in args
             destination = [a for a in args if a.startswith("--destination_table=")]
             assert destination and (
-                "sandbox:backfills_staging_derived.t_2021_01_05"
-                in destination[0]
+                "sandbox:backfills_staging_derived.t_2021_01_05" in destination[0]
             )
 
     def test_query_backfill_with_scheduling_overrides(self, runner):

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -13,7 +13,6 @@ from bigquery_etl.util.target import (
     Target,
     _normalize_table_ref,
     _substitute_3part_ref,
-    _target_ref_for_source,
     collect_target_dependencies,
     extract_commit_from_dataset_name,
     get_deployed_tables_in_target,
@@ -23,6 +22,7 @@ from bigquery_etl.util.target import (
     read_source_identity_from_manifest,
     render_artifact_prefix_pattern,
     render_dataset_pattern,
+    target_ref_for_source,
 )
 
 
@@ -578,7 +578,7 @@ class TestTargetRefForSource:
             project_id="dev-proj",
             dataset_prefix="user_main_{{ artifact.project_id }}_",
         )
-        proj, ds, tbl = _target_ref_for_source(
+        proj, ds, tbl = target_ref_for_source(
             target, "dev-proj", "moz-fx-data-shared-prod", "telemetry_derived", "tbl_v1"
         )
         assert proj == "dev-proj"
@@ -587,7 +587,7 @@ class TestTargetRefForSource:
 
     def test_dataset_field(self):
         target = Target(name="dev", project_id="dev-proj", dataset="anna_dev")
-        proj, ds, tbl = _target_ref_for_source(
+        proj, ds, tbl = target_ref_for_source(
             target, "dev-proj", "moz-fx-data-shared-prod", "telemetry_derived", "tbl_v1"
         )
         assert (proj, ds, tbl) == ("dev-proj", "anna_dev", "tbl_v1")
@@ -599,14 +599,14 @@ class TestTargetRefForSource:
             dataset="anna_dev",
             artifact_prefix="branch_{{ artifact.dataset_id }}_",
         )
-        _, _, tbl = _target_ref_for_source(
+        _, _, tbl = target_ref_for_source(
             target, "dev-proj", "moz-fx-data-shared-prod", "telemetry_derived", "tbl_v1"
         )
         assert tbl == "branch_telemetry_derived_tbl_v1"
 
     def test_no_dataset_or_prefix_passthrough(self):
         target = Target(name="dev", project_id="dev-proj")
-        proj, ds, tbl = _target_ref_for_source(
+        proj, ds, tbl = target_ref_for_source(
             target, "dev-proj", "moz-fx-data-shared-prod", "telemetry_derived", "tbl_v1"
         )
         assert (proj, ds, tbl) == ("dev-proj", "telemetry_derived", "tbl_v1")


### PR DESCRIPTION
## Description

This allows running backfills (both managed and direct) in a dev project for testing.  Especially needed since we don't have write access to `moz-fx-data-shared-prod.backfills_staging_derived`.  query.py are explicitly not supported and will be handled in a future change (DENG-11224)

Tested with
```sh
bqetl --target dev query run \
  sql/moz-fx-data-shared-prod/monitoring_derived/shredder_per_job_stats_v1/query.sql \
  --parameter=submission_date:DATE:2026-05-01 --write

bqetl backfill create moz-fx-data-shared-prod.monitoring_derived.shredder_per_job_stats_v1 \
  --start_date=2026-05-02 --end_date=2026-05-03 \
  --watcher=bewu@mozilla.com --reason="testing --target backfill support"

bqetl --target dev backfill initiate \
  moz-fx-data-shared-prod.monitoring_derived.shredder_per_job_stats_v1

bq query --use_legacy_sql=false --project_id=benwubenwutest \
  'SELECT DATE(end_time) d, COUNT(*) FROM `benwubenwutest.backfills_staging_derived.monitoring_derived__shredder_per_job_stats_v1_2026_06_04` GROUP BY d ORDER BY d'

# after setting status to complete
bqetl --target dev backfill complete \
  moz-fx-data-shared-prod.monitoring_derived.shredder_per_job_stats_v1

bq query --use_legacy_sql=false --project_id=benwubenwutest \
  'SELECT DATE(end_time) d, COUNT(*) FROM `benwubenwutest.dev_benwu_backfill_target_support__moz_fx_data_shared_prod__monitoring_derived.shredder_per_job_stats_v1` GROUP BY d ORDER BY d'

bqetl --target dev target clean --branch benwu/backfill-target-support
```

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
