### PR TITLE
chore(DENG-11226): complete backfill for fenix_derived.attribution_clients_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: reverting fenix submission_date changes in https://github.com/mozilla/bigquery-etl/pull/9534
   watchers:
   - kbammarito@mozilla.com
-  status: Initiate
+  status: Complete
   override_retention_limit: false
 2025-05-20:
   start_date: 2023-04-08


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR completes the backfill for `fenix_derived.attribution_clients_v1` after reverting the `fenix` changes in https://github.com/mozilla/bigquery-etl/pull/9534.

## Related Tickets & Documents
* DENG-11226
* https://github.com/mozilla/bigquery-etl/pull/9525

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
