### PR TITLE
chore(DENG-11226): set shredder_mitigation: true

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_events_v1/metadata.yaml
@@ -10,7 +10,7 @@ labels:
   incremental: true
   owner1: rzhao
   table_type: aggregate
-  shredder_mitigation: false
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_mobile_feature_usage
 bigquery:

--- a/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/feature_usage_metrics_v2/metadata.yaml
@@ -9,7 +9,7 @@ labels:
   incremental: true
   owner1: rzhao
   table_type: aggregate
-  shredder_mitigation: false
+  shredder_mitigation: true
 scheduling:
   dag_name: bqetl_mobile_feature_usage
 bigquery:


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR restores `shredder_mitigation: true` in `feature_usage_events_v1` and `feature_usage_metrics_v2`'s `metadata.yaml`s after setting it to `false` in https://github.com/mozilla/bigquery-etl/pull/9539

## Related Tickets & Documents
* DENG-11226
* https://github.com/mozilla/bigquery-etl/pull/9534

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
