### PR TITLE
Fix bqetl_braze wait_for tasks hanging on bqetl_accounts_db

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1435,7 +1435,7 @@ bqetl_google_search_console:
     - impact/tier_1
 
 bqetl_braze:
-  schedule_interval: 0 5,13,21 * * *
+  schedule_interval: 30 4,13,22 * * *
   description: ETL for Braze workflows.
   default_args:
     owner: lmcfall@mozilla.com


### PR DESCRIPTION
## Description

Move `bqetl_braze` to `30 4,13,22 * * *` so its runs land on the `bqetl_accounts_db` (`30 1/3`) and `bqetl_subplat_hourly` (`30 * * * *`) grids. The old `0 5,13,21` schedule shared no execution dates with either upstream, so the generated `ExternalTaskSensors` (no computable `execution_delta`) waited forever. No downstream DAGs depend on bqetl_braze.

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
