### PR TITLE
chore(schema): add field descriptions for telemetry_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
@@ -108,6 +108,7 @@ fields:
 - mode: NULLABLE
   name: first_seen_year
   type: INTEGER
+  description: The calendar year in which the client's profile was first seen by Mozilla's telemetry pipeline.
 - mode: NULLABLE
   name: attributed
   type: BOOLEAN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -1154,12 +1154,15 @@ fields:
 - mode: NULLABLE
   name: search_count_webextension
   type: INTEGER
+  description: Total number of searches initiated via a WebExtension (browser extension) on the first seen day.
 - mode: NULLABLE
   name: search_count_alias
   type: INTEGER
+  description: Total number of searches initiated using a search engine alias (keyword shortcut) in the URL bar on the first seen day.
 - mode: NULLABLE
   name: search_count_urlbar_searchmode
   type: INTEGER
+  description: Total number of searches performed while the URL bar was in search mode on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1170,6 +1173,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_browser_ui_interaction_preferences_pane_home_sum
   type: RECORD
+  description: Keyed count of user interactions with the Firefox Home section in Preferences, keyed by UI element, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1180,6 +1184,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_sum
   type: RECORD
+  description: Keyed count of URL bar autofill result selections by autofill type on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1190,6 +1195,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_about_sum
   type: RECORD
+  description: Keyed count of URL bar autofill selections for about; page results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1200,6 +1206,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_adaptive_sum
   type: RECORD
+  description: Keyed count of URL bar adaptive autofill result selections on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1210,6 +1217,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_origin_sum
   type: RECORD
+  description: Keyed count of URL bar origin-based autofill result selections on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1220,6 +1228,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_other_sum
   type: RECORD
+  description: Keyed count of URL bar 'other' type autofill result selections on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1230,6 +1239,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_preloaded_sum
   type: RECORD
+  description: Keyed count of URL bar preloaded site autofill result selections on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1240,6 +1250,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_url_sum
   type: RECORD
+  description: Keyed count of URL bar full URL autofill result selections on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1250,6 +1261,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_bookmark_sum
   type: RECORD
+  description: Keyed count of bookmark result selections from the URL bar dropdown on the first seen day, keyed by search mode.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1260,6 +1272,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_dynamic_sum
   type: RECORD
+  description: Keyed count of dynamic (provider-generated) result selections from the URL bar on the first seen day, keyed by provider.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1270,6 +1283,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_extension_sum
   type: RECORD
+  description: Keyed count of extension-provided result selections from the URL bar on the first seen day, keyed by extension.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1280,6 +1294,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_formhistory_sum
   type: RECORD
+  description: Keyed count of form history result selections from the URL bar on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1290,6 +1305,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_history_sum
   type: RECORD
+  description: Keyed count of browsing history result selections from the URL bar dropdown on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1300,6 +1316,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_keyword_sum
   type: RECORD
+  description: Keyed count of keyword (search alias) result selections from the URL bar on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1310,6 +1327,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_remotetab_sum
   type: RECORD
+  description: Keyed count of remote tab result selections from the URL bar (synced from other devices) on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1320,6 +1338,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_searchengine_sum
   type: RECORD
+  description: Keyed count of search engine suggestion result selections from the URL bar on the first seen day, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1330,6 +1349,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_searchsuggestion_sum
   type: RECORD
+  description: Keyed count of search suggestion result selections from the URL bar on the first seen day, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1340,6 +1360,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_switchtab_sum
   type: RECORD
+  description: Keyed count of switch-to-tab result selections from the URL bar on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1350,6 +1371,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_tabtosearch_sum
   type: RECORD
+  description: Keyed count of tab-to-search result selections from the URL bar on the first seen day, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1360,6 +1382,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_tip_sum
   type: RECORD
+  description: Keyed count of tip result selections from the URL bar (informational tips shown in the dropdown) on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1370,6 +1393,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_topsite_sum
   type: RECORD
+  description: Keyed count of top site result selections from the URL bar on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1380,6 +1404,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_unknown_sum
   type: RECORD
+  description: Keyed count of unknown result type selections from the URL bar on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1390,21 +1415,27 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_visiturl_sum
   type: RECORD
+  description: Keyed count of direct URL visit result selections from the URL bar on the first seen day.
 - mode: NULLABLE
   name: default_private_search_engine
   type: STRING
+  description: The internal identifier of the client's default private browsing search engine (e.g., 'ddg', 'google-b-d'). Null if not configured.
 - mode: NULLABLE
   name: default_private_search_engine_data_load_path
   type: STRING
+  description: The anonymized load path of the private browsing default search engine config file.
 - mode: NULLABLE
   name: default_private_search_engine_data_name
   type: STRING
+  description: The display name of the client's default private browsing search engine.
 - mode: NULLABLE
   name: default_private_search_engine_data_origin
   type: STRING
+  description: The origin type of the private browsing default search engine ('default', 'verified', 'unverified', or 'invalid').
 - mode: NULLABLE
   name: default_private_search_engine_data_submission_url
   type: STRING
+  description: The HTTP search submission URL for the private browsing default search engine.
 - fields:
   - mode: NULLABLE
     name: engine
@@ -1418,9 +1449,12 @@ fields:
   mode: REPEATED
   name: search_counts
   type: RECORD
+  description: Array of per-engine per-source search count records, each with the engine identifier, search source (e.g., 'urlbar', 'searchbar'), and
+    count.
 - mode: NULLABLE
   name: user_pref_browser_search_region
   type: STRING
+  description: The client's configured browser search region code (e.g., 'US', 'DE'), used to determine region-specific default search settings.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1431,6 +1465,7 @@ fields:
   mode: REPEATED
   name: search_with_ads
   type: RECORD
+  description: Keyed count of searches that returned pages with ads, keyed by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1441,6 +1476,7 @@ fields:
   mode: REPEATED
   name: ad_clicks
   type: RECORD
+  description: Keyed count of ad clicks on search result pages, keyed by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1451,6 +1487,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_sum
   type: RECORD
+  description: Keyed count of URL bar searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1461,6 +1498,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of URL bar handoff searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1471,6 +1509,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of URL bar persisted searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1481,6 +1520,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of URL bar search mode searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1491,6 +1531,7 @@ fields:
   mode: REPEATED
   name: search_content_contextmenu_sum
   type: RECORD
+  description: Keyed count of right-click context menu searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1501,6 +1542,7 @@ fields:
   mode: REPEATED
   name: search_content_about_home_sum
   type: RECORD
+  description: Keyed count of about:home searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1511,6 +1553,7 @@ fields:
   mode: REPEATED
   name: search_content_about_newtab_sum
   type: RECORD
+  description: Keyed count of new tab page searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1521,6 +1564,7 @@ fields:
   mode: REPEATED
   name: search_content_searchbar_sum
   type: RECORD
+  description: Keyed count of search bar searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1531,6 +1575,7 @@ fields:
   mode: REPEATED
   name: search_content_system_sum
   type: RECORD
+  description: Keyed count of system-initiated searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1541,6 +1586,7 @@ fields:
   mode: REPEATED
   name: search_content_webextension_sum
   type: RECORD
+  description: Keyed count of WebExtension-initiated searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1551,6 +1597,7 @@ fields:
   mode: REPEATED
   name: search_content_tabhistory_sum
   type: RECORD
+  description: Keyed count of tab history searches by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1561,6 +1608,7 @@ fields:
   mode: REPEATED
   name: search_content_reload_sum
   type: RECORD
+  description: Keyed count of search reload events by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1571,6 +1619,7 @@ fields:
   mode: REPEATED
   name: search_content_unknown_sum
   type: RECORD
+  description: Keyed count of searches with unknown source by search engine on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1581,6 +1630,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_sum
   type: RECORD
+  description: Keyed count of URL bar search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1591,6 +1641,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of URL bar handoff search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -8,6 +8,7 @@ fields:
 - mode: NULLABLE
   name: second_seen_date
   type: DATE
+  description: The date the server received the second ping from this client after first_seen_date. Null if the client has not yet sent a second ping.
 - mode: NULLABLE
   name: client_id
   type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -2472,10 +2472,12 @@ fields:
 - name: places_bookmarks_searchbar_cumulative_searches_sum
   type: INTEGER
   mode: NULLABLE
+  description: Cumulative count of bookmark searches via the bookmarks search bar on the first seen day.
 - name: scalar_parent_library_link_sum
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of link navigations from the Firefox Library panel by content type on the first seen day.
   - name: key
     type: STRING
     mode: NULLABLE
@@ -2486,6 +2488,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of Firefox Library panel open events by trigger method on the first seen day.
   - name: key
     type: STRING
     mode: NULLABLE
@@ -2496,6 +2499,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of searches performed within the Firefox Library panel by panel type on the first seen day.
   - name: key
     type: STRING
     mode: NULLABLE
@@ -2505,30 +2509,39 @@ fields:
 - name: startup_profile_selection_reason_first
   type: STRING
   mode: NULLABLE
+  description: The reason the profile was selected at startup, from the first ping of the first seen day (e.g., 'firstrun-created-default', 'default').
 - name: first_document_id
   type: STRING
   mode: NULLABLE
+  description: The document ID of the first ping received from this client on its first seen day.
 - name: partner_id
   type: STRING
   mode: NULLABLE
+  description: The partner identifier from the Firefox distribution configuration (e.g., 'ubuntu', 'mozillaonline'). Null if no partner.
 - name: distribution_version
   type: STRING
   mode: NULLABLE
+  description: The version string of the Firefox distribution package (e.g., '1.0', '2023.6'). Null for standard builds.
 - name: distributor
   type: STRING
   mode: NULLABLE
+  description: The name of the organization that distributed this Firefox build (e.g., 'canonical', 'mozillaonline', 'mint').
 - name: distributor_channel
   type: STRING
   mode: NULLABLE
+  description: The channel through which the distributor released this Firefox build (e.g., 'mainWinStub', 'ubuntu', 'firefox').
 - name: env_build_platform_version
   type: STRING
   mode: NULLABLE
+  description: The XULRunner platform version string from the build environment.
 - name: env_build_xpcom_abi
   type: STRING
   mode: NULLABLE
+  description: The binary ABI string from the build environment (e.g., 'x86_64-msvc', 'aarch64-gcc3').
 - name: geo_db_version
   type: STRING
   mode: NULLABLE
+  description: The version of the IP geolocation database used to resolve the client's location.
 - name: apple_model_id
   type: STRING
   mode: NULLABLE
@@ -2537,12 +2550,15 @@ fields:
 - name: max_subsession_counter
   type: INTEGER
   mode: NULLABLE
+  description: The highest subsession counter value seen from this client on the first seen day, indicating total number of subsessions.
 - name: min_subsession_counter
   type: INTEGER
   mode: NULLABLE
+  description: The lowest subsession counter value seen from this client on the first seen day.
 - name: startup_profile_selection_first_ping_only
   type: STRING
   mode: NULLABLE
+  description: The profile selection reason from the first ping of the first seen day, without fallback logic.
 - name: profile_group_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -1652,6 +1652,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of URL bar persisted search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1662,6 +1663,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of URL bar search mode result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1672,6 +1674,7 @@ fields:
   mode: REPEATED
   name: search_withads_contextmenu_sum
   type: RECORD
+  description: Keyed count of context menu search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1682,6 +1685,7 @@ fields:
   mode: REPEATED
   name: search_withads_about_home_sum
   type: RECORD
+  description: Keyed count of about:home search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1692,6 +1696,7 @@ fields:
   mode: REPEATED
   name: search_withads_about_newtab_sum
   type: RECORD
+  description: Keyed count of new tab page search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1702,6 +1707,7 @@ fields:
   mode: REPEATED
   name: search_withads_searchbar_sum
   type: RECORD
+  description: Keyed count of search bar result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1712,6 +1718,7 @@ fields:
   mode: REPEATED
   name: search_withads_system_sum
   type: RECORD
+  description: Keyed count of system-initiated search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1722,6 +1729,7 @@ fields:
   mode: REPEATED
   name: search_withads_webextension_sum
   type: RECORD
+  description: Keyed count of WebExtension-initiated search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1732,6 +1740,7 @@ fields:
   mode: REPEATED
   name: search_withads_tabhistory_sum
   type: RECORD
+  description: Keyed count of tab history search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1742,6 +1751,7 @@ fields:
   mode: REPEATED
   name: search_withads_reload_sum
   type: RECORD
+  description: Keyed count of reload search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1752,6 +1762,7 @@ fields:
   mode: REPEATED
   name: search_withads_unknown_sum
   type: RECORD
+  description: Keyed count of unknown-source search result pages containing ads, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1762,6 +1773,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_sum
   type: RECORD
+  description: Keyed count of ad clicks on URL bar search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1772,6 +1784,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of ad clicks on URL bar handoff search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1782,6 +1795,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of ad clicks on URL bar persisted search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1792,6 +1806,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of ad clicks on URL bar search mode result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1802,6 +1817,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_contextmenu_sum
   type: RECORD
+  description: Keyed count of ad clicks on context menu search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1812,6 +1828,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_about_home_sum
   type: RECORD
+  description: Keyed count of ad clicks on about:home search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1822,6 +1839,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_about_newtab_sum
   type: RECORD
+  description: Keyed count of ad clicks on new tab page search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1832,6 +1850,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_searchbar_sum
   type: RECORD
+  description: Keyed count of ad clicks on search bar result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1842,6 +1861,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_system_sum
   type: RECORD
+  description: Keyed count of ad clicks on system-initiated search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1852,6 +1872,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_webextension_sum
   type: RECORD
+  description: Keyed count of ad clicks on WebExtension-initiated search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1862,6 +1883,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_tabhistory_sum
   type: RECORD
+  description: Keyed count of ad clicks on tab history search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1872,6 +1894,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_reload_sum
   type: RECORD
+  description: Keyed count of ad clicks on reload search result pages, by search engine, on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1882,39 +1905,51 @@ fields:
   mode: REPEATED
   name: search_adclicks_unknown_sum
   type: RECORD
+  description: Keyed count of ad clicks on unknown-source search result pages, by search engine, on the first seen day.
 - mode: NULLABLE
   name: update_background
   type: BOOLEAN
+  description: Whether background updates (downloading updates when Firefox is not running) are enabled.
 - mode: NULLABLE
   name: user_pref_browser_search_suggest_enabled
   type: STRING
+  description: User preference controlling whether search suggestions appear in the URL bar ('true'/'false' as string). Null if not explicitly set.
 - mode: NULLABLE
   name: user_pref_browser_widget_in_navbar
   type: STRING
+  description: User preference controlling whether a specific widget is shown in the navigation bar ('true'/'false' as string). Null if not set.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_searches
   type: STRING
+  description: User preference controlling whether URL bar search suggestions are shown ('true'/'false' as string). Null if not explicitly set.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_show_search_suggestions_first
   type: STRING
+  description: User preference controlling whether search suggestions appear before browsing history in URL bar results. Null if not set.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_quicksuggest
   type: STRING
+  description: User preference controlling whether Firefox Suggest results appear in the URL bar. Null if not set.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
   type: STRING
+  description: User preference controlling whether sponsored Firefox Suggest results appear in the URL bar ('true'/'false' as string).
 - mode: NULLABLE
   name: user_pref_browser_urlbar_quicksuggest_onboarding_dialog_choice
   type: STRING
+  description: The user's response to the Firefox Suggest onboarding dialog (e.g., 'close_1', 'not_now_2', 'reject_2'). Null if not shown.
 - mode: NULLABLE
   name: scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum
   type: INTEGER
+  description: Total number of URIs visited across both normal and private browsing modes on the first seen day.
 - mode: NULLABLE
   name: user_pref_browser_newtabpage_enabled
   type: STRING
+  description: User preference controlling whether the Firefox new tab page is enabled ('true'/'false' as string). Null if not explicitly set.
 - mode: NULLABLE
   name: user_pref_app_shield_optoutstudies_enabled
   type: STRING
+  description: User preference controlling whether the client participates in Shield studies ('true'/'false' as string). Null if not explicitly set.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1925,6 +1960,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sum
   type: RECORD
+  description: Keyed count of Firefox Suggest (Quicksuggest) result clicks by suggestion type on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1935,6 +1971,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sum
   type: RECORD
+  description: Keyed count of Firefox Suggest (Quicksuggest) result impressions by suggestion type on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1945,6 +1982,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sum
   type: RECORD
+  description: Keyed count of times the user clicked 'Help' on a Firefox Suggest result by suggestion type on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1955,6 +1993,7 @@ fields:
   mode: REPEATED
   name: contextual_services_topsites_click_sum
   type: RECORD
+  description: Keyed count of contextual services top site clicks by source on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1965,18 +2004,23 @@ fields:
   mode: REPEATED
   name: contextual_services_topsites_impression_sum
   type: RECORD
+  description: Keyed count of contextual services top site impressions by source on the first seen day.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_quicksuggest_nonsponsored
   type: STRING
+  description: User preference controlling whether non-sponsored Firefox Suggest results appear in the URL bar ('true'/'false' as string).
 - mode: NULLABLE
   name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
   type: STRING
+  description: User preference controlling whether interaction data with Firefox Suggest is collected ('true'/'false' as string).
 - mode: NULLABLE
   name: scalar_a11y_hcm_foreground
   type: INTEGER
+  description: The foreground color value (as an integer) used in Windows High Contrast Mode. Non-null only when High Contrast Mode is active.
 - mode: NULLABLE
   name: scalar_a11y_hcm_background
   type: INTEGER
+  description: The background color value (as an integer) used in Windows High Contrast Mode. Non-null only when High Contrast Mode is active.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1987,6 +2031,8 @@ fields:
   mode: REPEATED
   name: a11y_theme
   type: RECORD
+  description: Keyed array of accessibility theme overrides detected for this client, where each key is a theme name and the value is a boolean indicating
+    whether it is active.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1997,6 +2043,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of help clicks on non-sponsored best-match Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2007,6 +2054,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of help clicks on sponsored best-match Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2017,6 +2065,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_nonsponsored_sum
   type: RECORD
+  description: Keyed count of user blocks on non-sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2027,6 +2076,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_sponsored_sum
   type: RECORD
+  description: Keyed count of user blocks on sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2037,6 +2087,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of user blocks on sponsored best-match Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2047,6 +2098,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of user blocks on non-sponsored best-match Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -2109,6 +2109,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of clicks on sponsored best-match Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2119,6 +2120,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of clicks on non-sponsored best-match Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2129,6 +2131,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of impressions for sponsored best-match Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2139,18 +2142,23 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of impressions for non-sponsored best-match Firefox Suggest results on the first seen day.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_bestmatch
   type: STRING
+  description: User preference for showing Best Match results in URL bar suggestions ('true' to enable). Null if not set.
 - mode: NULLABLE
   name: scalar_parent_browser_ui_interaction_textrecognition_error_sum
   type: INTEGER
+  description: Total number of errors encountered when using the Text Recognition feature on the first seen day.
 - mode: NULLABLE
   name: text_recognition_interaction_timing_sum
   type: INTEGER
+  description: Total time in milliseconds spent on Text Recognition interactions on the first seen day.
 - mode: NULLABLE
   name: text_recognition_interaction_timing_count_sum
   type: INTEGER
+  description: Total number of Text Recognition interaction timing measurements recorded on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2161,81 +2169,107 @@ fields:
   mode: REPEATED
   name: scalar_parent_browser_ui_interaction_content_context_sum
   type: RECORD
+  description: Keyed count of user interactions with the browser content context menu, keyed by menu item, on the first seen day.
 - mode: NULLABLE
   name: text_recognition_api_performance_sum
   type: INTEGER
+  description: Total API performance measurement in milliseconds for Text Recognition operations on the first seen day.
 - mode: NULLABLE
   name: text_recognition_api_performance_count_sum
   type: INTEGER
+  description: Total number of Text Recognition API performance measurements recorded on the first seen day.
 - mode: NULLABLE
   name: text_recognition_text_length_sum
   type: INTEGER
+  description: Total length of text recognized by the Text Recognition feature on the first seen day.
 - mode: NULLABLE
   name: text_recognition_text_length_count_sum
   type: INTEGER
+  description: Total number of Text Recognition text length measurements recorded on the first seen day.
 - mode: NULLABLE
   name: places_searchbar_cumulative_searches_sum
   type: INTEGER
+  description: Cumulative total of searches performed via the Places search bar on the first seen day.
 - mode: NULLABLE
   name: places_searchbar_cumulative_filter_count_sum
   type: INTEGER
+  description: Cumulative total of filter applications in the Places search bar on the first seen day.
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_taskbar_private
   type: BOOLEAN
+  description: Whether Firefox was launched in Private Browsing mode via the taskbar on the first seen day.
 - mode: NULLABLE
   name: dom_parentprocess_private_window_used
   type: BOOLEAN
+  description: Whether the client opened a Private Browsing window on the first seen day. True if a private window was used.
 - mode: NULLABLE
   name: os_environment_is_taskbar_pinned_any
   type: BOOLEAN
+  description: Whether Firefox is pinned to the Windows taskbar in any mode (regular or private). True if pinned in either mode.
 - mode: NULLABLE
   name: os_environment_is_taskbar_pinned_private_any
   type: BOOLEAN
+  description: Whether Firefox Private Browsing is pinned to the Windows taskbar in any configuration.
 - mode: NULLABLE
   name: os_environment_is_taskbar_pinned_private
   type: BOOLEAN
+  description: Whether Firefox Private Browsing mode is specifically pinned to the Windows taskbar.
 - mode: NULLABLE
   name: bookmark_migrations_quantity_chrome
   type: INTEGER
+  description: Number of bookmarks migrated from Google Chrome on the first seen day.
 - mode: NULLABLE
   name: bookmark_migrations_quantity_edge
   type: INTEGER
+  description: Number of bookmarks migrated from Microsoft Edge on the first seen day.
 - mode: NULLABLE
   name: bookmark_migrations_quantity_safari
   type: INTEGER
+  description: Number of bookmarks migrated from Apple Safari on the first seen day.
 - mode: NULLABLE
   name: bookmark_migrations_quantity_all
   type: INTEGER
+  description: Total number of bookmarks migrated from all browsers on the first seen day.
 - mode: NULLABLE
   name: history_migrations_quantity_chrome
   type: INTEGER
+  description: Number of history entries migrated from Google Chrome on the first seen day.
 - mode: NULLABLE
   name: history_migrations_quantity_edge
   type: INTEGER
+  description: Number of history entries migrated from Microsoft Edge on the first seen day.
 - mode: NULLABLE
   name: history_migrations_quantity_safari
   type: INTEGER
+  description: Number of history entries migrated from Apple Safari on the first seen day.
 - mode: NULLABLE
   name: history_migrations_quantity_all
   type: INTEGER
+  description: Total number of history entries migrated from all browsers on the first seen day.
 - mode: NULLABLE
   name: logins_migrations_quantity_chrome
   type: INTEGER
+  description: Number of saved logins migrated from Google Chrome on the first seen day.
 - mode: NULLABLE
   name: logins_migrations_quantity_edge
   type: INTEGER
+  description: Number of saved logins migrated from Microsoft Edge on the first seen day.
 - mode: NULLABLE
   name: logins_migrations_quantity_safari
   type: INTEGER
+  description: Number of saved logins migrated from Apple Safari on the first seen day.
 - mode: NULLABLE
   name: logins_migrations_quantity_all
   type: INTEGER
+  description: Total number of saved logins migrated from all browsers on the first seen day.
 - mode: NULLABLE
   name: media_play_time_ms_audio_sum
   type: INTEGER
+  description: Total time in milliseconds audio media was playing in this client's browser on the first seen day.
 - mode: NULLABLE
   name: media_play_time_ms_video_sum
   type: INTEGER
+  description: Total time in milliseconds video media was playing in this client's browser on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2246,6 +2280,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of user blocks on dynamic Wikipedia Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2256,6 +2291,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_weather_sum
   type: RECORD
+  description: Keyed count of user blocks on weather Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2266,6 +2302,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of clicks on dynamic Wikipedia Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2276,6 +2313,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_nonsponsored_sum
   type: RECORD
+  description: Keyed count of clicks on non-sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2286,6 +2324,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sponsored_sum
   type: RECORD
+  description: Keyed count of clicks on sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2296,6 +2335,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_weather_sum
   type: RECORD
+  description: Keyed count of clicks on weather Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2306,6 +2346,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of help clicks on dynamic Wikipedia Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2316,6 +2357,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_nonsponsored_sum
   type: RECORD
+  description: Keyed count of help clicks on non-sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2326,6 +2368,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sponsored_sum
   type: RECORD
+  description: Keyed count of help clicks on sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2336,6 +2379,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_weather_sum
   type: RECORD
+  description: Keyed count of help clicks on weather Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2346,6 +2390,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of impressions for dynamic Wikipedia Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2356,6 +2401,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_nonsponsored_sum
   type: RECORD
+  description: Keyed count of impressions for non-sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2366,6 +2412,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sponsored_sum
   type: RECORD
+  description: Keyed count of impressions for sponsored Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2376,6 +2423,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_weather_sum
   type: RECORD
+  description: Keyed count of impressions for weather Firefox Suggest results on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2386,6 +2434,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_opened_sum
   type: RECORD
+  description: Keyed count of Firefox Sidebar panel open events by sidebar panel name on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2396,6 +2445,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_search_sum
   type: RECORD
+  description: Keyed count of searches performed within the Firefox Sidebar by sidebar panel name on the first seen day.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2406,15 +2456,19 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_link_sum
   type: RECORD
+  description: Keyed count of link navigations from the Firefox Sidebar by sidebar panel name on the first seen day.
 - name: places_previousday_visits_mean
   type: FLOAT
   mode: NULLABLE
+  description: Mean number of page visits from the previous day, averaged across subsessions on the first seen day.
 - name: places_library_cumulative_bookmark_searches_sum
   type: INTEGER
   mode: NULLABLE
+  description: Cumulative count of bookmark searches in the Firefox Library panel on the first seen day.
 - name: places_library_cumulative_history_searches_sum
   type: INTEGER
   mode: NULLABLE
+  description: Cumulative count of history searches in the Firefox Library panel on the first seen day.
 - name: places_bookmarks_searchbar_cumulative_searches_sum
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -799,9 +799,11 @@ fields:
 - mode: NULLABLE
   name: search_count_urlbar_handoff
   type: INTEGER
+  description: Total number of searches initiated via a handoff from the new tab URL bar to the browser URL bar on the first seen day.
 - mode: NULLABLE
   name: search_count_urlbar_persisted
   type: INTEGER
+  description: Total number of searches where the URL bar retained the search term after the search on the first seen day.
 - mode: NULLABLE
   name: session_restored_mean
   type: FLOAT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -1130,21 +1130,27 @@ fields:
 - mode: NULLABLE
   name: scalar_parent_os_environment_is_taskbar_pinned
   type: BOOLEAN
+  description: Whether Firefox is pinned to the Windows taskbar. True if pinned.
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_desktop
   type: BOOLEAN
+  description: Whether Firefox was launched via a desktop shortcut on the first seen day.
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_start_menu
   type: BOOLEAN
+  description: Whether Firefox was launched via the Windows Start Menu on the first seen day.
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_taskbar
   type: BOOLEAN
+  description: Whether Firefox was launched via the Windows taskbar on the first seen day.
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_other_shortcut
   type: BOOLEAN
+  description: Whether Firefox was launched via a non-desktop shortcut on the first seen day.
 - mode: NULLABLE
   name: scalar_parent_os_environment_launched_via_other
   type: BOOLEAN
+  description: Whether Firefox was launched via any other mechanism on the first seen day.
 - mode: NULLABLE
   name: search_count_webextension
   type: INTEGER


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.telemetry_derived`

> Generated by the metadata agent pipeline on 2026-06-05.

### Summary

| | |
|---|---|
| Tables updated | 2 |
| Fields described | 411 |
| Probe-matched | 0 / 411 |
| Global.yaml candidates | 485 |
| Contradictions flagged | 0 |

### How Descriptions Were Generated

1. **Data profiling** — null rates, distinct values, and value distributions sampled from live BigQuery data
2. **Probe context** — No source ping found in DataHub for most tables; cfs_ga4_attr_v1 traced to first-shutdown ping, clients_daily_event_v1 to event ping, clients_daily_agg_by_default_browser_lifecycle_stage_v1/clients_first_seen_28_days_later tables to crash/first-shutdown pings; most tables are derived aggregations without direct probe lineage
3. **Reconciliation** — Claude reconciled observed data with probe definitions

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `active_users_aggregates_v1` | 17 | 0/17 |
| `clients_first_seen_v1` | 394 | 2/394 |

### Global.yaml Candidates

Fields routed to `global.yaml` — consistent meaning across datasets:

- `app_name` — The name of the browser or application (e.g., 'Firefox', 'Fenix', 'Firefox iOS').
- `attribution_campaign` — The attribution campaign identifier from the install attribution, indicating the marketing campaign that drove the installation (utm_campaign value).
- `attribution_content` — The attribution content identifier from the install attribution, indicating the specific creative or link within a campaign.
- `attribution_experiment` — The attribution experiment key associated with the install, used to track funnel experiment parameters.
- `attribution_medium` — The attribution medium from the install attribution, indicating the category of channel that drove the installation (e.g., 'organic', 'referral', 'cpc').
- `attribution_source` — The attribution source from the install attribution, indicating the referring partner domain or website that drove the installation.
- `attribution_variation` — The attribution variation key associated with the install, used to track funnel experiment variation parameters.
- `city` — The city in which the activity took place, as determined by IP geolocation.
- `dau` — The number of daily active users on the submission date, counting clients that reported at least one qualifying ping.
- `mau` — The number of monthly active users on the submission date, counting clients that reported at least one qualifying ping in the prior 28 days.
- `wau` — The number of weekly active users on the submission date, counting clients that reported at least one qualifying ping in the prior 7 days.
- `app_name` — The name of the browser or application (e.g., 'Firefox Desktop', 'Fenix', 'Firefox iOS').
- `app_version` — User-visible version string of the browser (e.g. '151.0', '150.0.3').
- `attribution_medium` — The attribution medium from the install attribution, indicating the category of channel that drove the installation (e.g., 'organic', 'referral', 'cpc').
- `attribution_source` — The attribution source from the install attribution, indicating the referring partner domain or website that drove the installation.
- `os_version` — The operating system version string on the client's device (e.g., '10.0' for Windows, '16' for Android).
- `activity_segment` — Classification of users based on their browsing activity. E.g., infrequent, casual, regular.
- `app_name` — The name of the application.
- `app_version` — User visible version string (e.g. "1.0.3") for the browser.
- `app_version_major` — The major version of the user visible app version string for the browser, e.g. "142.1.3", has major version 142.
- `app_version_minor` — The minor version of the user visible app version string for the browser, e.g. "142.1.3" has minor version 1.
- `attribution_medium` — The attribution medium; similar or the same as UTM medium.
- `attribution_source` — The attribution source; similar or the same as UTM source.
- `channel` — The normalized channel the application is being distributed on.
- `country` — Name of the country in which the activity took place, as determined by the IP geolocation.
- `dau` — The number of daily active users, corresponding to the count of clients that reported at least one ping on the submission_date and qualify as active.
- `distribution_id` — The distribution id associated with the install of Firefox.
- `is_default_browser` — A flag indicating whether the browser is set as the default browser on the client side.
- `locale` — Set of language- and/or country-based preferences for a user interface.
- `mau` — The number of monthly active users, corresponding to the count of clients that reported at least one ping on the previous 28 days from the submission_date and qualify as active.
- `os` — The normalized name of the operating system running at the client.
- `os_version` — Version of the operating system running at the client, e.g. "100.9.11".
- `os_version_major` — Major or first part of the operating system version running at the client. E.g. for version "100.9.11", the major is 100.
- `os_version_minor` — Minor part of the operating system version running at the client. E.g. for version "100.9.11", the minor is 9.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `wau` — The number of weekly active users, corresponding to the count of clients that reported at least one ping on the previous 7 days from the submission_date and qualify as active.
- `activity_segment` — User activity segment based on browsing frequency (e.g. 'infrequent_user', 'casual_user', 'core_user', 'regular_user', 'other').
- `app_version_major` — The major component of the user-visible app version string (e.g. 151 for version '151.0.1').
- `app_version_minor` — The minor component of the user-visible app version string (e.g. 1 for version '151.1.0').
- `app_version_patch_revision` — The patch/revision component of the app version. Null (~61%) for versions without a patch number (sampled 2026-06-02).
- `is_default_browser` — A flag indicating whether the browser is set as the default browser on the client side. Always null for this mobile TOU table (sampled 2026-06-02).
- `windows_build_number` — The Windows build number (e.g. 22000). Always null for mobile platforms (sampled 2026-06-02).
- `app_name` — The name of the browser or application (e.g., 'Firefox Desktop', 'Fenix', 'Firefox iOS').
- `app_version` — User-visible version string of the browser (e.g. '151.0', '150.0.3').
- `attribution_medium` — The attribution medium from the install attribution, indicating the category of channel that drove the installation (e.g., 'organic', 'referral', 'cpc').
- `attribution_source` — The attribution source from the install attribution, indicating the referring partner domain or website that drove the installation.
- `city` — The city in which the activity took place, as determined by IP geolocation.
- `os_version` — The operating system version string on the client's device (e.g., '10.0' for Windows, '16' for Android).
- `app_name` — The application name from telemetry.active_users (e.g. 'Firefox Desktop', 'Fenix').
- `dau` — DAU (daily active users) from telemetry.active_users for this app name and submission_date, as recorded at the time of the DAG run.
- `mau` — MAU (monthly active users) from telemetry.active_users for this app name and submission_date, as recorded at the time of the DAG run.
- `submission_date` — The submission date from telemetry.active_users for which this rollup row applies.
- `wau` — WAU (weekly active users) from telemetry.active_users for this app name and submission_date, as recorded at the time of the DAG run.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `country` — The two-letter ISO 3166-1 country code of the client, limited to US, DE, GB, FR, CA, and AU.
- `normalized_channel` — The normalized Firefox release channel associated with the engagement (e.g. 'release', 'beta').
- `submission_date` — The date for which engagement counts are aggregated.
- `app_channel` — The release channel for this application entry, e.g. 'release', 'beta', or 'nightly'.
- `app_name` — The snake_case application name used internally (e.g. 'firefox_desktop', 'fenix').
- `app_build_id` — The build ID of the Firefox application, in YYYYMMDDHHMMSS format.
- `app_name` — The name of the browser application (always 'Firefox' in this table).
- `architecture` — The CPU architecture of the client's build (e.g., 'x86-64', 'aarch64', 'x86').
- `attribution_campaign` — The campaign identifier from the install attribution, indicating the marketing campaign that drove the installation.
- `attribution_content` — The attribution content identifier from the install attribution, indicating the specific creative or link within a campaign.
- `attribution_dlsource` — Identifier indicating where the Firefox installation originated (e.g., 'mozorg', 'fxdotcom', 'mozillaci').
- `attribution_dltoken` — A unique token created at Firefox download time to correlate installs with download events.
- `attribution_experiment` — The attribution experiment key associated with the install.
- `attribution_medium` — The attribution medium from the install (e.g., 'organic', 'referral', 'cpc').
- `attribution_source` — The attribution source from the install, indicating the referring domain or partner.
- `attribution_ua` — The derived user agent type at attribution time (e.g., 'chrome', 'edge', 'firefox').
- `attribution_variation` — The attribution variation key associated with the install.
- `city` — The city in which the activity took place, as determined by IP geolocation.
- `first_seen_date` — The date the server first received a ping from this client, establishing the profile's first-seen date.
- `is_desktop` — Whether this client is a desktop Firefox installation. True for desktop, false for other platforms.
- `normalized_os_version` — The normalized operating system version string (e.g., '10.0' for Windows, '6.8.0' for Linux).
- `os` — The name of the operating system on the client device, as reported by the telemetry environment (e.g. 'Windows_NT', 'Darwin', 'Linux').
- `os_version` — The operating system version string (e.g., '10.0' for Windows, '6.1' for Windows 7).
- `app_build_id` — The build ID string of the Firefox application (e.g. '20200403170909'). NULL indicates all build IDs are aggregated together.
- `app_version` — The major version number of Firefox (e.g. 75, 76). Represents the browser version for which probe counts are aggregated.
- `channel` — The Firefox release channel from which the data was collected (e.g. 'release', 'beta', 'nightly').
- `client_id` — A unique identifier (UUID) for the client.
- `os` — The normalized name of the operating system (e.g. 'Windows', 'Mac', 'Linux'). NULL indicates all operating systems are aggregated together.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `app_build_id` — The build ID of the Firefox application (e.g. '20200403170909'). Null for roughly 26% of rows.
- `app_version` — The integer major version of the Firefox application (e.g. 75, 76). Used to filter rows to recent versions when computing aggregates.
- `channel` — The normalized release channel the application is distributed on (e.g. release, beta, nightly).
- `client_id` — A unique identifier (UUID) for the client.
- `os` — The normalized name of the operating system running at the client. Null for ~45% of rows; observed values include Windows, Linux, and Mac.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `normalized_os_version` — The normalized operating system version string (e.g., '10.0' for Windows, '6.8.0' for Linux, '25.3.0' for macOS).
- `app_build_id` — The build ID of the Firefox application (e.g. '20200403170909').
- `channel` — The normalized release channel the application is distributed on (e.g. release, beta, nightly).
- `os` — The normalized name of the operating system running at the client.
- `app_build_id` — The build ID of the Firefox application in YYYYMMDDHHMMSS format.
- `app_name` — The name of the browser application (always 'Firefox' for desktop telemetry).
- `app_version` — The user-visible version string of the Firefox application (e.g. '149.0.2'). Sourced from the URI metadata of the ping.
- `attribution.campaign` — The campaign identifier from the install attribution.
- `attribution.content` — The attribution content identifier from the install attribution.
- `attribution.dlsource` — Identifier indicating where the Firefox installation originated (e.g., 'mozorg', 'fxdotcom').
- `attribution.dltoken` — A unique token created at Firefox download time to correlate installs with download events.
- `attribution.experiment` — The attribution experiment key associated with the install.
- `attribution.medium` — The attribution medium from the install (e.g., 'organic', 'referral', 'cpc').
- `attribution.source` — The attribution source from the install attribution, indicating the referring partner domain that drove the installation.
- `attribution.ua` — The derived user agent type at attribution time (e.g., 'chrome', 'edge', 'firefox').
- `attribution.variation` — The attribution variation key associated with the install.
- `city` — The city in which the client's activity took place, as determined by IP geolocation.
- `first_seen_date` — Date when the server first received a ping from this client.
- `isp_name` — The name of the internet service provider associated with the client's IP address.
- `normalized_os_version` — The normalized operating system version string (e.g., '10.0' for Windows, '6.8.0' for Linux).
- `os_version` — The operating system version string (e.g., '10.0' for Windows, '24.6.0' for macOS).
- `app_build_id` — The build ID of the Firefox application in YYYYMMDDHHMMSS format.
- `app_build_id` — The build ID of the Firefox application in YYYYMMDDHHMMSS format.
- `app_name` — The name of the browser application (always 'Firefox' for desktop telemetry).
- `attribution.campaign` — The campaign identifier from the install attribution.
- `attribution.content` — The attribution content identifier from the install attribution.
- `attribution.dlsource` — Identifier indicating where the Firefox installation originated (e.g., 'mozorg', 'fxdotcom').
- `attribution.dltoken` — A unique token created at Firefox download time to correlate installs with download events.
- `attribution.experiment` — The attribution experiment key associated with the install.
- `attribution.medium` — The attribution medium from the install (e.g., 'organic', 'referral', 'cpc').
- `attribution.source` — The attribution source from the install attribution, indicating the referring partner domain that drove the installation.
- `attribution.ua` — The derived user agent type at attribution time (e.g., 'chrome', 'edge', 'firefox').
- `attribution.variation` — The attribution variation key associated with the install.
- `city` — The city in which the client's activity took place, as determined by IP geolocation.
- `isp_name` — The name of the internet service provider associated with the client's IP address.
- `normalized_os_version` — The normalized operating system version string (e.g., '10.0' for Windows, '6.8.0' for Linux).
- `os_version` — The operating system version string (e.g., '10.0' for Windows, '24.6.0' for macOS).
- `attribution_campaign` — The campaign identifier from the install attribution.
- `attribution_content` — The attribution content identifier from the install attribution.
- `attribution_dlsource` — Identifier indicating where the Firefox installation originated (e.g., 'mozorg', 'fxdotcom').
- `attribution_dltoken` — A unique token created at Firefox download time to correlate installs with download events.
- `attribution_experiment` — The attribution experiment key associated with the install.
- `attribution_medium` — The attribution medium from the install (e.g., 'organic', 'referral', 'cpc').
- `attribution_source` — The attribution source from the install attribution, indicating the referring partner domain that drove the installation.
- `attribution_ua` — The derived user agent type at attribution time (e.g., 'chrome', 'edge', 'firefox').
- `build_id` — The Firefox build ID of the client at the time of first seen, in YYYYMMDDHHMMSS format.
- `first_seen_date` — Date when the server first received a ping from this client, establishing the start of the 28-day observation window.
- `os_version` — The operating system version of the client as a numeric value.
- `app_build_id` — The build ID of the Firefox application reported on first seen date, in YYYYMMDDHHMMSS format (sampled 2026-05-29).
- `app_name` — The name of the browser application; always 'Firefox' in this table (sampled 2026-05-29).
- `app_version` — The version string of the Firefox application on the first seen date (e.g. '151.0.1') (sampled 2026-05-29).
- `attribution.campaign` — Identifier of the particular marketing campaign that led to the download of Firefox.
- `attribution.content` — Identifier indicating the particular link within a campaign that drove the Firefox download.
- `attribution.dlsource` — Identifier indicating where this Firefox installation originated (e.g., mozorg, fxdotcom, mozillaci).
- `attribution.dltoken` — Unique token created at Firefox download time, used to link an installation to a specific download event.
- `attribution.experiment` — Funnel experiment parameter recorded at download time.
- `attribution.medium` — Category of the traffic source that drove the Firefox download, such as 'referral' for partner referrals.
- `attribution.source` — Referring partner domain from which Firefox was downloaded, when the install originated via a known partner.
- `attribution.ua` — The browser user agent used to download the Firefox installer, derived from the download request.
- `attribution.variation` — Variation parameter of the funnel experiment recorded at download time.
- `city` — The city in which the client's activity took place on first seen, as determined by IP geolocation.
- `client_id` — A unique identifier (UUID) for the client installation.
- `country` — The ISO 3166-1 alpha-2 country code of the client, determined by IP geolocation at the time of first seen ping (sampled 2026-05-29).
- `distribution_id` — The identifier of the Firefox distribution (e.g. 'canonical-002', 'mozilla-MSIX', 'mint-001') that supplied this install (sampled 2026-05-29).
- `first_seen_date` — Date when the server first received a ping from this client.
- `isp_name` — The name of the internet service provider associated with the client's IP address at first seen (sampled 2026-05-29).
- `os` — The name of the operating system running on the client (e.g., 'Windows_NT', 'Darwin', 'Linux').
- `profile_group_id` — A UUID identifying the profile group on a single device, used for cross-product correlation.
- `sample_id` — A number (0–99) derived from client_id for convenient sub-sampling; allows analysts to work on a fraction of the data without biasing by client.
- `app_build_id` — The build ID of the Firefox application binary, formatted as a timestamp string (e.g. '20260116091309').
- `app_build_id` — The build ID of the Firefox application, identifying the specific build associated with this client's histogram aggregates. May be '*' when aggregated across all build IDs.
- `app_build_id` — The build ID of the Firefox application used to compute these per-bucket counts. May be '*' when the row aggregates across all build IDs for a given channel and OS combination.
- `app_build_id` — The Firefox application build ID, or NULL when this row aggregates across all build IDs (corresponding to '*' in the upstream bucket counts table).
- `app_build_id` — The build ID of the application, a timestamp-based string identifying the exact Firefox build (e.g. '20260511200624') (sampled 2026-05-29).
- `app_name` — The name of the browser application; always 'Firefox' for this table (sampled 2026-05-29).
- `app_version` — User visible version string (e.g. '150.0.3') for the browser (sampled 2026-05-29).
- `first_seen_date` — Date when the server first received a ping from this client.
- `normalized_os_version` — Normalized version string of the operating system (e.g. '10.0' for Windows 10, '24.6.0' for a Linux kernel); matches the global os_version alias (sampled 2026-05-29).
- `os_version` — Raw version string of the operating system as reported by the client (e.g. '10.0' for Windows, '24.6.0' for Linux); high cardinality on Linux (sampled 2026-05-29).
- `app_build_id` — The build ID of the Firefox application reported by the client on the most recent active day.
- `app_name` — The name of the application (always 'Firefox' for this table).
- `country` — The ISO 3166-1 alpha-2 country code determined by IP geolocation of the client on the most recent active day.
- `distribution_id` — The distribution identifier for the Firefox installation, identifying partnerships or custom builds (e.g., 'canonical-002', 'MozillaOnline').
- `first_seen_date` — The date when the server first received any telemetry ping from this client.
- `is_default_browser` — Whether Firefox is set as the default web browser on the client. True means Firefox handles web URLs by default.
- `isp_name` — The name of the internet service provider associated with the client's IP address on the most recent active day.
- `locale` — Set of language- and/or country-based preferences for the Firefox user interface (e.g., 'en-US', 'fr', 'zh-CN').
- `normalized_channel` — The normalized release channel the client is on (e.g., 'release', 'beta', 'nightly', 'esr', 'aurora', 'Other'). Non-standard channel strings are collapsed to 'Other'.
- `normalized_os_version` — The operating system version string normalized to a consistent format at ingestion (e.g., '10.0' for Windows, '25.3.0' for macOS, '6.17.0' for Linux).
- `os_version` — The operating system version string as reported by the client before normalization (e.g., '10.0' for Windows, '25.3.0' for macOS, kernel version strings for Linux).
- `app_build_id` — The build ID of the Firefox application (e.g., '20240509170740'). An asterisk ('*') indicates the value has been aggregated across all build IDs.
- `channel` — The Firefox release channel from which the client is reporting (e.g., 'release', 'beta', 'nightly').
- `channel` — The normalized release channel the application is being distributed on (e.g. 'nightly', 'beta', 'release'). (sampled 2026-06-02)
- `attribution_campaign` — The campaign this client/install was attributed to (utm_campaign value, identifying a specific marketing campaign or promotion).
- `attribution_content` — The attribution content associated with the install; similar or the same as UTM content.
- `attribution_experiment` — The attribution experiment key associated with the install, used to track install-time experiment assignments.
- `attribution_medium` — The attribution medium associated with the install; similar or the same as UTM medium.
- `attribution_source` — The attribution source associated with the install; similar or the same as UTM source.
- `attribution_variation` — The attribution variation key associated with the install, identifying which experiment variation the user was exposed to.
- `normalized_app_name` — The normalized name of the Firefox application variant (e.g., 'Fenix', 'Firefox Desktop', 'Firefox iOS'). Set to 'Other' if the app name was not recognized.
- `normalized_os_version` — The operating system version normalized to a consistent format at ingestion (e.g., '10.0' for Windows, '16' for Android, '26.3.1' for iOS).
- `app_build_id` — The build identifier of the application as reported in the core ping URI metadata (e.g., '33292015').
- `country` — ISO 3166-1 alpha-2 country code of the client, determined by IP geolocation at ingestion.
- `default_browser` — Whether Firefox is set as the default browser on the client device at the time of the last core ping submission. Null when this information was not reported.
- `distribution_id` — The distribution identifier associated with the Firefox installation, used to attribute installs to OEM or partner distributions (e.g., 'mozillaonline'). Null for standard Mozilla installs.
- `first_seen_date` — The date on which the server first received a core ping from this client, joined from core_clients_first_seen_v1.
- `locale` — The locale of the application during the session (e.g., en-US, fr-FR), representing the most frequently observed value for this client on the submission date.
- `normalized_channel` — The normalized release channel of the application (e.g., release, beta, nightly). Set to 'Other' if the channel reported by the client was not recognized.
- `os` — The operating system of the client device (e.g., Android, iOS, iPadOS), representing the most frequently observed value for this client on the submission date.
- `app_build_id` — The build identifier of the application as reported in the core ping URI metadata on the client's most recently active day.
- `first_seen_date` — The date on which the server first received a core ping from this client.
- `application_name` — The normalized application name reporting the crash (always 'Firefox' in this table, sampled 2026-06-02).
- `build_id` — The application build ID from the crash ping (e.g., '20260514164700'). Represents the modal build ID observed across all crash pings for this client on the day.
- `channel` — The normalized release channel of the crashing application (e.g., 'release', 'esr', 'beta', 'nightly', 'Other').
- `client_id` — A unique identifier (UUID) for the client.
- `country_code` — The ISO 3166-1 alpha-2 country code for the country where the crash occurred, as determined by IP geolocation.
- `os` — The normalized operating system of the crashing client (e.g., 'Windows', 'Linux', 'Mac').
- `os_version` — The OS version string of the crashing client (e.g., '10.0', '6.1' for Windows versions). Represents the modal value across all crash pings for this client on the day.
- `sample_id` — A number, 0-99, that samples by client_id and allows filtering data for analysis. It is a pipeline-generated artifact that should match between pings.
- `submission_date` — The date when the telemetry crash ping was received on the server side.
- `architecture` — The CPU architecture of the client device (e.g., 'x86-64', 'aarch64', 'x86').
- `attribution_campaign` — The campaign this client's install was attributed to, identifying a specific marketing campaign or promotion.
- `attribution_content` — The attribution content identifier; similar to UTM content, indicating the particular link or creative within a campaign.
- `attribution_experiment` — The attribution experiment key associated with the client's install, identifying a download-funnel experiment.
- `attribution_medium` — The attribution medium; similar to UTM medium, indicating the category of traffic source (e.g., 'referral', 'paidsearch').
- `attribution_source` — The attribution source; the referring domain or partner from which the client installed Firefox (e.g., 'www.google.com').
- `attribution_ua` — The browser user-agent used to download Firefox, indicating the browser the client was using prior to installation (e.g., 'chrome', 'edge', 'firefox').
- `city` — City retrieved as a result of a geographic lookup based on the client's IP address. Null when the city cannot be determined.
- `first_seen_date` — Date when the server first received a ping from this client; used as the cohort assignment date.
- `normalized_app_name` — The normalized application name (e.g., 'Firefox'). Set to 'Other' if the application name was not recognized.
- `normalized_os_version` — The operating system version normalized to a consistent format at ingestion (e.g., '10.0' for Windows, '6.17.0' for Linux, '25.3.0' for macOS).
- `subdivision1` — The first-level country subdivision (e.g., state, province) determined by IP geolocation, using standard subdivision codes. Null when the subdivision cannot be determined.
- `attribution_source` — The attribution source; the referring domain or partner from which the client installed Firefox (e.g., 'www.google.com', 'www.bing.com'). Null when no attribution source is recorded.
- `attribution_ua` — The browser user-agent used to download Firefox, indicating the browser the client was using prior to installation (e.g., 'chrome', 'edge', 'firefox'). Empty string when the UA could not be parsed.
- `build_id` — The Firefox build identifier string (e.g., '20260516144017'), encoding the date and time the build was compiled.
- `os_version` — The major.minor version of the operating system on the client at the time of first launch, truncated to the minor component for privacy (e.g., '10', '6.1').
- `attribution_source` — The referring domain or source from which the Firefox installer was downloaded (e.g. 'www.google.com', 'www.bing.com'). Null for ~60% of new profiles where attribution data was not captured.
- `attribution_ua` — The browser user agent used to download the Firefox installer. Possible values include 'chrome', 'edge', 'firefox', 'other', 'ie', or empty string when the browser could not be detected.
- `channel` — The normalized release channel of Firefox on which the new profile was created (e.g. 'release', 'esr', 'beta', 'nightly', 'aurora', 'Other').
- `distribution_id` — The distribution identifier for the Firefox build, indicating which partner or OEM distribution produced the installer (e.g. 'canonical-002', 'mint-001'). Null for ~71% of new profiles.
- `os` — The normalized name of the operating system on which the new profile was created (e.g. 'Windows', 'Linux', 'Mac').
- `country_code` — The ISO 3166-1 alpha-2 country code where the client is located, as determined by IP geolocation. Countries with fewer than 5000 distinct clients may be aggregated into 'OTHER' for privacy.
- `app_name` — The name of the application that sent the event ping (e.g., 'Firefox').
- `attribution_dltoken` — A unique token created at Firefox download time, used to link installs to specific download events across attribution pipelines.
- `attribution_source` — The referring domain or source that led to the Firefox installation, similar to UTM source (e.g., 'www.google.com', 'www.bing.com').
- `build_architecture` — The CPU architecture for which Firefox was compiled (e.g., 'x86-64', 'aarch64', 'x86'), as recorded at build time.
- `build_id` — The build ID of the Firefox application, formatted as a date-time string (e.g., '20260520211922'), identifying the specific build that produced the event.
- `os_version` — The operating system version string at the client, prior to normalization (e.g., '10.0' for Windows, '25.5.0' for macOS, '6.8.0' for Linux).
- `timestamp` — The server-side timestamp when the event ping was received, used for ordering and joining with other telemetry data.
- `submission_date` — The date for which this event type snapshot was generated; represents the latest date processed in the incremental update.
- `normalized_channel` — The normalized release channel of the Firefox client (e.g. 'release', 'beta', 'nightly', 'esr', 'aurora', 'Other'). Set to 'Other' if the reported channel was unrecognized.
- `normalized_channel` — The normalized release channel of the Firefox client (e.g. 'release', 'beta', 'nightly', 'esr', 'aurora', 'Other'). Null for ~3.7% of rows (sampled 2026-06-02).
- `normalized_channel` — The normalized release channel of the Firefox client (e.g. 'release', 'beta', 'nightly', 'esr'). Null for ~73% of rows, covering older experiments that lacked channel data (sampled 2026-06-02).
- `normalized_channel` — The normalized release channel of the Firefox client (e.g. 'release', 'beta', 'nightly', 'esr'). Null for ~30% of rows (sampled 2026-06-02).
- `normalized_channel` — The normalized release channel of the Firefox client (e.g. 'release', 'beta', 'nightly', 'esr'). No null values in v1 (sampled 2026-06-02).
- `submission_date` — The date when the telemetry ping is received on the server side.
- `normalized_channel` — The normalized release channel of the Firefox client (e.g. 'release', 'beta', 'nightly', 'esr'). Null for ~1.6% of rows (sampled 2026-06-02).
- `submission_date` — The date when the telemetry ping is received on the server side.
- `activity_segments_v1` — User engagement segment based on browsing frequency. Values: 'core_user', 'regular_user', 'infrequent_user', 'casual_user', 'other' (sampled 2026-06-02).
- `app_version` — User visible version string (e.g. '151.0.1') for the browser. The most common value as of sample date was '151.0.1' (sampled 2026-06-02).
- `client_id` — A unique identifier (UUID) for the client.
- `country` — ISO 3166-1 alpha-2 code of the country in which the activity took place, as determined by IP geolocation (e.g. 'US', 'DE', 'FR') (sampled 2026-06-02).
- `first_seen_date` — Date when the server first received a ping from this client.
- `is_default_browser` — True if Firefox is set as the default browser on the client; false otherwise. True for ~58% of clients (sampled 2026-06-02).
- `normalized_os_version` — Version of the operating system version running at the client (e.g. '10.0' for Windows 10, '25.5.0' for Linux kernel) (sampled 2026-06-02).
- `os` — The name of the operating system running on the client (e.g. 'Windows_NT', 'Darwin', 'Linux') (sampled 2026-06-02).
- `profile_group_id` — A UUID identifying the profile group on a single device, allowing user-oriented correlation of data. Null for ~2.1% of clients (sampled 2026-06-02).
- `submission_date` — The date when the telemetry ping is received on the server side.
- `subsample_id` — A number, 0-99, that samples by client_id to allow filtering data for analysis. Uniformly distributed across 100 buckets (sampled 2026-06-02).
- `app_version_major` — The major version number of the application that crashed (e.g. 115 for Firefox ESR 115, 140 for Firefox 140) (sampled 2026-06-02).
- `app_version_minor` — The minor version number of the application that crashed (e.g. 36 for Firefox ESR 115.36.0) (sampled 2026-06-02).
- `client_info.telemetry_sdk_build` — The version of the Glean SDK at the time the crash ping was collected (e.g. '67.2.0') (sampled 2026-06-02).
- `document_id` — The document ID specified in the URI when the client sent this message, uniquely identifying each crash ping submission.
- `normalized_channel` — The normalized release channel of the crashing application (e.g. 'release', 'esr', 'beta', 'nightly'). Null for ~73% of rows (older/unrecognized clients) (sampled 2026-06-02).
- `normalized_country_code` — ISO 3166-1 alpha-2 country code of the client's location, as determined by IP geolocation (e.g. 'US', 'IN', 'FR') (sampled 2026-06-02).
- `normalized_os` — The normalized name of the operating system on which the crash occurred (e.g. 'Windows', 'Linux', 'Android', 'Mac') (sampled 2026-06-02).
- `normalized_os_version` — Version of the operating system on which the crash occurred (e.g. '10.0' for Windows 10, '6.1' for Windows 7) (sampled 2026-06-02).
- `sample_id` — A number, 0-99, that samples by client_id to allow filtering data for analysis; always 17 in this table as it is a sample partition (sampled 2026-06-02).
- `submission_timestamp` — Timestamp when the crash ping is received on the server side.
- `country` — ISO 3166-1 alpha-2 country code for the client's location as determined by IP geolocation (e.g. 'US', 'DE', 'CN') (sampled 2026-06-02).
- `dau` — The number of daily active users, corresponding to the count of clients that reported at least one qualifying ping on the submission date.
- `distribution_id` — The distribution id associated with the install of Firefox (e.g. 'mozilla-win-eol-esr115', 'MozillaOnline'). Null for ~75.6% of rows representing direct or unattributed installs (sampled 2026-06-02).
- `mau` — The number of monthly active users, corresponding to the count of clients that reported at least one ping in the previous 28 days from the submission date.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `wau` — The number of weekly active users, corresponding to the count of clients that reported at least one ping in the previous 7 days from the submission date.
- `activity_segment` — Classification of the client's browsing activity level during the reporting period. Values include 'infrequent_user', 'casual_user', 'regular_user', 'core_user', and 'other'.
- `channel` — The release channel through which Firefox is distributed to users (e.g. 'release', 'esr', 'beta', 'nightly', 'aurora').
- `country` — ISO 3166-1 alpha-2 country code of the client, as determined by IP geolocation at ping ingestion.
- `distribution_id` — The distribution identifier associated with the Firefox install, identifying the partner or distribution channel (e.g. 'canonical-002', 'mozilla-win-eol-esr115'). NULL for standard Mozilla builds.
- `os` — The normalized name of the operating system running at the client (e.g. 'Windows', 'Mac', 'Linux').
- `submission_date` — The date when the telemetry ping is received on the server side.
- `activity_segment` — Classification of users based on their browsing activity. E.g., infrequent, casual, regular.
- `campaign` — The attribution campaign (UTM campaign) for the Firefox installation; null when the client is not attributed (sampled 2026-06-02).
- `channel` — The normalized channel the application is being distributed on.
- `content` — The attribution content (UTM content) for the Firefox installation; null when the client is not attributed (sampled 2026-06-02).
- `country` — Name of the country in which the activity took place, as determined by the IP geolocation.
- `dau` — The number of daily active users, corresponding to the count of clients that reported at least one ping on the submission_date and qualify as active. Null for dimension slices with no activity on that day (sampled 2026-06-02).
- `distribution_id` — The distribution id associated with the install of Firefox.
- `mau` — The number of monthly active users, corresponding to the count of clients that reported at least one ping in the previous 28 days and qualify as active. Null for dimension slices with no activity in the window (sampled 2026-06-02).
- `medium` — The attribution medium (UTM medium) for the Firefox installation; null when the client is not attributed (sampled 2026-06-02).
- `os` — The normalized name of the operating system running at the client. Observed values include Windows, Mac, Linux, and Other (sampled 2026-06-02).
- `source` — The attribution source (UTM source) for the Firefox installation; null when the client is not attributed (sampled 2026-06-02).
- `submission_date` — The date when the telemetry ping is received on the server side.
- `wau` — The number of weekly active users, corresponding to the count of clients that reported at least one ping in the previous 7 days and qualify as active. Null for dimension slices with no activity in the window (sampled 2026-06-02).
- `app_build_id` — The build ID of the application (a date-time stamp string identifying the specific build, e.g. 20231001120000).
- `app_display_version` — The user-visible version string of the Firefox application as displayed in the UI (e.g. 118.0.2).
- `app_name` — The name of the browser application (e.g. Firefox).
- `app_version` — The version string of the Firefox application (e.g. 118.0).
- `attribution_experiment` — The attribution experiment key associated with the Firefox installation, used to track A/B tests or experiments that influenced the install.
- `attribution_variation` — The attribution variation key associated with the Firefox installation, identifying the specific variant within an attribution experiment.
- `channel` — The release channel of the application as reported by the client (e.g. release, beta, nightly).
- `client_id` — A unique identifier (UUID) for the client.
- `country` — Name of the country in which the activity took place, as determined by IP geolocation.
- `distribution_id` — The distribution ID associated with the Firefox install, identifying the partner or channel through which Firefox was distributed.
- `document_id` — The document ID specified in the URI when the client sent this message.
- `fxa_configured` — Boolean indicating whether a Firefox Accounts (FxA) account was configured (signed in) on this client during this session.
- `is_default_browser` — True if Firefox is configured as the default browser on the client's operating system; false otherwise.
- `locale` — The locale of the Firefox application interface (e.g. en-US, fr, de), reflecting the user's language preference.
- `normalized_channel` — The normalized channel the application is being distributed on.
- `normalized_os_version` — The operating system version normalized to a consistent format at ingestion (e.g. "10.0" for Windows, "25.3.0" for macOS). Windows 10 and Windows 11 both show "10.0"; use windows_build_number >= 22000 to identify Windows 11.
- `os` — The name of the operating system running on the client (e.g. Windows_NT, Darwin, Linux).
- `os_version` — The operating system version running at the client prior to normalization (e.g. "10.0" for Windows, "25.3.0" for macOS).
- `sample_id` — A number, 0–99, that samples by client_id and allows filtering data for analysis. It is a pipeline-generated artifact that should match between pings.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `channel` — The normalized release channel of the Firefox build (e.g. 'release', 'beta', 'nightly').
- `submission_date` — The date when the telemetry ping is received on the server side.
- `channel` — The Firefox release channel (e.g., 'release', 'beta', 'nightly') for which the probe count data was extracted.
- `os` — The normalized operating system name for which this probe count row applies.
- `version` — The Firefox major version number for which this probe count row applies.
- `app_build_id` — The build identifier of the Firefox Beta application in YYYYMMDDHHMMSS format; '*' represents an aggregation across all build IDs.
- `app_version` — The major version number of the Firefox Beta application (e.g. 146, 147, 148).
- `os` — The operating system of the client (e.g. 'Windows', 'Mac', 'Linux'); '*' represents an aggregation across all operating systems.
- `app_build_id` — The build identifier of the Firefox Nightly application in YYYYMMDDHHMMSS format; '*' represents an aggregation across all build IDs.
- `app_version` — The major version number of the Firefox Nightly application (e.g. 147, 148, 149).
- `os` — The operating system of the client (e.g. 'Windows', 'Mac', 'Linux'); '*' represents an aggregation across all operating systems.
- `app_build_id` — The build identifier of the Firefox Release application in YYYYMMDDHHMMSS format; '*' represents an aggregation across all build IDs.
- `app_version` — The major version number of the Firefox Release application (e.g. 145, 146, 147).
- `os` — The operating system of the client (e.g. 'Windows', 'Mac', 'Linux'); '*' represents an aggregation across all operating systems.
- `app_build_id` — The build identifier of the Firefox application in YYYYMMDDHHMMSS format; '*' represents an aggregation across all build IDs.
- `app_version` — The major version number of the Firefox application.
- `os` — The operating system of the client (e.g. 'Windows', 'Mac', 'Linux'); '*' represents an aggregation across all operating systems.
- `app_build_id` — The build identifier of the Firefox application in YYYYMMDDHHMMSS format; '*' represents an aggregation across all build IDs.
- `app_version` — The major version number of the Firefox application; 999 is used as a sentinel for cross-version rollups.
- `channel` — The normalized Firefox release channel (e.g. 'release', 'beta', 'nightly').
- `os` — The operating system of the client (e.g. 'Windows', 'Mac', 'Linux', 'Other'); '*' represents an aggregation across all operating systems. NULL when this rollup dimension is not applicable.
- `app_build_id` — The build identifier of the Firefox application in YYYYMMDDHHMMSS format; '*' represents an aggregation across all build IDs.
- `app_version` — The major version number of the Firefox application; 999 is a sentinel for cross-version rollups. NULL for approximately 41% of rows where version information is not available.
- `os` — The operating system of the client (e.g. 'Windows', 'Mac', 'Linux', 'Other'); '*' represents an aggregation across all operating systems.
- `app_build_id` — The build identifier of the Firefox application in YYYYMMDDHHMMSS format; NULL (approximately 4% of rows) represents an aggregation across all build IDs.
- `app_version` — The major version number of the Firefox application; 999 is a sentinel for cross-version rollups. NULL for approximately 41% of rows where version information is not available.
- `channel` — The normalized Firefox release channel (e.g. 'nightly', 'release', 'beta'); NULL for approximately 0.6% of rows where the channel cannot be determined.
- `os` — The operating system of the client (e.g. 'Windows', 'Mac', 'Linux', 'Other'); NULL (approximately 18% of rows) represents an aggregation across all operating systems that maps to '*' in the extract table.
- `channel` — The normalized release channel of the Firefox build on the client (e.g. 'release', 'beta', 'nightly').
- `os` — The normalized name of the operating system running at the client (e.g. 'Windows', 'Mac', 'Linux').
- `submission_date` — The date when the telemetry ping is received on the server side.
- `app_build_id` — The build identifier of the Firefox application (YYYYMMDDHHMMSS format). Null when data is aggregated across all builds for the version.
- `channel` — The Firefox release channel, e.g. 'nightly', 'beta', or 'release'. Used to segment GLAM histogram percentile data by distribution channel.
- `os` — The operating system of the clients contributing to this row. One of 'Windows', 'Mac', 'Linux', 'Other', or null when aggregated across all OS values (sampled 2026-06-02).
- `submission_date` — The date for which the metric value (observed or forecast) applies.
- `channel` — The Firefox release channel. One of 'release', 'beta', or 'nightly', representing the three primary distribution channels tracked in this table.
- `channel` — The Firefox release channel. One of 'release', 'beta', 'nightly', or 'esr', representing the four distribution channels tracked from the Mozilla product-details API.
- `submission_date` — The date to which this forecast cache entry applies.
- `channel` — The Firefox release channel (e.g., 'release', 'beta', 'nightly', 'esr') for the clients in this cohort.
- `country` — Two-letter ISO 3166-1 alpha-2 country code of the client's location, as determined by IP geolocation.
- `is_default_browser` — True if Firefox is set as the operating system's default browser on the client; false otherwise.
- `locale` — The browser locale (e.g., 'en-US', 'fr', 'de') of the clients in this cohort.
- `normalized_os` — The normalized name of the operating system (e.g., 'Windows', 'Mac', 'Linux') running on the client.
- `additional_properties` — A JSON string containing any payload properties present in the raw ping that are not represented as explicit columns in the schema.
- `client_id` — A UUID uniquely identifying the Firefox client.
- `document_id` — The document ID specified in the URI when the client sent this ping, used for deduplication.
- `normalized_app_name` — The normalized application name; set to 'Other' if the app name was not recognized during ingestion.
- `normalized_channel` — The normalized release channel; set to 'Other' if the channel was not recognized during ingestion.
- `normalized_country_code` — An ISO 3166-1 alpha-2 country code derived from IP geolocation at ingestion time.
- `normalized_os` — The normalized operating system name; set to 'Other' if the OS was not recognized during ingestion.
- `normalized_os_version` — The operating system version normalized to a consistent format at ingestion.
- `profile_group_id` — A UUID uniquely identifying the profile group on a single device, enabling user-oriented correlation of data across profiles.
- `sample_id` — A stable hash of client_id modulo 100 (0–99) used to partition data; this table contains only rows where sample_id = 0 (a 1% sample).
- `submission_timestamp` — Timestamp when the ingestion edge server accepted this ping.
- `app_name` — The name of the browser application (e.g., 'Firefox').
- `is_default_browser` — True if Firefox is set as the operating system's default browser; false otherwise.
- `os_version` — The operating system version string reported by the client (e.g., '10.0' for Windows, '5.1' for Windows XP).
- `additional_properties` — A JSON string containing any payload properties present in the raw ping that are not represented as explicit columns in the schema.
- `client_id` — A UUID uniquely identifying the Firefox client.
- `document_id` — The document ID specified in the URI when the client sent this ping, used for deduplication.
- `normalized_app_name` — The normalized application name; set to 'Other' if the app name was not recognized during ingestion.
- `normalized_channel` — The normalized release channel; filtered to 'nightly' for all rows in this table.
- `normalized_country_code` — An ISO 3166-1 alpha-2 country code derived from IP geolocation at ingestion time.
- `normalized_os` — The normalized operating system name; set to 'Other' if the OS was not recognized during ingestion.
- `normalized_os_version` — The operating system version normalized to a consistent format at ingestion.
- `profile_group_id` — A UUID uniquely identifying the profile group on a single device, enabling user-oriented correlation of data across profiles.
- `sample_id` — A stable hash of client_id modulo 100 (0–99), used to partition data for analysis.
- `submission_timestamp` — Timestamp when the ingestion edge server accepted this ping.
- `additional_properties` — A JSON string containing any payload properties present in the raw ping that are not represented as explicit columns in the schema.
- `client_id` — A UUID uniquely identifying the Firefox client.
- `document_id` — The document ID specified in the URI when the client sent this ping, used for deduplication.
- `normalized_app_name` — The normalized application name; set to 'Other' if the app name was not recognized during ingestion.
- `normalized_channel` — The normalized release channel; set to 'Other' if the channel was not recognized during ingestion.
- `normalized_country_code` — An ISO 3166-1 alpha-2 country code derived from IP geolocation at ingestion time.
- `normalized_os` — The normalized operating system name; set to 'Other' if the OS was not recognized during ingestion.
- `normalized_os_version` — The operating system version normalized to a consistent format at ingestion.
- `profile_group_id` — A UUID uniquely identifying the profile group on a single device, enabling user-oriented correlation of data across profiles.
- `sample_id` — A stable hash of client_id modulo 100 (0–99) used to partition data; this table contains only rows where sample_id = 0 (a 1% sample).
- `submission_timestamp` — Timestamp when the ingestion edge server accepted this ping.
- `additional_properties` — A JSON string containing any payload properties present in the raw ping that are not represented as explicit columns in the schema.
- `client_id` — A UUID uniquely identifying the Firefox client.
- `document_id` — The document ID specified in the URI when the client sent this ping, used for deduplication.
- `normalized_app_name` — The normalized application name; set to 'Other' if the app name was not recognized during ingestion.
- `normalized_channel` — The normalized release channel; set to 'Other' if the channel was not recognized during ingestion.
- `normalized_country_code` — An ISO 3166-1 alpha-2 country code derived from IP geolocation at ingestion time.
- `normalized_os` — The normalized operating system name; set to 'Other' if the OS was not recognized during ingestion.
- `normalized_os_version` — The operating system version normalized to a consistent format at ingestion.
- `sample_id` — A stable hash of client_id modulo 100 (0–99) used to partition data; this table contains only rows where sample_id = 0 (a 1% sample).
- `submission_timestamp` — Timestamp when the ingestion edge server accepted this ping.
- `normalized_os_version` — The user-visible version of the operating system (e.g. '10.0' for Windows 10, '6.8' for Linux kernel 6.8). Derived from the Glean os_version metric.
- `activity_segment` — Classification of users based on their browsing activity. E.g., infrequent, casual, regular.
- `channel` — The normalized channel the application is being distributed on (e.g. 'release', 'esr', 'beta', 'nightly').
- `country_code` — Code of the country in which the activity took place, as determined by the IP geolocation. Unknown or NULL values are normally stored as '??'.
- `os` — The name of the operating system for clients in this aggregate row (e.g. 'Windows', 'Mac', 'Linux').
- `os_version` — The user-visible version of the operating system for clients in this aggregate row (e.g. '10.0' for Windows 10).
- `submission_date` — The date when the telemetry ping is received on the server side.
- `activity_segment` — Classification of users based on their browsing activity. E.g., infrequent, casual, regular.
- `channel` — The normalized channel the application is being distributed on.
- `country_code` — Code of the country in which the activity took place, as determined by the IP geolocation. Unknown or NULL values are normally stored as '??'.
- `os` — The name of the operating system running on the client for this visit (e.g. 'Windows', 'Mac', 'Linux').
- `os_version` — The user-visible version of the operating system (e.g. '10.0' for Windows 10, '25.5.0' for Android). Derived from the Glean os_version metric.
- `activity_segment` — Classification of users based on their browsing activity. E.g., infrequent, casual, regular.
- `normalized_os_version` — The user-visible version of the operating system (e.g. '10.0' for Windows 10). Derived from the Glean os_version metric.
- `mau` — Monthly Active Users — count of unique Firefox Desktop clients active within the past 28 days.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `mau` — Monthly Active Users — count of unique Firefox Desktop clients active within the past 28 days.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `app_build_id` — The build ID of the Firefox application (e.g., '20240509170740'). Null for rows aggregated across all builds.
- `app_version` — The major Firefox version number of the clients contributing to this row.
- `channel` — The normalized Firefox release channel (e.g., 'release', 'nightly', 'beta').
- `os` — The normalized operating system for the aggregated clients. Null for rows that aggregate across all OS values.
- `adjust_network` — The name of the Adjust Network that sourced the installation. Populated only for mobile clients (~14% non-null).
- `app_name` — The name of the browser application (e.g., 'Firefox Desktop', 'Fenix', 'Firefox iOS').
- `attribution_medium` — The attribution medium (similar to UTM medium) associated with the client's install. Null for ~28% of rows.
- `attribution_source` — The attribution source (similar to UTM source) associated with the client's install. Null for ~28% of rows.
- `dau` — The number of daily active users for the dimension combination on the submission_date.
- `country` — Code of the country in which the activity took place, as determined by IP geolocation. The compressed variant retains only the top ~15 countries.
- `os` — The normalized name of the operating system (compressed to top values: 'Windows_NT', 'Darwin', 'Linux', 'Other').
- `app_name` — The name of the browser application. For this desktop-specific table always 'Firefox'.
- `os_version` — The version string of the operating system (e.g., '10.0' for Windows 10, '24.6.0' for macOS).
- `app_name` — The name of the application. Null for this FxA table (not application-specific).
- `app_version` — The Firefox Account backend version string.
- `channel` — The normalized release channel. Null for Firefox Account activity (not channel-specific).
- `country` — Code of the country in which the activity took place, as determined by IP geolocation.
- `locale` — Set of language- and/or country-based preferences for the Firefox Account user interface.
- `os` — The normalized name of the operating system (e.g., 'Android', 'Windows', 'Mac OS X', 'Linux', 'iOS').
- `os_version` — The version string of the operating system (e.g., '10' for Windows 10, '16' for Android 16).
- `submission_date` — The date when the telemetry ping is received on the server side.
- `app_name` — The name of the browser application (e.g., 'Firefox', 'Fenix', 'Firefox iOS').
- `os_version` — The version string of the operating system (e.g., '10.0' for Windows 10).
- `channel` — The normalized release channel (e.g., 'release', 'beta', 'nightly').
- `country` — Code of the country in which the activity took place, as determined by IP geolocation. The compressed variant retains only the top ~15 countries.
- `locale` — Set of language- and/or country-based preferences for the user interface (compressed to top values).
- `os` — The normalized name of the operating system. For this non-desktop table always 'Other'.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `app_name` — The name of the non-desktop browser application (e.g., 'Fenix', 'Firefox iOS', 'Firefox Non-desktop').
- `app_version` — User visible version string for the non-desktop browser.
- `channel` — The normalized release channel (e.g., 'release', 'beta', 'nightly').
- `country` — Code of the country in which the activity took place, as determined by IP geolocation.
- `locale` — Set of language- and/or country-based preferences for the user interface.
- `os` — The normalized name of the operating system (e.g., 'Android', 'iOS').
- `os_version` — The version string of the operating system (e.g., '16', '13').
- `submission_date` — The date when the telemetry ping is received on the server side.
- `build_id` — The build identifier of the product that crashed (e.g., '20260520211922').
- `normalized_os_version` — The normalized version string of the operating system (e.g., '10.0' for Windows 10).
- `app_build_id` — The build ID of the Firefox application (e.g., '20191202093317').
- `app_version` — The major Firefox version number for this row (e.g., 72, 73).
- `channel` — The normalized Firefox release channel (e.g., 'release', 'beta', 'nightly').
- `client_id` — A unique identifier (UUID) for the client.
- `os` — The normalized name of the operating system running at the client (e.g., 'Windows', 'Mac', 'Linux').
- `sample_id` — A number, 0-99, that samples by client_id and allows filtering data for analysis. It is a pipeline-generated artifact that should match between pings.
- `fields.client_id` — A unique identifier (UUID) for the client, nested inside the fields struct.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `client_id` — A unique identifier (UUID) for the client.
- `submission_timestamp` — Timestamp when the ping is received on the server side.
- `submission_date` — The date when the telemetry ping is received on the server side.
- `attribution_campaign` — The marketing campaign identifier that led to the Firefox install, e.g. 'SET_DEFAULT_BROWSER', 'non-fx-button'. Desktop only; null for mobile (sampled 2026-06-02).
- `attribution_content` — The attribution content parameter from the Firefox installer, identifying the specific link or creative within a campaign that led to the download. Desktop only; null for mobile (sampled 2026-06-02).
- `attribution_experiment` — A funnel experiment parameter from the Firefox installer attribution, used to track download-funnel experiments. Desktop only; null for mobile (sampled 2026-06-02).
- `attribution_medium` — The marketing medium that drove the Firefox install, e.g. 'referral', 'paidsearch', 'email'. Desktop only; null for mobile (sampled 2026-06-02).
- `attribution_source` — The referring partner domain or source that directed the user to download Firefox, e.g. 'www.google.com', 'www.bing.com'. Desktop only; null for mobile (sampled 2026-06-02).
- `attribution_variation` — The variation arm of the installer funnel experiment, e.g. 'treatment' or 'control'. Desktop only; null for mobile (sampled 2026-06-02).
- `city` — The city associated with the client's IP address as determined by IP geolocation. Null or '??' when city cannot be determined (sampled 2026-06-02).
- `normalized_os_version` — The normalized version string of the operating system running on the client, e.g. '10.0', '6.1', '16'. Derived from the telemetry environment.
- `os_version_patch` — The patch (third) component of the OS version string. For example, for '100.9.11', the patch is 11. Defaults to 0 when not present or parseable.
- `app_version` — User visible version string (e.g. '151.0.1') for the Firefox Desktop browser on the submission date.
- `client_id` — A unique identifier (UUID) for the client.
- `country` — An ISO 3166-1 alpha-2 country code identifying the country of the client based on IP geolocation. Defaults to '??' when unknown.
- `experiments` — An array of key-value pairs listing the Nimbus experiments and rollouts the client was enrolled in on the submission date, where key is the experiment slug and value is the branch name (e.g. 'control', 'treatment-a').
- `locale` — Set of language- and/or country-based preferences for the browser user interface, e.g. 'en-US', 'de', 'fr'.
- `normalized_channel` — The normalized channel the application is being distributed on, e.g. 'release', 'esr', 'beta', 'nightly'.

### Contradictions Found

_None_

### Skipped

- 0 fields excluded (undocumented tier — out of scope)
- 0 empty or undeployed tables
- 0 fields already described (unchanged)

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Global.yaml candidates verified as truly cross-dataset
- [ ] Contradictions investigated before merging
