### PR TITLE
chore(schema): add field descriptions for telemetry_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/active_users_aggregates_v1/schema.yaml
@@ -108,6 +108,7 @@ fields:
 - mode: NULLABLE
   name: first_seen_year
   type: INTEGER
+  description: The calendar year in which the client's profile was first seen by Mozilla's telemetry pipeline.
 - mode: NULLABLE
   name: attributed
   type: BOOLEAN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -1159,6 +1159,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_browser_ui_interaction_preferences_pane_home_sum
   type: RECORD
+  description: Keyed count of user interactions in the Firefox Preferences Home panel, keyed by the specific UI element interacted with.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1169,6 +1170,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_sum
   type: RECORD
+  description: Keyed count of URL bar autofill result selections, keyed by the autofill source (e.g., 'origin', 'url', 'adaptive').
 - fields:
   - mode: NULLABLE
     name: key
@@ -1179,6 +1181,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_about_sum
   type: RECORD
+  description: Keyed count of URL bar selections of autofill suggestions for about; pages, keyed by the specific page.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1189,6 +1192,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_adaptive_sum
   type: RECORD
+  description: Keyed count of URL bar selections of adaptive autofill suggestions (learned from the user's history), keyed by source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1199,6 +1203,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_origin_sum
   type: RECORD
+  description: Keyed count of URL bar selections of origin-based autofill suggestions, keyed by the domain origin.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1209,6 +1214,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_other_sum
   type: RECORD
+  description: Keyed count of URL bar selections of autofill suggestions of type 'other', keyed by source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1219,6 +1225,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_preloaded_sum
   type: RECORD
+  description: Keyed count of URL bar selections of autofill suggestions from the preloaded top sites list, keyed by site.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1229,6 +1236,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_url_sum
   type: RECORD
+  description: Keyed count of URL bar selections of full-URL autofill suggestions, keyed by source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1239,6 +1247,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_bookmark_sum
   type: RECORD
+  description: Keyed count of URL bar result selections of bookmarks, keyed by the search entry point (e.g., 'urlbar', 'searchbar').
 - fields:
   - mode: NULLABLE
     name: key
@@ -1249,6 +1258,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_dynamic_sum
   type: RECORD
+  description: Keyed count of URL bar selections of dynamic result types, keyed by result type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1259,6 +1269,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_extension_sum
   type: RECORD
+  description: Keyed count of URL bar result selections provided by a browser extension, keyed by extension ID.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1269,6 +1280,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_formhistory_sum
   type: RECORD
+  description: Keyed count of URL bar selections of form history suggestions, keyed by field name.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1279,6 +1291,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_history_sum
   type: RECORD
+  description: Keyed count of URL bar selections of browsing history results, keyed by the entry point.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1289,6 +1302,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_keyword_sum
   type: RECORD
+  description: Keyed count of URL bar selections of keyword (search engine shortcut) results, keyed by keyword.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1299,6 +1313,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_remotetab_sum
   type: RECORD
+  description: Keyed count of URL bar selections of remote tabs (tabs from synced devices), keyed by device type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1309,6 +1324,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_searchengine_sum
   type: RECORD
+  description: Keyed count of URL bar selections that launched a search via a specific engine, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1319,6 +1335,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_searchsuggestion_sum
   type: RECORD
+  description: Keyed count of URL bar selections of search suggestions, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -1346,6 +1346,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_switchtab_sum
   type: RECORD
+  description: Keyed count of URL bar selections that switched to an already-open tab, keyed by entry point.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1356,6 +1357,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_tabtosearch_sum
   type: RECORD
+  description: Keyed count of URL bar result selections for tab-to-search (engine from site), keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1366,6 +1368,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_tip_sum
   type: RECORD
+  description: Keyed count of URL bar selections of tip results (e.g., redirect tips), keyed by tip type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1376,6 +1379,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_topsite_sum
   type: RECORD
+  description: Keyed count of URL bar selections of Top Sites results, keyed by site identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1386,6 +1390,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_unknown_sum
   type: RECORD
+  description: Keyed count of URL bar selections of result types that could not be categorized, keyed by source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1396,6 +1401,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_visiturl_sum
   type: RECORD
+  description: Keyed count of URL bar selections where the user navigated directly to a typed URL, keyed by entry point.
 - mode: NULLABLE
   name: default_private_search_engine
   type: STRING
@@ -1443,6 +1449,7 @@ fields:
   mode: REPEATED
   name: search_with_ads
   type: RECORD
+  description: Keyed count of search result page impressions that contained ads, keyed by search engine and access point (e.g., 'google-b-d:urlbar').
 - fields:
   - mode: NULLABLE
     name: key
@@ -1453,6 +1460,7 @@ fields:
   mode: REPEATED
   name: ad_clicks
   type: RECORD
+  description: Keyed count of ad clicks on search result pages, keyed by search engine and access point (e.g., 'google-b-d:urlbar').
 - fields:
   - mode: NULLABLE
     name: key
@@ -1463,6 +1471,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_sum
   type: RECORD
+  description: Keyed count of searches initiated from the URL bar, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1473,6 +1482,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of searches initiated via URL bar handoff from the new tab page, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1483,6 +1493,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of searches where the URL bar retained the search term after submission, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1493,6 +1504,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of searches performed while the URL bar was in search mode, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1906,6 +1918,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sum
   type: RECORD
+  description: Keyed count of Firefox Suggest (Quicksuggest) result clicks, keyed by suggestion type and source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1916,6 +1929,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sum
   type: RECORD
+  description: Keyed count of Firefox Suggest result impressions (times a result was shown), keyed by suggestion type and source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1926,6 +1940,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sum
   type: RECORD
+  description: Keyed count of times the 'Learn More' help link was clicked on a Firefox Suggest result, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1936,6 +1951,7 @@ fields:
   mode: REPEATED
   name: contextual_services_topsites_click_sum
   type: RECORD
+  description: Keyed count of Top Sites tile clicks in the Firefox new tab page, keyed by tile source and position.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1946,6 +1962,7 @@ fields:
   mode: REPEATED
   name: contextual_services_topsites_impression_sum
   type: RECORD
+  description: Keyed count of Top Sites tile impressions in the Firefox new tab page, keyed by tile source and position.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_quicksuggest_nonsponsored
   type: STRING
@@ -1972,6 +1989,7 @@ fields:
   mode: REPEATED
   name: a11y_theme
   type: RECORD
+  description: Keyed boolean indicators of Windows accessibility theme settings active for this client, keyed by theme attribute name.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1982,6 +2000,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of help link clicks on non-sponsored Best Match Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1992,6 +2011,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of help link clicks on sponsored Best Match Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2002,6 +2022,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_nonsponsored_sum
   type: RECORD
+  description: Keyed count of times a non-sponsored Firefox Suggest result was dismissed/blocked, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2012,6 +2033,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_sponsored_sum
   type: RECORD
+  description: Keyed count of times a sponsored Firefox Suggest result was dismissed/blocked, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2022,6 +2044,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of times a sponsored Best Match Firefox Suggest result was blocked, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2032,6 +2055,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of times a non-sponsored Best Match Firefox Suggest result was blocked, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2042,6 +2066,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of clicks on sponsored Best Match Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2052,6 +2077,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of clicks on non-sponsored Best Match Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2062,6 +2088,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of impressions of sponsored Best Match Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2072,6 +2099,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of impressions of non-sponsored Best Match Firefox Suggest results, keyed by suggestion type.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_bestmatch
   type: STRING
@@ -2098,6 +2126,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_browser_ui_interaction_content_context_sum
   type: RECORD
+  description: Keyed count of user interactions with the browser content area context menu, keyed by the menu item action.
 - mode: NULLABLE
   name: text_recognition_api_performance_sum
   type: INTEGER
@@ -2236,6 +2265,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of times a dynamic Wikipedia Firefox Suggest result was blocked, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2246,6 +2276,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_weather_sum
   type: RECORD
+  description: Keyed count of times a weather Firefox Suggest result was blocked, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2256,6 +2287,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of clicks on dynamic Wikipedia Firefox Suggest results, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2266,6 +2298,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_nonsponsored_sum
   type: RECORD
+  description: Keyed count of clicks on non-sponsored Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2276,6 +2309,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sponsored_sum
   type: RECORD
+  description: Keyed count of clicks on sponsored Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2286,6 +2320,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_weather_sum
   type: RECORD
+  description: Keyed count of clicks on weather Firefox Suggest results, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2296,6 +2331,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of help link clicks on dynamic Wikipedia Firefox Suggest results, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2306,6 +2342,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_nonsponsored_sum
   type: RECORD
+  description: Keyed count of help link clicks on non-sponsored Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2316,6 +2353,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sponsored_sum
   type: RECORD
+  description: Keyed count of help link clicks on sponsored Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2326,6 +2364,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_weather_sum
   type: RECORD
+  description: Keyed count of help link clicks on weather Firefox Suggest results, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2336,6 +2375,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of impressions of dynamic Wikipedia Firefox Suggest results, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2346,6 +2386,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_nonsponsored_sum
   type: RECORD
+  description: Keyed count of impressions of non-sponsored Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2356,6 +2397,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sponsored_sum
   type: RECORD
+  description: Keyed count of impressions of sponsored Firefox Suggest results, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2366,6 +2408,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_weather_sum
   type: RECORD
+  description: Keyed count of impressions of weather Firefox Suggest results, keyed by suggestion source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2376,6 +2419,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_opened_sum
   type: RECORD
+  description: Keyed count of times Firefox Sidebar panels were opened, keyed by sidebar panel name (e.g., 'bookmarks', 'history').
 - fields:
   - mode: NULLABLE
     name: key
@@ -2386,6 +2430,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_search_sum
   type: RECORD
+  description: Keyed count of searches performed within Firefox Sidebar panels, keyed by panel name.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2396,6 +2441,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_link_sum
   type: RECORD
+  description: Keyed count of link activations within Firefox Sidebar panels, keyed by panel name.
 - name: places_previousday_visits_mean
   type: FLOAT
   mode: NULLABLE
@@ -2416,6 +2462,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of link activations within the Firefox Library panel, keyed by section (e.g., 'bookmarks', 'history').
   - name: key
     type: STRING
     mode: NULLABLE
@@ -2426,6 +2473,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of times the Firefox Library panel was opened, keyed by entry point (e.g., 'toolbar', 'menu').
   - name: key
     type: STRING
     mode: NULLABLE
@@ -2436,6 +2484,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of searches performed within the Firefox Library panel, keyed by section.
   - name: key
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_joined_v1/schema.yaml
@@ -1515,6 +1515,7 @@ fields:
   mode: REPEATED
   name: search_content_contextmenu_sum
   type: RECORD
+  description: Keyed count of searches initiated via the right-click context menu, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1525,6 +1526,7 @@ fields:
   mode: REPEATED
   name: search_content_about_home_sum
   type: RECORD
+  description: Keyed count of searches from the about:home new tab page, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1535,6 +1537,7 @@ fields:
   mode: REPEATED
   name: search_content_about_newtab_sum
   type: RECORD
+  description: Keyed count of searches from the new tab page, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1545,6 +1548,7 @@ fields:
   mode: REPEATED
   name: search_content_searchbar_sum
   type: RECORD
+  description: Keyed count of searches from the dedicated search bar, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1555,6 +1559,7 @@ fields:
   mode: REPEATED
   name: search_content_system_sum
   type: RECORD
+  description: Keyed count of system-initiated searches (OS-level integration), keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1565,6 +1570,7 @@ fields:
   mode: REPEATED
   name: search_content_webextension_sum
   type: RECORD
+  description: Keyed count of searches initiated via a browser extension, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1575,6 +1581,7 @@ fields:
   mode: REPEATED
   name: search_content_tabhistory_sum
   type: RECORD
+  description: Keyed count of searches initiated via browser tab history navigation, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1585,6 +1592,7 @@ fields:
   mode: REPEATED
   name: search_content_reload_sum
   type: RECORD
+  description: Keyed count of searches triggered by a page reload action, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1595,6 +1603,7 @@ fields:
   mode: REPEATED
   name: search_content_unknown_sum
   type: RECORD
+  description: Keyed count of searches from unclassified entry points, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1605,6 +1614,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from URL bar searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1615,6 +1625,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from URL bar handoff searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1625,6 +1636,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of search result pages with ads where the URL bar retained the search term, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1635,6 +1647,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from URL bar search-mode searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1645,6 +1658,7 @@ fields:
   mode: REPEATED
   name: search_withads_contextmenu_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from context menu searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1655,6 +1669,7 @@ fields:
   mode: REPEATED
   name: search_withads_about_home_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from about:home searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1665,6 +1680,7 @@ fields:
   mode: REPEATED
   name: search_withads_about_newtab_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from new tab page searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1675,6 +1691,7 @@ fields:
   mode: REPEATED
   name: search_withads_searchbar_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from the search bar, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1685,6 +1702,7 @@ fields:
   mode: REPEATED
   name: search_withads_system_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from system-initiated searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1695,6 +1713,7 @@ fields:
   mode: REPEATED
   name: search_withads_webextension_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from extension-initiated searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1705,6 +1724,7 @@ fields:
   mode: REPEATED
   name: search_withads_tabhistory_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from tab history navigation, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1715,6 +1735,7 @@ fields:
   mode: REPEATED
   name: search_withads_reload_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from page reload, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1725,6 +1746,7 @@ fields:
   mode: REPEATED
   name: search_withads_unknown_sum
   type: RECORD
+  description: Keyed count of search result pages with ads from unclassified entry points, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1735,6 +1757,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_sum
   type: RECORD
+  description: Keyed count of ad clicks on search result pages from URL bar searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1745,6 +1768,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of ad clicks on search result pages from URL bar handoff searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1755,6 +1779,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of ad clicks on search result pages where the URL bar retained the search term, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1765,6 +1790,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of ad clicks on search result pages from URL bar search-mode searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1775,6 +1801,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_contextmenu_sum
   type: RECORD
+  description: Keyed count of ad clicks from context menu searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1785,6 +1812,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_about_home_sum
   type: RECORD
+  description: Keyed count of ad clicks from about:home searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1795,6 +1823,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_about_newtab_sum
   type: RECORD
+  description: Keyed count of ad clicks from new tab page searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1805,6 +1834,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_searchbar_sum
   type: RECORD
+  description: Keyed count of ad clicks from the search bar, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1815,6 +1845,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_system_sum
   type: RECORD
+  description: Keyed count of ad clicks from system-initiated searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1825,6 +1856,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_webextension_sum
   type: RECORD
+  description: Keyed count of ad clicks from extension-initiated searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1835,6 +1867,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_tabhistory_sum
   type: RECORD
+  description: Keyed count of ad clicks from tab history navigation searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1845,6 +1878,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_reload_sum
   type: RECORD
+  description: Keyed count of ad clicks from page reload searches, keyed by search engine identifier.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1855,6 +1889,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_unknown_sum
   type: RECORD
+  description: Keyed count of ad clicks from unclassified search entry points, keyed by search engine identifier.
 - mode: NULLABLE
   name: update_background
   type: BOOLEAN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -1654,6 +1654,7 @@ fields:
   mode: REPEATED
   name: search_withads_contextmenu_sum
   type: RECORD
+  description: Keyed count of context menu search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1664,6 +1665,7 @@ fields:
   mode: REPEATED
   name: search_withads_about_home_sum
   type: RECORD
+  description: Keyed count of about:home search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1674,6 +1676,7 @@ fields:
   mode: REPEATED
   name: search_withads_about_newtab_sum
   type: RECORD
+  description: Keyed count of new tab page search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1684,6 +1687,7 @@ fields:
   mode: REPEATED
   name: search_withads_searchbar_sum
   type: RECORD
+  description: Keyed count of search bar search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1694,6 +1698,7 @@ fields:
   mode: REPEATED
   name: search_withads_system_sum
   type: RECORD
+  description: Keyed count of system-initiated search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1704,6 +1709,7 @@ fields:
   mode: REPEATED
   name: search_withads_webextension_sum
   type: RECORD
+  description: Keyed count of extension-initiated search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1714,6 +1720,7 @@ fields:
   mode: REPEATED
   name: search_withads_tabhistory_sum
   type: RECORD
+  description: Keyed count of tab history search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1724,6 +1731,7 @@ fields:
   mode: REPEATED
   name: search_withads_reload_sum
   type: RECORD
+  description: Keyed count of reload-triggered search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1734,6 +1742,7 @@ fields:
   mode: REPEATED
   name: search_withads_unknown_sum
   type: RECORD
+  description: Keyed count of unclassified-entry-point search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1744,6 +1753,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_sum
   type: RECORD
+  description: Keyed count of ad clicks from URL bar searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1754,6 +1764,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of ad clicks from new-tab handoff searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1764,6 +1775,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of ad clicks from persisted-URL-bar searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1774,6 +1786,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of ad clicks from URL bar search-mode searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1784,6 +1797,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_contextmenu_sum
   type: RECORD
+  description: Keyed count of ad clicks from context menu searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1794,6 +1808,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_about_home_sum
   type: RECORD
+  description: Keyed count of ad clicks from about:home searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1804,6 +1819,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_about_newtab_sum
   type: RECORD
+  description: Keyed count of ad clicks from new tab page searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1814,6 +1830,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_searchbar_sum
   type: RECORD
+  description: Keyed count of ad clicks from search bar searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1824,6 +1841,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_system_sum
   type: RECORD
+  description: Keyed count of ad clicks from system-initiated searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1834,6 +1852,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_webextension_sum
   type: RECORD
+  description: Keyed count of ad clicks from extension-initiated searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1844,6 +1863,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_tabhistory_sum
   type: RECORD
+  description: Keyed count of ad clicks from tab history navigation searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1854,6 +1874,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_reload_sum
   type: RECORD
+  description: Keyed count of ad clicks from reload-triggered searches, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1864,6 +1885,7 @@ fields:
   mode: REPEATED
   name: search_adclicks_unknown_sum
   type: RECORD
+  description: Keyed count of ad clicks from unclassified search entry points, keyed by engine.
 - mode: NULLABLE
   name: update_background
   type: BOOLEAN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -1445,6 +1445,7 @@ fields:
   mode: REPEATED
   name: search_with_ads
   type: RECORD
+  description: Keyed count of search result page impressions containing ads, keyed by search engine and access point.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1455,6 +1456,7 @@ fields:
   mode: REPEATED
   name: ad_clicks
   type: RECORD
+  description: Keyed count of ad clicks on search result pages, keyed by search engine and access point.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1465,6 +1467,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_sum
   type: RECORD
+  description: Keyed count of searches from the URL bar, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1475,6 +1478,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of searches via URL bar new-tab handoff, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1485,6 +1489,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of searches where the URL bar retained the term after submission, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1495,6 +1500,7 @@ fields:
   mode: REPEATED
   name: search_content_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of URL bar search-mode searches, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1505,6 +1511,7 @@ fields:
   mode: REPEATED
   name: search_content_contextmenu_sum
   type: RECORD
+  description: Keyed count of context menu searches, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1515,6 +1522,7 @@ fields:
   mode: REPEATED
   name: search_content_about_home_sum
   type: RECORD
+  description: Keyed count of searches from the about:home page, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1525,6 +1533,7 @@ fields:
   mode: REPEATED
   name: search_content_about_newtab_sum
   type: RECORD
+  description: Keyed count of searches from the new tab page, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1535,6 +1544,7 @@ fields:
   mode: REPEATED
   name: search_content_searchbar_sum
   type: RECORD
+  description: Keyed count of searches from the dedicated search bar, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1545,6 +1555,7 @@ fields:
   mode: REPEATED
   name: search_content_system_sum
   type: RECORD
+  description: Keyed count of system-initiated searches, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1555,6 +1566,7 @@ fields:
   mode: REPEATED
   name: search_content_webextension_sum
   type: RECORD
+  description: Keyed count of extension-initiated searches, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1565,6 +1577,7 @@ fields:
   mode: REPEATED
   name: search_content_tabhistory_sum
   type: RECORD
+  description: Keyed count of searches from tab history navigation, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1575,6 +1588,7 @@ fields:
   mode: REPEATED
   name: search_content_reload_sum
   type: RECORD
+  description: Keyed count of searches triggered by page reload, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1585,6 +1599,7 @@ fields:
   mode: REPEATED
   name: search_content_unknown_sum
   type: RECORD
+  description: Keyed count of searches from unclassified entry points, keyed by search engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1595,6 +1610,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_sum
   type: RECORD
+  description: Keyed count of URL bar search result pages that contained ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1605,6 +1621,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_handoff_sum
   type: RECORD
+  description: Keyed count of new-tab handoff search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1615,6 +1632,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_persisted_sum
   type: RECORD
+  description: Keyed count of persisted-URL-bar search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1625,6 +1643,7 @@ fields:
   mode: REPEATED
   name: search_withads_urlbar_searchmode_sum
   type: RECORD
+  description: Keyed count of search-mode search result pages with ads, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1970,6 +1989,7 @@ fields:
   mode: REPEATED
   name: a11y_theme
   type: RECORD
+  description: Keyed boolean indicators of Windows accessibility theme settings active for this client, keyed by theme attribute name.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1980,6 +2000,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of help link clicks on non-sponsored Best Match Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1990,6 +2011,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of help link clicks on sponsored Best Match Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2000,6 +2022,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_nonsponsored_sum
   type: RECORD
+  description: Keyed count of times a non-sponsored Firefox Suggest result was dismissed/blocked.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2010,6 +2033,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_sponsored_sum
   type: RECORD
+  description: Keyed count of times a sponsored Firefox Suggest result was dismissed/blocked.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2020,6 +2044,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of times a sponsored Best Match Firefox Suggest result was blocked.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2030,6 +2055,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of times a non-sponsored Best Match Firefox Suggest result was blocked.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2040,6 +2066,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of clicks on sponsored Best Match Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2050,6 +2077,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of clicks on non-sponsored Best Match Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2060,6 +2088,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of impressions of sponsored Best Match Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2070,6 +2099,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_nonsponsored_bestmatch_sum
   type: RECORD
+  description: Keyed count of impressions of non-sponsored Best Match Firefox Suggest results.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_bestmatch
   type: STRING
@@ -2207,6 +2237,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of times a dynamic Wikipedia Firefox Suggest result was blocked.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2217,6 +2248,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_block_weather_sum
   type: RECORD
+  description: Keyed count of times a weather Firefox Suggest result was blocked.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2227,6 +2259,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of clicks on dynamic Wikipedia Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2237,6 +2270,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_nonsponsored_sum
   type: RECORD
+  description: Keyed count of clicks on non-sponsored Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2247,6 +2281,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sponsored_sum
   type: RECORD
+  description: Keyed count of clicks on sponsored Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2257,6 +2292,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_weather_sum
   type: RECORD
+  description: Keyed count of clicks on weather Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2267,6 +2303,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of help link clicks on dynamic Wikipedia Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2277,6 +2314,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_nonsponsored_sum
   type: RECORD
+  description: Keyed count of help link clicks on non-sponsored Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2287,6 +2325,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sponsored_sum
   type: RECORD
+  description: Keyed count of help link clicks on sponsored Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2297,6 +2336,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_weather_sum
   type: RECORD
+  description: Keyed count of help link clicks on weather Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2307,6 +2347,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_dynamic_wikipedia_sum
   type: RECORD
+  description: Keyed count of impressions of dynamic Wikipedia Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2317,6 +2358,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_nonsponsored_sum
   type: RECORD
+  description: Keyed count of impressions of non-sponsored Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2327,6 +2369,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sponsored_sum
   type: RECORD
+  description: Keyed count of impressions of sponsored Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2337,6 +2380,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_weather_sum
   type: RECORD
+  description: Keyed count of impressions of weather Firefox Suggest results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2347,6 +2391,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_opened_sum
   type: RECORD
+  description: Keyed count of times Firefox Sidebar panels were opened, keyed by panel name.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2357,6 +2402,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_search_sum
   type: RECORD
+  description: Keyed count of searches within Firefox Sidebar panels, keyed by panel name.
 - fields:
   - mode: NULLABLE
     name: key
@@ -2367,6 +2413,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_sidebar_link_sum
   type: RECORD
+  description: Keyed count of link activations within Firefox Sidebar panels, keyed by panel name.
 - name: places_previousday_visits_mean
   type: FLOAT
   mode: NULLABLE
@@ -2387,6 +2434,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of link activations within the Firefox Library panel, keyed by section.
   - name: key
     type: STRING
     mode: NULLABLE
@@ -2397,6 +2445,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of times the Firefox Library panel was opened, keyed by entry point.
   - name: key
     type: STRING
     mode: NULLABLE
@@ -2407,6 +2456,7 @@ fields:
   type: RECORD
   mode: REPEATED
   fields:
+  description: Keyed count of searches within the Firefox Library panel, keyed by section.
   - name: key
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_daily_v6/schema.yaml
@@ -1155,6 +1155,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_browser_ui_interaction_preferences_pane_home_sum
   type: RECORD
+  description: Keyed count of user interactions in the Firefox Preferences Home panel, keyed by UI element.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1165,6 +1166,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_sum
   type: RECORD
+  description: Keyed count of URL bar autofill result selections, keyed by autofill source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1175,6 +1177,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_about_sum
   type: RECORD
+  description: Keyed count of URL bar selections of autofill suggestions for about; pages.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1185,6 +1188,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_adaptive_sum
   type: RECORD
+  description: Keyed count of URL bar selections of adaptive (history-learned) autofill suggestions.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1195,6 +1199,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_origin_sum
   type: RECORD
+  description: Keyed count of URL bar selections of origin-based autofill suggestions.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1205,6 +1210,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_other_sum
   type: RECORD
+  description: Keyed count of URL bar selections of 'other' type autofill suggestions.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1215,6 +1221,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_preloaded_sum
   type: RECORD
+  description: Keyed count of URL bar selections of autofill suggestions from the preloaded top sites list.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1225,6 +1232,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_autofill_url_sum
   type: RECORD
+  description: Keyed count of URL bar selections of full-URL autofill suggestions.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1235,6 +1243,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_bookmark_sum
   type: RECORD
+  description: Keyed count of URL bar result selections of bookmarks, keyed by search entry point.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1245,6 +1254,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_dynamic_sum
   type: RECORD
+  description: Keyed count of URL bar selections of dynamic result types.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1255,6 +1265,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_extension_sum
   type: RECORD
+  description: Keyed count of URL bar results provided by a browser extension that were selected.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1265,6 +1276,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_formhistory_sum
   type: RECORD
+  description: Keyed count of URL bar selections of form history suggestions.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1275,6 +1287,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_history_sum
   type: RECORD
+  description: Keyed count of URL bar selections of browsing history results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1285,6 +1298,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_keyword_sum
   type: RECORD
+  description: Keyed count of URL bar selections of keyword (search engine shortcut) results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1295,6 +1309,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_remotetab_sum
   type: RECORD
+  description: Keyed count of URL bar selections of remote (synced device) tabs.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1305,6 +1320,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_searchengine_sum
   type: RECORD
+  description: Keyed count of URL bar selections that launched a search, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1315,6 +1331,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_searchsuggestion_sum
   type: RECORD
+  description: Keyed count of URL bar selections of search suggestions, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1325,6 +1342,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_switchtab_sum
   type: RECORD
+  description: Keyed count of URL bar selections that switched to an already-open tab.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1335,6 +1353,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_tabtosearch_sum
   type: RECORD
+  description: Keyed count of URL bar tab-to-search result selections, keyed by engine.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1345,6 +1364,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_tip_sum
   type: RECORD
+  description: Keyed count of URL bar selections of tip results (redirect tips), keyed by tip type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1355,6 +1375,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_topsite_sum
   type: RECORD
+  description: Keyed count of URL bar selections of Top Sites results.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1365,6 +1386,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_unknown_sum
   type: RECORD
+  description: Keyed count of URL bar result selections of unclassified types.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1375,6 +1397,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_urlbar_picked_visiturl_sum
   type: RECORD
+  description: Keyed count of URL bar selections where the user navigated directly to a typed URL.
 - mode: NULLABLE
   name: default_private_search_engine
   type: STRING
@@ -1876,6 +1899,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_click_sum
   type: RECORD
+  description: Keyed count of Firefox Suggest result clicks, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1886,6 +1910,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_impression_sum
   type: RECORD
+  description: Keyed count of Firefox Suggest result impressions, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1896,6 +1921,7 @@ fields:
   mode: REPEATED
   name: contextual_services_quicksuggest_help_sum
   type: RECORD
+  description: Keyed count of Firefox Suggest 'Learn More' help link clicks, keyed by suggestion type.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1906,6 +1932,7 @@ fields:
   mode: REPEATED
   name: contextual_services_topsites_click_sum
   type: RECORD
+  description: Keyed count of Top Sites tile clicks on the new tab page, keyed by tile position and source.
 - fields:
   - mode: NULLABLE
     name: key
@@ -1916,6 +1943,7 @@ fields:
   mode: REPEATED
   name: contextual_services_topsites_impression_sum
   type: RECORD
+  description: Keyed count of Top Sites tile impressions on the new tab page, keyed by tile position and source.
 - mode: NULLABLE
   name: user_pref_browser_urlbar_suggest_quicksuggest_nonsponsored
   type: STRING
@@ -2068,6 +2096,7 @@ fields:
   mode: REPEATED
   name: scalar_parent_browser_ui_interaction_content_context_sum
   type: RECORD
+  description: Keyed count of user interactions with the browser content area context menu, keyed by menu item action.
 - mode: NULLABLE
   name: text_recognition_api_performance_sum
   type: INTEGER

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v1/schema.yaml
@@ -8,6 +8,7 @@ fields:
 - mode: NULLABLE
   name: second_seen_date
   type: DATE
+  description: The date the server received the second ping from this client after the first-seen date. Null if the client has not sent a second ping.
 - mode: NULLABLE
   name: client_id
   type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_visits_v1/schema.yaml
@@ -75,6 +75,8 @@ fields:
 - mode: REPEATED
   name: newtab_blocked_sponsors
   type: STRING
+  description: Array of advertiser names that the user has dismissed from the topsites sponsored shortcuts
+    section, as reported by the newtab.blocked_sponsors metric.
 - fields:
   - mode: NULLABLE
     name: key
@@ -111,9 +113,13 @@ fields:
 - mode: NULLABLE
   name: had_non_impression_engagement
   type: BOOLEAN
+  description: True if the newtab visit included at least one click, search issued, or save action (i.e.,
+    any engagement beyond passive impressions); false otherwise.
 - mode: NULLABLE
   name: had_non_search_engagement
   type: BOOLEAN
+  description: True if the newtab visit included at least one click or save action on non-search content
+    (e.g., topsites, Pocket tiles, wallpapers); false if only search or impression events occurred.
 - fields:
   - mode: NULLABLE
     name: search_engine
@@ -302,6 +308,8 @@ fields:
 - mode: NULLABLE
   name: newtab_default_ui
   type: STRING
+  description: Whether the user is viewing Firefox's default newtab or homepage UI. Set to 'default' when
+    the open source matches the configured enabled page category, and 'non-default' otherwise.
 - name: newtab_weather_widget_enabled
   type: BOOLEAN
   mode: NULLABLE
@@ -312,24 +320,36 @@ fields:
   - name: wallpaper_selected_wallpaper
     type: STRING
     mode: NULLABLE
+  description: The identifier or name of the wallpaper that was selected (e.g., 'hot-air-balloons', 'custom')
+    when the wallpaper click event occurred. Null when a wallpaper was not selected in this interaction.
   - name: wallpaper_clicks
     type: INTEGER
     mode: NULLABLE
   - name: wallpaper_clicks_had_previous_wallpaper
     type: INTEGER
     mode: NULLABLE
+  description: Count of wallpaper click events where the user already had a previously selected wallpaper
+    before choosing this one, indicating a wallpaper change rather than a first-time selection.
   - name: wallpaper_clicks_first_selected_wallpaper
     type: INTEGER
     mode: NULLABLE
+  description: Count of wallpaper click events where no previous wallpaper was set, representing the user's
+    first-ever wallpaper selection.
   - name: wallpaper_category_clicks
     type: INTEGER
     mode: NULLABLE
+  description: Count of clicks on wallpaper category tabs in the wallpaper picker UI during this newtab
+    visit, indicating how many times the user browsed wallpaper categories.
   - name: wallpaper_highlight_dismissals
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the user dismissed the wallpaper feature highlight/onboarding prompt during
+    this newtab visit.
   - name: wallpaper_highlight_cta_clicks
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the user clicked the call-to-action button in the wallpaper feature highlight/onboarding
+    prompt during this newtab visit.
 - name: weather_interactions
   type: RECORD
   mode: REPEATED
@@ -337,15 +357,21 @@ fields:
   - name: weather_widget_impressions
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the weather widget was visible (impressed) to the user during this newtab
+    visit.
   - name: weather_widget_location_selected
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the user selected a location in the weather widget's location picker during
+    this newtab visit.
   - name: weather_widget_clicks
     type: INTEGER
     mode: NULLABLE
   - name: weather_widget_load_errors
     type: INTEGER
     mode: NULLABLE
+  description: Count of weather widget load errors encountered during this newtab visit, where the weather
+    data failed to fetch or render.
   - name: weather_widget_change_display_to_detailed
     type: INTEGER
     mode: NULLABLE
@@ -355,6 +381,8 @@ fields:
 - name: newtab_selected_topics
   type: STRING
   mode: REPEATED
+  description: Array of content topic names the user has selected in the newtab topic selection UI, used
+    to personalize the Pocket recommendations feed.
 - name: topic_selection_interactions
   type: RECORD
   mode: REPEATED
@@ -362,21 +390,32 @@ fields:
   - name: previous_topics
     type: STRING
     mode: NULLABLE
+  description: A comma-separated string of topic names that were previously selected by the user before
+    this topic selection interaction. Empty string or null if no topics were previously selected.
   - name: topics
     type: STRING
     mode: NULLABLE
+  description: A comma-separated string of topic names that were selected by the user during this topic
+    selection interaction. Empty string or null if no topics were set.
   - name: topic_selection_open
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the topic selection modal was opened during this newtab visit.
   - name: topic_selection_dismiss
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the user dismissed the topic selection modal without saving changes during
+    this newtab visit.
   - name: topic_selection_topics_first_saved
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the user saved their topic selection for the first time (first_save=true)
+    during this newtab visit.
   - name: topic_selection_topics_updated
     type: INTEGER
     mode: NULLABLE
+  description: Count of times the user updated their previously saved topic selections (first_save=false)
+    during this newtab visit.
 - mode: NULLABLE
   name: profile_group_id
   type: STRING
@@ -385,9 +424,13 @@ fields:
 - name: newtab_window_inner_height
   type: INTEGER
   mode: NULLABLE
+  description: The inner height of the browser window in pixels at the time the newtab page was opened.
+    Null when the newtab.opened event was not recorded for this visit.
 - name: newtab_window_inner_width
   type: INTEGER
   mode: NULLABLE
+  description: The inner width of the browser window in pixels at the time the newtab page was opened. Null
+    when the newtab.opened event was not recorded for this visit.
 - mode: NULLABLE
   name: topsites_sponsored_tiles_configured
   type: INTEGER


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.telemetry_derived`

> Generated by the metadata agent pipeline on 2026-07-09.

### Summary

| | |
|---|---|
| Tables updated | 1 |
| Fields described | 51 |
| Probe-matched | 22 / 51 |
| Contradictions flagged | 0 |

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `newtab_visits_v1` | 51 | 22/51 |

### Contradictions Found

_None_

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Contradictions investigated before merging
