### PR TITLE
fix(DO-2139): revert fenix submission_date changes

### DIFF
--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.query.sql
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.query.sql
@@ -17,11 +17,7 @@ WITH new_profiles AS (
     {% endif %}
   FROM `{{ project_id }}.{{ dataset }}.baseline_clients_first_seen`
   WHERE
-    {% if app_name == "fenix" %}
-    submission_date = DATE_SUB(@submission_date, INTERVAL 2 DAY) -- see https://mozilla-hub.atlassian.net/browse/DO-2139 for more info about this decision
-    {% else %}
     submission_date = @submission_date
-    {% endif %}
     AND is_new_profile
 )
 {% if 'first_session' in product_attribution_group_pings %}
@@ -194,11 +190,7 @@ SELECT
   FROM
     `moz-fx-data-shared-prod.{{ dataset }}.play_store_attribution`
   WHERE
-    {% if app_name == "fenix" %}
-    DATE(submission_timestamp) BETWEEN DATE_SUB(@submission_date, INTERVAL 15 DAY) AND DATE_SUB(@submission_date, INTERVAL 1 DAY) -- see https://mozilla-hub.atlassian.net/browse/DO-2139 for more info about this decision
-    {% else %}
     DATE(submission_timestamp) = @submission_date
-    {% endif %}
     -- We stopped receiving play_store_attribution via the first-session ping on 2026-04-07 including this filter
     -- to only start using the new ping starting one day prior to this to ensure consistency.
     AND DATE(submission_timestamp) >= "2026-04-06"

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/query.sql
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/query.sql
@@ -10,10 +10,7 @@ WITH new_profiles AS (
   FROM
     `moz-fx-data-shared-prod.fenix.baseline_clients_first_seen`
   WHERE
-    submission_date = DATE_SUB(
-      @submission_date,
-      INTERVAL 2 DAY
-    ) -- see https://mozilla-hub.atlassian.net/browse/DO-2139 for more info about this decision
+    submission_date = @submission_date
     AND is_new_profile
 ),
 first_session_ping_base AS (
@@ -141,12 +138,7 @@ play_store_attribution_ping_base AS (
   FROM
     `moz-fx-data-shared-prod.fenix.play_store_attribution`
   WHERE
-    DATE(submission_timestamp)
-    BETWEEN DATE_SUB(@submission_date, INTERVAL 15 DAY)
-    AND DATE_SUB(
-      @submission_date,
-      INTERVAL 1 DAY
-    ) -- see https://mozilla-hub.atlassian.net/browse/DO-2139 for more info about this decision
+    DATE(submission_timestamp) = @submission_date
     -- We stopped receiving play_store_attribution via the first-session ping on 2026-04-07 including this filter
     -- to only start using the new ping starting one day prior to this to ensure consistency.
     AND DATE(submission_timestamp) >= "2026-04-06"


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR reverts the changes made for `fenix` in DO-2139. We will then backfill downstream tables where needed.

## Related Tickets & Documents
* [DO-2139](https://mozilla-hub.atlassian.net/browse/DO-2139)
* https://github.com/mozilla/bigquery-etl/pull/9498

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DO-2139]: https://mozilla-hub.atlassian.net/browse/DO-2139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ