### PR TITLE
chore(DENG-10722): initiate 2026-05-27 backfill for urlbar_events_daily_v2

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_v2/backfill.yaml
@@ -1,3 +1,14 @@
+2026-06-11:
+  start_date: 2026-05-27
+  end_date: 2026-05-27
+  reason: Backfill for https://mozilla-hub.atlassian.net/browse/DENG-10722. 27 May was missing.
+  watchers:
+  - kbammarito@mozilla.com
+  - nflorez@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
 2026-05-27:
   start_date: 2025-01-01
   end_date: 2026-05-27


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR initiates a backfill for `2026-05-27`. The date is currently missing in `urlbar_events_daily_v2`.

## Related Tickets & Documents
* DENG-10722

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
