### PR TITLE
chore(DENG-11226): initiate backfills for step 4 downstream tables after fenix_derived.attribution_clients_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
@@ -1,9 +1,10 @@
 2026-06-08:
   start_date: 2026-06-03
   end_date: 2026-06-08
-  reason: Backfill downstream of attribution_clients_v1 logic update
+  reason: DENG-11226, backfill downstream of attribution_clients_v1 logic update
   watchers:
   - cbeck@mozilla.com
+  - kbammarito@mozilla.com
   status: Initiate
   shredder_mitigation: false
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/backfill.yaml
@@ -20,5 +20,3 @@
   status: Complete
   shredder_mitigation: false
   override_retention_limit: true
-  override_depends_on_past_end_date: false
-  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_metrics_marketing_geo_testing_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_metrics_marketing_geo_testing_v1/backfill.yaml
@@ -1,9 +1,10 @@
 2026-06-08:
   start_date: 2026-06-03
   end_date: 2026-06-08
-  reason: Backfill downstream of attribution_clients_v1 logic update
+  reason: DENG-11226, backfill downstream of attribution_clients_v1 logic update
   watchers:
   - cbeck@mozilla.com
+  - kbammarito@mozilla.com
   status: Initiate
   shredder_mitigation: false
   override_retention_limit: false
@@ -20,5 +21,3 @@
   status: Complete
   shredder_mitigation: false
   override_retention_limit: true
-  override_depends_on_past_end_date: false
-  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_metrics_marketing_geo_testing_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_metrics_marketing_geo_testing_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2026-06-08:
+  start_date: 2026-06-03
+  end_date: 2026-06-08
+  reason: Backfill downstream of attribution_clients_v1 logic update
+  watchers:
+  - cbeck@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
+
 2025-02-05:
   start_date: 2021-01-01
   end_date: 2025-02-05
@@ -8,3 +20,5 @@
   status: Complete
   shredder_mitigation: false
   override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v2/backfill.yaml
@@ -1,9 +1,10 @@
 2026-06-08:
   start_date: 2026-06-03
   end_date: 2026-06-08
-  reason: Backfill downstream of attribution_clients_v1 logic update
+  reason: DENG-11226, backfill downstream of attribution_clients_v1 logic update
   watchers:
   - cbeck@mozilla.com
+  - kbammarito@mozilla.com
   status: Initiate
   shredder_mitigation: false
   override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/android_app_campaign_stats_v2/backfill.yaml
@@ -9,15 +9,3 @@
   override_retention_limit: false
   override_depends_on_past_end_date: false
   ignore_date_partition_offset: false
-
-2025-02-03:
-  start_date: 2021-01-01
-  end_date: 2025-02-03
-  reason: Initial backfill for the table
-  watchers:
-  - kik@mozilla.com
-  status: Complete
-  shredder_mitigation: false
-  override_retention_limit: true
-  override_depends_on_past_end_date: false
-  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description
This PR adds backfill initiate for three tables downstream of `fenix_derived.attribution_clients_v1` after reverting the `fenix` changes in https://github.com/mozilla/bigquery-etl/pull/9534

This is step 4 in backfill process, merged after `new_profile_activation_clients_v1` completes.

- `fenix_derived.new_profile_activations_v1`
- `fenix_derived.new_profile_metrics_marketing_geo_testing_v1`
- `google_ads_derived.android_app_campaign_stats_v2`

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-11226
* https://github.com/mozilla/bigquery-etl/pull/9534

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
