### PR TITLE
fix(braze_external): fxa_services as plain-array overwrite), not the add operator

### DIFF
--- a/sql/moz-fx-data-shared-prod/braze_external/changed_fxa_services_sync_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_fxa_services_sync_v1/metadata.yaml
@@ -7,20 +7,6 @@ description: |-
   onboard another service, add it to the service_subscription_groups mapping in the
   query (and to the matching mapping in changed_fxa_services_events_sync_v1).
 
-  The payload uses the array-of-objects `add` operator, so each new service is
-  appended to the user's existing fxa_services attribute. It also sets the profile
-  email so a new alias-only profile has a contactable address, and subscribes the
-  user to the mapped service's subscription group. We do NOT set the profile-level
-  email_subscribe (the global email master-switch), so we never re-subscribe a user
-  who has globally unsubscribed.
-
-  Braze's `add` always appends (it does not upsert or dedupe), so duplicates are
-  prevented solely by anti-joining against this table's own history (already_synced)
-  and emitting each (uid, service) only once. This table is therefore NOT expired --
-  it must keep full history, and re-backfilling/truncating it would create duplicate
-  array entries in Braze. Records sync to Braze on the fxa_id user alias (ALIAS_NAME
-  = uid, ALIAS_LABEL = 'fxa_id'). Sourced from braze_derived.fxa_services_v1.
-
   Note on email: the mapped service's emails are transactional communications, sent
   to people who have authorized and use that service. The subscription state
   ('subscribed') and group are simply how Braze routes those transactional sends.
@@ -34,8 +20,6 @@ bigquery:
     type: day
     field: updated_at
     require_partition_filter: false
-    # not expired: the query reads its own history (already_synced) to emit each
-    # (uid, service) only once
     expiration_days: null
 scheduling:
   dag_name: bqetl_braze

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_fxa_services_sync_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_fxa_services_sync_v1/query.sql
@@ -1,87 +1,57 @@
--- Ingestion payload APPENDS to a nested array-of-objects custom attribute
--- (fxa_services) and subscribes the user to the service's Braze transactional subscription group.
---
--- Scope: we only sync services that map to a Braze subscription group.
---
--- De-duplication: Braze's `add` operator ALWAYS appends (it does not upsert or
--- dedupe -- $identifier_key only applies to `update`/`remove`), so duplicates are
--- prevented solely by anti-joining against this table's own history (already_synced)
--- and emitting each (uid, service) at most once. This table must therefore keep
--- full history and is NOT expired. NOTE: re-backfilling or truncating this table
--- would re-emit `add`s and create duplicate array entries in Braze -- treat its
--- history as load-bearing.
---
--- Email/subscription semantics: the mapped service's emails are TRANSACTIONAL
--- service emails, routed via the service's subscription group.
--- We set the per-group subscription_state to 'subscribed' (delivery routing). We do
--- NOT set the profile-level email_subscribe, which is the user's GLOBAL email
--- master-switch.
+-- Braze Cloud Data Ingestion payload for FxA services mapped to a subscription
+-- group (today just 'smartwindow'). fxa_services is sent as a PLAIN ARRAY (not the
+-- `add` operator, which CDI collapses to a single object). We send each user's full
+-- mapped set so the overwrite rebuilds the array and keeps prior services; the
+-- watermark gates whole users (HAVING), since first_authorized_tos_at is immutable.
+-- To onboard a service, add a row to service_subscription_groups (keep in sync with
+-- changed_fxa_services_events_sync_v1).
 WITH service_subscription_groups AS (
   SELECT
     'smartwindow' AS service,
     '38994d30-52ea-4729-b6b3-255e05115db5' AS subscription_group_id
-  -- To onboard a new service, add a row here:
-  -- UNION ALL
-  -- SELECT '<service>', '<subscription-group-id>'
 ),
-already_synced AS (
-  SELECT DISTINCT
-    ALIAS_NAME AS uid,
-    JSON_VALUE(service_element, '$.service') AS service
+max_update AS (
+  SELECT
+    MAX(
+      TIMESTAMP(JSON_VALUE(service_element, '$.first_authorized_tos_at."$time"'))
+    ) AS latest_first_authorized_tos_at
   FROM
     `moz-fx-data-shared-prod.braze_external.changed_fxa_services_sync_v1`,
-    UNNEST(JSON_QUERY_ARRAY(payload.fxa_services["add"])) AS service_element
+    UNNEST(JSON_QUERY_ARRAY(payload.fxa_services)) AS service_element
 ),
-new_services AS (
-  SELECT
-    users.uid,
-    users.service,
-    ANY_VALUE(users.email) AS email,
-    ANY_VALUE(service_mapping.subscription_group_id) AS subscription_group_id,
-    MIN(users.first_authorized_tos_at) AS first_authorized_tos_at
-  FROM
-    `moz-fx-data-shared-prod.braze_derived.fxa_services_v1` AS users
-  INNER JOIN
-    service_subscription_groups AS service_mapping
-    USING (service)
-  LEFT JOIN
-    already_synced
-    ON already_synced.uid = users.uid
-    AND already_synced.service = users.service
-  WHERE
-    users.first_authorized_tos_at IS NOT NULL
-    AND already_synced.uid IS NULL
-  GROUP BY
-    uid,
-    service
-),
--- aggregate per user here so the final SELECT can UNNEST a plain array column;
--- BigQuery rejects an aggregate (ARRAY_AGG) nested directly inside UNNEST
 per_user AS (
   SELECT
-    services.uid,
-    ANY_VALUE(services.email) AS email,
-    -- the objects to append to the user's fxa_services array
+    users.uid,
+    ANY_VALUE(users.email) AS email,
     ARRAY_AGG(
       STRUCT(
-        services.service AS service,
+        users.service AS service,
         STRUCT(
-          FORMAT_TIMESTAMP(
-            '%Y-%m-%d %H:%M:%E6S UTC',  -- Braze-required nested-timestamp format
-            services.first_authorized_tos_at,
+          FORMAT_TIMESTAMP(  -- Braze-required nested-timestamp format
+            '%Y-%m-%d %H:%M:%E6S UTC',
+            users.first_authorized_tos_at,
             'UTC'
           ) AS `$time`
         ) AS first_authorized_tos_at
       )
       ORDER BY
-        services.first_authorized_tos_at  -- ascending: element [0] is the first service
-    ) AS services_to_add,
-    -- distinct subscription groups for this user's newly synced services
-    ARRAY_AGG(DISTINCT services.subscription_group_id) AS subscription_group_ids
+        users.first_authorized_tos_at
+    ) AS fxa_services,
+    ARRAY_AGG(DISTINCT service_mapping.subscription_group_id) AS subscription_group_ids
   FROM
-    new_services AS services
+    `moz-fx-data-shared-prod.braze_derived.fxa_services_v1` AS users
+  INNER JOIN
+    service_subscription_groups AS service_mapping
+    USING (service)
+  WHERE
+    users.first_authorized_tos_at IS NOT NULL  -- null timestamps error in Braze
   GROUP BY
-    uid
+    users.uid
+  HAVING
+    MAX(users.first_authorized_tos_at) > COALESCE(
+      (SELECT latest_first_authorized_tos_at FROM max_update),
+      TIMESTAMP('2020-01-01')
+    )
 )
 SELECT
   CURRENT_TIMESTAMP() AS UPDATED_AT,
@@ -91,7 +61,7 @@ SELECT
     TO_JSON(
       STRUCT(
         per_user.email AS email,
-        STRUCT(per_user.services_to_add AS `add`) AS fxa_services,
+        per_user.fxa_services AS fxa_services,
         ARRAY(
           SELECT AS STRUCT
             group_id AS subscription_group_id,

--- a/sql/moz-fx-data-shared-prod/braze_external/changed_fxa_services_sync_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/braze_external/changed_fxa_services_sync_v1/query.sql
@@ -1,23 +1,43 @@
 -- Braze Cloud Data Ingestion payload for FxA services mapped to a subscription
 -- group (today just 'smartwindow'). fxa_services is sent as a PLAIN ARRAY (not the
--- `add` operator, which CDI collapses to a single object). We send each user's full
--- mapped set so the overwrite rebuilds the array and keeps prior services; the
--- watermark gates whole users (HAVING), since first_authorized_tos_at is immutable.
--- To onboard a service, add a row to service_subscription_groups (keep in sync with
--- changed_fxa_services_events_sync_v1).
+-- `add` operator, which CDI collapses to a single object). We anti-join against this
+-- table's own history (already_synced) to find users with any mapped service not yet
+-- synced -- timestamp-independent, so onboarding a service backfills its existing
+-- authorizers and late/backdated rows aren't dropped -- then emit each such user's
+-- FULL mapped set so the overwrite rebuilds the array and keeps prior services.
+-- Requires full history (NOT expired). To onboard a service, add a row to
+-- service_subscription_groups (keep in sync with changed_fxa_services_events_sync_v1).
+-- Note: rows written before the plain-array change stored fxa_services as
+-- {"add": [...]}, which JSON_QUERY_ARRAY reads as empty, so the first run after
+-- deploy re-emits every user once to migrate them to the array shape.
 WITH service_subscription_groups AS (
   SELECT
     'smartwindow' AS service,
     '38994d30-52ea-4729-b6b3-255e05115db5' AS subscription_group_id
 ),
-max_update AS (
-  SELECT
-    MAX(
-      TIMESTAMP(JSON_VALUE(service_element, '$.first_authorized_tos_at."$time"'))
-    ) AS latest_first_authorized_tos_at
+already_synced AS (
+  SELECT DISTINCT
+    ALIAS_NAME AS uid,
+    JSON_VALUE(service_element, '$.service') AS service
   FROM
     `moz-fx-data-shared-prod.braze_external.changed_fxa_services_sync_v1`,
     UNNEST(JSON_QUERY_ARRAY(payload.fxa_services)) AS service_element
+),
+users_with_new_service AS (
+  SELECT DISTINCT
+    users.uid
+  FROM
+    `moz-fx-data-shared-prod.braze_derived.fxa_services_v1` AS users
+  INNER JOIN
+    service_subscription_groups
+    USING (service)
+  LEFT JOIN
+    already_synced
+    ON already_synced.uid = users.uid
+    AND already_synced.service = users.service
+  WHERE
+    users.first_authorized_tos_at IS NOT NULL
+    AND already_synced.uid IS NULL
 ),
 per_user AS (
   SELECT
@@ -27,7 +47,7 @@ per_user AS (
       STRUCT(
         users.service AS service,
         STRUCT(
-          FORMAT_TIMESTAMP(  -- Braze-required nested-timestamp format
+          FORMAT_TIMESTAMP(
             '%Y-%m-%d %H:%M:%E6S UTC',
             users.first_authorized_tos_at,
             'UTC'
@@ -43,15 +63,13 @@ per_user AS (
   INNER JOIN
     service_subscription_groups AS service_mapping
     USING (service)
+  INNER JOIN
+    users_with_new_service
+    USING (uid)
   WHERE
-    users.first_authorized_tos_at IS NOT NULL  -- null timestamps error in Braze
+    users.first_authorized_tos_at IS NOT NULL
   GROUP BY
     users.uid
-  HAVING
-    MAX(users.first_authorized_tos_at) > COALESCE(
-      (SELECT latest_first_authorized_tos_at FROM max_update),
-      TIMESTAMP('2020-01-01')
-    )
 )
 SELECT
   CURRENT_TIMESTAMP() AS UPDATED_AT,


### PR DESCRIPTION
## Description

Braze CDI payload syncing each FxA user's authorized subscription-group services as the fxa_services array attribute.


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
