### PR TITLE
[DENG-11241] Grant customer experience SA access

### DIFF
--- a/sql/moz-fx-data-shared-prod/customer_experience/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/customer_experience/dataset_metadata.yaml
@@ -12,3 +12,8 @@ workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
   - workgroup:mozilla-confidential/data-viewers
+# Scoped read-only access for the Customer Experience RAG service account.
+# https://mozilla-hub.atlassian.net/browse/DENG-11241
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:dataplatform/customer-experience-viewer


### PR DESCRIPTION
## Description

Adds a dataset-level `bigquery.dataViewer` grant for `workgroup:dataplatform/customer-experience-viewer` on customer_experience, scoping to read these views only. 

cc @lucia-vargas-a 

depends on https://github.com/mozilla/global-platform-admin/pull/6655

## Related Tickets & Documents
* DENG-11241

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
