### PR TITLE
chore(DENG-11226): complete backfills for step 3 tables downstream of fenix_derived.attribution_clients_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_clients_v1/backfill.yaml
@@ -5,11 +5,12 @@
   watchers:
   - cbeck@mozilla.com
   - kbammarito@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false
   ignore_date_partition_offset: false
+
 2025-05-22:
   start_date: 2023-04-09
   end_date: 2025-05-20

--- a/sql/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/backfill.yaml
@@ -5,11 +5,12 @@
   watchers:
   - cbeck@mozilla.com
   - kbammarito@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false
   ignore_date_partition_offset: false
+
 2025-01-22:
   start_date: 2024-03-05
   end_date: 2025-01-21

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - cbeck@mozilla.com
   - kbammarito@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/google_ads_derived/fenix_conversion_event_categorization_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/google_ads_derived/fenix_conversion_event_categorization_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - cbeck@mozilla.com
   - kbammarito@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - cbeck@mozilla.com
   - kbammarito@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR completes the backfill for five tables downstream of `fenix_derived.attribution_clients_v1` after reverting the `fenix` changes in https://github.com/mozilla/bigquery-etl/pull/9534

- `fenix_derived.new_profiles_v1`
- `fenix_derived.new_profile_activation_clients_v1`
- `google_ads_derived.fenix_conversion_event_categorization_v1`
- `telemetry_derived.rolling_cohorts_v2`
- `glean_telemetry_derived.rolling_cohorts_v1`

## Related Tickets & Documents
* DENG-11226
* https://github.com/mozilla/bigquery-etl/pull/9534
* https://github.com/mozilla/bigquery-etl/pull/9538

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
