### PR TITLE
fix: Allow the `bqetl query schema render` command's `name` argument to work as intended (DENG-9946)

### DIFF
--- a/bigquery_etl/cli/utils.py
+++ b/bigquery_etl/cli/utils.py
@@ -20,7 +20,7 @@ from bigquery_etl.util.common import TempDatasetReference, project_dirs
 
 QUERY_FILE_RE = re.compile(
     r"^.*/([a-zA-Z0-9-]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+(_v[0-9]+)?)/"
-    r"(?:query\.sql|shredder_mitigation_query\.sql|part1\.sql|script\.sql|query\.py|view\.sql|metadata\.yaml|backfill\.yaml)$"
+    r"(?:query\.sql|shredder_mitigation_query\.sql|part1\.sql|script\.sql|query\.py|view\.sql|metadata\.yaml|schema\.yaml|backfill\.yaml)$"
 )
 CHECKS_FILE_RE = re.compile(
     r"^.*/([a-zA-Z0-9-]+)/([a-zA-Z0-9_]+)/([a-zA-Z0-9_]+(_v[0-9]+)?)/"

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -387,6 +387,11 @@ class TestQuery:
                 "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1/query.sql", "w"
             ) as f:
                 f.write("SELECT 1")
+            with open(
+                "sql/moz-fx-data-shared-prod/telemetry_derived/query_v1/schema.yaml",
+                "w",
+            ) as f:
+                f.write("fields: []")
 
             os.mkdir("sql/moz-fx-data-shared-prod/telemetry_derived/query_v2")
             with open(
@@ -477,6 +482,15 @@ class TestQuery:
                 )
                 == 1
             )
+
+            schema_matches = paths_matching_name_pattern(
+                "telemetry_derived.query_v1",
+                "sql/",
+                "moz-fx-data-shared-prod",
+                files=["schema.yaml"],
+            )
+            assert len(schema_matches) == 1
+            assert schema_matches[0].name == "schema.yaml"
 
     def test_attach_metadata_labels(self, runner):
         with runner.isolated_filesystem():


### PR DESCRIPTION
## Description
The `paths_matching_name_pattern()` utility function wasn't matching `schema.yaml` files by default, so passing ETL/view IDs to `bqetl query schema render` commands was failing with errors like `No files matching: foo.bar, ['schema.yaml']`.

Fixup for https://github.com/mozilla/bigquery-etl/pull/9035.

## Related Tickets & Documents
* DENG-9946: Add `bqetl` support for including YAML from other files in `schema.yaml` files
* https://github.com/mozilla/bigquery-etl/pull/9035

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
