### PR TITLE
Initiate backfill for Focus Android without shredder mitigation

### DIFF
--- a/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
@@ -8,3 +8,14 @@
   status: Complete
   shredder_mitigation: true
   override_retention_limit: false
+
+2026-06-15:
+  start_date: 2026-04-15
+  end_date: 2026-05-25
+  reason: Fix inflated Focus Android metrics caused by duplicate client_ids in core_clients_last_seen_v1.
+  watchers:
+  - ascholtz@mozilla.com
+  - lvargas@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
@@ -16,7 +16,7 @@
     Related Bug https://bugzilla.mozilla.org/show_bug.cgi?id=2042189. 
     
     This backfill does not use shredder mitigation because it requires an update of the metrics (not preserve),
-    thus a decrease is expected in the originally calculated metrics is expected after completing this backfill
+    thus a decrease is expected in the originally calculated metrics after completing this backfill
     and only for this period, due to shredder effect.
     
     This is not expected to affect company KPIS [dau, wau, mau], because it only updates data already excluded

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
@@ -13,6 +13,7 @@
   start_date: 2026-04-15
   end_date: 2026-05-25
   reason: Fix inflated Focus Android metrics caused by duplicate client_ids in core_clients_last_seen_v1.
+    Related Bug https://bugzilla.mozilla.org/show_bug.cgi?id=2042189. 
     
     This backfill does not use shredder mitigation because it requires an update of the metrics (not preserve),
     thus a decrease is expected in the originally calculated metrics is expected after completing this backfill

--- a/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/focus_android_derived/active_users_aggregates_v4/backfill.yaml
@@ -13,6 +13,14 @@
   start_date: 2026-04-15
   end_date: 2026-05-25
   reason: Fix inflated Focus Android metrics caused by duplicate client_ids in core_clients_last_seen_v1.
+    
+    This backfill does not use shredder mitigation because it requires an update of the metrics (not preserve),
+    thus a decrease is expected in the originally calculated metrics is expected after completing this backfill
+    and only for this period, due to shredder effect.
+    
+    This is not expected to affect company KPIS [dau, wau, mau], because it only updates data already excluded
+    from the KPI reporting view `focus_android.active_users_aggregates`.
+    https://github.com/mozilla/bigquery-etl/blob/cdf99147d40bb70e072715bc54e50fd51f7b55c6/sql/moz-fx-data-shared-prod/focus_android/active_users_aggregates/view.sql#L18
   watchers:
   - ascholtz@mozilla.com
   - lvargas@mozilla.com

--- a/sql_generators/active_users_aggregates_v4/__init__.py
+++ b/sql_generators/active_users_aggregates_v4/__init__.py
@@ -102,6 +102,7 @@ def generate(target_project, output_dir, use_cloud_function):
     view_template = env.get_template("view.sql")
     # metadata template
     metadata_template = "metadata.yaml"
+    focus_metadata_template = "focus_android_metadata.yaml"
     # schema templates
     desktop_table_schema_template = "desktop_table_schema.yaml"
     desktop_view_schema_template = "desktop_view_schema.yaml"
@@ -338,12 +339,17 @@ def generate(target_project, output_dir, use_cloud_function):
             )
 
         # Write metadata YAML.
+        # Focus Android uses a dedicated template (shredder_mitigation disabled).
         write_sql(
             output_dir=output_dir,
             full_table_id=f"{target_project}.{browser.name}_derived.{TABLE_NAME}",
             basename="metadata.yaml",
             sql=render(
-                metadata_template,
+                (
+                    focus_metadata_template
+                    if browser.name == "focus_android"
+                    else metadata_template
+                ),
                 template_folder=THIS_PATH / "templates",
                 app_value=browser.value,
                 app_name=browser.name,

--- a/sql_generators/active_users_aggregates_v4/templates/focus_android_metadata.yaml
+++ b/sql_generators/active_users_aggregates_v4/templates/focus_android_metadata.yaml
@@ -1,0 +1,45 @@
+friendly_name: {{ app_value }} Active Users Aggregates
+description: |-
+  This table contains dau, wau, mau, daily users,
+  weekly users and monthly users for {{ app_value }},
+  aggregated by submission_date, attribution, channel,
+  country, city, device model, distribution_id, os details
+  and activity segment.
+
+  - dau is counting the users who reported a ping on the date and
+  are qualified as active users.
+  - daily_users counts all the users who reported a ping on the date.
+  Only dau is exposed in the view telemetry.active_users_aggregates.
+
+  The table is labeled as "change_controlled", which implies
+  that changes require the approval of at least one owner.
+  
+  The label "shredder mitigation" indicates that this table is set up for
+  managed backfill with shredder mitigation, as described in
+  https://mozilla.github.io/bigquery-etl/cookbooks/creating_a_derived_dataset/#initiating-the-backfill.
+
+  Proposal:
+  https://docs.google.com/document/d/1qvWO49Lr_Z_WErh3I3058A3B1YuiuURx19K3aTdmejM/edit?usp=sharing
+owners:
+  - lvargas@mozilla.com
+  - mozilla/kpi_table_reviewers
+labels:
+  level: gold
+  incremental: true
+  change_controlled: true
+  shredder_mitigation: false
+scheduling:
+  dag_name: bqetl_analytics_aggregations
+  task_name: {{ app_name }}_{{ table_name }}
+  date_partition_offset: -1
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+  clustering:
+    fields:
+      - country
+      - app_name
+      - attribution_medium
+      - channel


### PR DESCRIPTION
## Description

Backfill Focus Android active_users_aggregates_v4 without shredder mitigation.

Related [Bug 2042189](https://bugzilla.mozilla.org/show_bug.cgi?id=2042189)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
