### PR TITLE
Add pointers to backfill documentation in AGENTS.md and review checklist

### DIFF
--- a/.github/reviewer_checklist.md
+++ b/.github/reviewer_checklist.md
@@ -4,6 +4,7 @@
 - [ ] If the PR comes from a fork, carefully review the changed code (especially workflow files, scripts, and code) before approving the `external-fork` environment deployment to run integration CI tests.
 - [ ] If adding a new field to a query, ensure that the schema and dependent downstream schemas have been updated.
 - [ ] When adding a new derived dataset, ensure that data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data can be available in the [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
+- [ ] If a `backfill.yaml` is edited, consult the [backfill documentation](/docs/cookbooks/backfilling_a_table.md) to ensure the backfill for the table is supported and the configuration is correct.
 
 For modifications to schemas in restricted namespaces (see [`CODEOWNERS`](https://github.com/mozilla/bigquery-etl/blob/main/CODEOWNERS)):
 - [ ] Follow the [change control procedure](https://docs.google.com/document/d/1TTJi4ht7NuzX6BPG_KTr6omaZg70cEpxe9xlpfnHj9k/edit#heading=h.ttegrcfy18ck)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ A target-based dev environment lets queries run against real data in a non-produ
 Never run, deploy, or backfill against production.
 
 ## Documentation
+- Backfilling a table: `docs/cookbooks/backfilling_a_table.md`
 - Creating queries: `docs/cookbooks/creating_a_derived_dataset.md`
 - Common workflows: `docs/cookbooks/common_workflows.md`
 - Development workflows (target-based dev environment): `docs/cookbooks/development_workflows.md`

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import tempfile
 from collections import defaultdict
-from datetime import date, datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timedelta
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -289,10 +289,10 @@ def create(
         click.echo("\n".join(errors))
         sys.exit(1)
 
-    if end_date.date() == datetime.now(timezone.utc).date():
+    if end_date.date() == date.today():
         click.echo(
             click.style(
-                "WARNING: end_date is today (UTC). The upstream table may not have data "
+                "WARNING: end_date is today. The upstream table may not have data "
                 "for today yet if its daily ETL hasn't run, in which case the backfill "
                 "writes an empty partition that gets copied into production on complete. "
                 "Consider using an end_date whose upstream data is already available.",

--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import tempfile
 from collections import defaultdict
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -288,6 +288,17 @@ def create(
     ):
         click.echo("\n".join(errors))
         sys.exit(1)
+
+    if end_date.date() == datetime.now(timezone.utc).date():
+        click.echo(
+            click.style(
+                "WARNING: end_date is today (UTC). The upstream table may not have data "
+                "for today yet if its daily ETL hasn't run, in which case the backfill "
+                "writes an empty partition that gets copied into production on complete. "
+                "Consider using an end_date whose upstream data is already available.",
+                fg="yellow",
+            )
+        )
 
     existing_backfills = get_entries_from_qualified_table_name(
         sql_dir, qualified_table_name, table_not_exists_ok=True

--- a/docs/cookbooks/backfilling_a_table.md
+++ b/docs/cookbooks/backfilling_a_table.md
@@ -98,6 +98,11 @@ This limitation is tracked in https://mozilla-hub.atlassian.net/browse/DENG-1005
 
 4. Watchers need to join the #dataops-alerts Slack channel. They will be notified via Slack when processing is complete, and you can validate your backfill data.
 
+**Something to watch out for:** If the `end_date` of a backfill is the current day (e.g. `end_date = entry_date`)
+and the backfill is started, the ETL for the upstream tables likely will not have run yet, causing the backfill to
+create an empty partition. If the backfill is completed on a later day, it will copy the empty partition into the
+production table, causing an empty partition in production.
+
 ## Backfilling with a Python script:
 
 Tables that use a `query.py` file instead of `query.sql` are also supported with backfills, but have additional considerations.


### PR DESCRIPTION
## Description

Adds a warning if the backfill end_date is the current day and adds some pointers to the documentation to guide AI code review to it (although it's already been doing it)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
