### PR TITLE
Moving the startdate back for testing

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2775,7 +2775,7 @@ bqetl_data_governance_metadata:
     (idempotent). Leaving both unset reproduces the scheduled behaviour.
   default_args:
     owner: gkatre@mozilla.com
-    start_date: "2026-06-15"
+    start_date: "2026-06-08"
     email: ["gkatre@mozilla.com"]
     retries: 1
     retry_delay: 30m


### PR DESCRIPTION
## Description

Setting the startdate back to test/initiate a manual run

## Related Tickets & Documents
* DENG-11231

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
