### PR TITLE
Skip DAU comparison check for klar_ios and klar_android active_users_aggregates

### DIFF
--- a/sql_generators/active_users_aggregates_v3/templates/mobile_checks.sql
+++ b/sql_generators/active_users_aggregates_v3/templates/mobile_checks.sql
@@ -58,6 +58,8 @@ SELECT
     NULL
   );
 
+{# Skip the DAU check for klar_ios/klar_android: their DAU is too low/volatile for the 50% threshold #}
+{% if app_name not in ["klar_ios", "klar_android"] -%}
 {% raw -%}
 
 #fail
@@ -87,3 +89,4 @@ SELECT
   );
 
 {% endraw %}
+{%- endif %}


### PR DESCRIPTION


## Description

Follow-up to https://mozilla.slack.com/archives/C01E8GDG80N/p1780948063884559

The DAU checks are too volatile for klar_ios and klar_android so this PR removes them.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
