### PR TITLE
chore(DENG-11226): initiate backfills for step2 downstream tables after fenix_derived.attribution_clients_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/engagement_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/engagement_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-06-08:
+  start_date: 2026-06-03
+  end_date: 2026-06-08
+  reason: DENG-11226, backfill downstream of attribution_clients_v1 logic update
+  watchers:
+  - kbammarito@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
+
 2025-01-22:
   start_date: 2024-03-05
   end_date: 2025-01-21

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/backfill.yaml
@@ -8,14 +8,3 @@
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false
-
-2025-01-29:
-  start_date: 2021-01-01
-  end_date: 2025-01-28
-  reason: Fix join logic for mobile feature metrics (DENG-7535)
-  watchers:
-  - vsabino@mozilla.com
-  - kwindau@mozilla.com
-  status: Complete
-  shredder_mitigation: false
-  override_retention_limit: true

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/metadata.yaml
@@ -10,7 +10,7 @@ labels:
   incremental: true
   owner1: rzhao
   table_type: aggregate
-  shredder_mitigation: true
+  shredder_mitigation: false
 scheduling:
   dag_name: bqetl_mobile_feature_usage
 bigquery:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/metadata.yaml
@@ -9,7 +9,7 @@ labels:
   incremental: true
   owner1: rzhao
   table_type: aggregate
-  shredder_mitigation: true
+  shredder_mitigation: false
 scheduling:
   dag_name: bqetl_mobile_feature_usage
 bigquery:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_clients_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-06-08:
+  start_date: 2026-06-03
+  end_date: 2026-06-08
+  reason: DENG-11226, backfill downstream of attribution_clients_v1 logic update
+  watchers:
+  - kbammarito@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
+
 2025-06-11:
   start_date: 2023-05-01
   end_date: 2025-06-11

--- a/sql/moz-fx-data-shared-prod/fenix_derived/profile_dau_metrics_marketing_geo_testing_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/profile_dau_metrics_marketing_geo_testing_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-06-08:
+  start_date: 2026-06-03
+  end_date: 2026-06-08
+  reason: DENG-11226, backfill downstream of attribution_clients_v1 logic update
+  watchers:
+  - kbammarito@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
+
 2025-02-07:
   start_date: 2021-01-01
   end_date: 2025-02-07

--- a/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/retention_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-06-08:
+  start_date: 2026-06-03
+  end_date: 2026-06-08
+  reason: DENG-11226, backfill downstream of attribution_clients_v1 logic update
+  watchers:
+  - kbammarito@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
+
 2025-10-03:
   start_date: 2025-05-15
   end_date: 2025-05-21


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR adds backfill initiate for six tables downstream of `fenix_derived.attribution_clients_v1` after https://github.com/mozilla/bigquery-etl/pull/9545

`fenix_derived`:
- `engagement_v1`
- `feature_usage_events_v1`
- `feature_usage_metrics_v2`
- `new_profile_clients_v1`
- `profile_dau_metrics_marketing_geo_testing_v1`
- `retention_v1`

We are setting the `shredder_mitigation: false` in the `metadata.yaml` for `feature_usage_events_v1` and `feature_usage_metrics_v2` so it matches the `backfill.yaml` entries (per other DE's decision that `shredder_mitigation` is not needed on these particular backfills). We will restore the setting after completion.

## Related Tickets & Documents
* DENG-11226
* https://github.com/mozilla/bigquery-etl/pull/9545

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
