### PR TITLE
feat(DENG-11222): add KB search success rate base table and view

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-06-16:
+  start_date: 2024-04-10
+  end_date: 2026-06-15
+  reason: Initial backfill to populate ga4_search_success_sessions_base_v1 (DENG-11222).
+  watchers:
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: true
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/metadata.yaml
@@ -1,0 +1,34 @@
+friendly_name: GA4 Search Success Sessions (Base)
+description: |
+  Session-level KB search success signals for Mozilla Support (SUMO), derived
+  from GA4 events.
+
+  Grain: Search session (user_pseudo_id x ga_session_id) x day
+
+  A search session is any GA4 session containing a `search` event. A search is
+  considered "successful" when the same session also views a KB article
+  (content_group = 'kb-article') AFTER a search event:
+  - is_successful_search: any KB view after a search in the session
+  - is_successful_search_1min / _2min: KB view within 60 / 120 seconds of the
+    closest preceding search event
+
+  search_locale is taken from the session's first search event.
+
+  Used by:
+  - sumo_search_success_kpis (daily search success rate + moving averages)
+owners:
+  - phlee@mozilla.com
+  - mozilla/customer_experience
+labels:
+  incremental: true
+  application: sumo
+  type: base_metrics
+  schedule: daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: session_date
+    require_partition_filter: false
+scheduling:
+  dag_name: bqetl_sumo_metrics
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/query.sql
@@ -1,0 +1,114 @@
+-- Session-level KB search success signals for SUMO, derived from GA4 events.
+--
+-- Search success = a KB-article view that happens AFTER a `search` event within
+-- the same GA4 session (user_pseudo_id x ga_session_id). The `_1min` / `_2min`
+-- flags additionally require the KB view to land within 60 / 120 seconds of the
+-- closest preceding search event.
+--
+-- Grain: search session (user_pseudo_id x ga_session_id) x day.
+-- Incremental: one submission_date partition per run.
+WITH search_events AS (
+  SELECT
+    user_pseudo_id,
+    event_timestamp,
+    (
+      SELECT
+        ep.value.int_value
+      FROM
+        UNNEST(event_params) AS ep
+      WHERE
+        ep.key = 'ga_session_id'
+    ) AS ga_session_id,
+    (
+      SELECT
+        ep.value.string_value
+      FROM
+        UNNEST(event_params) AS ep
+      WHERE
+        ep.key = 'locale'
+    ) AS search_locale
+  FROM
+    `mozdata.sumo_ga.ga4_events`
+  WHERE
+    submission_date = @submission_date
+    AND event_name = 'search'
+),
+-- One row per search session, with the locale of its first search event.
+search_sessions AS (
+  SELECT
+    user_pseudo_id,
+    ga_session_id,
+    ARRAY_AGG(search_locale ORDER BY event_timestamp LIMIT 1)[OFFSET(0)] AS search_locale
+  FROM
+    search_events
+  WHERE
+    ga_session_id IS NOT NULL
+  GROUP BY
+    user_pseudo_id,
+    ga_session_id
+),
+-- KB-article engagement events, carrying their session id.
+kb_article_events AS (
+  SELECT
+    user_pseudo_id,
+    event_timestamp,
+    (
+      SELECT
+        ep.value.int_value
+      FROM
+        UNNEST(event_params) AS ep
+      WHERE
+        ep.key = 'ga_session_id'
+    ) AS ga_session_id
+  FROM
+    `mozdata.sumo_ga.ga4_events`
+  WHERE
+    submission_date = @submission_date
+    AND event_name = 'user_engagement'
+    AND EXISTS (
+      SELECT
+        1
+      FROM
+        UNNEST(event_params) AS ep
+      WHERE
+        ep.key = 'content_group'
+        AND ep.value.string_value = 'kb-article'
+    )
+),
+-- For each session, seconds from the closest preceding search to a KB view.
+kb_events_after_search AS (
+  SELECT
+    kb.user_pseudo_id,
+    kb.ga_session_id,
+    MIN(
+      TIMESTAMP_DIFF(
+        TIMESTAMP_MICROS(kb.event_timestamp),
+        TIMESTAMP_MICROS(se.event_timestamp),
+        SECOND
+      )
+    ) AS min_diff_in_seconds
+  FROM
+    kb_article_events kb
+  INNER JOIN
+    search_events se
+    ON kb.ga_session_id = se.ga_session_id
+    AND kb.user_pseudo_id = se.user_pseudo_id
+    AND kb.event_timestamp > se.event_timestamp
+  GROUP BY
+    kb.user_pseudo_id,
+    kb.ga_session_id
+)
+SELECT
+  @submission_date AS session_date,
+  s.search_locale,
+  s.user_pseudo_id,
+  s.ga_session_id,
+  IF(kb.ga_session_id IS NOT NULL, 1, 0) AS is_successful_search,
+  IF(kb.min_diff_in_seconds <= 60, 1, 0) AS is_successful_search_1min,
+  IF(kb.min_diff_in_seconds <= 120, 1, 0) AS is_successful_search_2min
+FROM
+  search_sessions s
+LEFT JOIN
+  kb_events_after_search kb
+  ON s.user_pseudo_id = kb.user_pseudo_id
+  AND s.ga_session_id = kb.ga_session_id

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/query.sql
@@ -38,7 +38,9 @@ search_sessions AS (
   SELECT
     user_pseudo_id,
     ga_session_id,
-    ARRAY_AGG(search_locale ORDER BY event_timestamp LIMIT 1)[OFFSET(0)] AS search_locale
+    ARRAY_AGG(search_locale IGNORE NULLS ORDER BY event_timestamp LIMIT 1)[
+      SAFE_OFFSET(0)
+    ] AS search_locale
   FROM
     search_events
   WHERE

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/schema.yaml
@@ -1,0 +1,29 @@
+fields:
+- name: session_date
+  type: DATE
+  mode: NULLABLE
+  description: Submission date of the GA4 events that make up the search session
+- name: search_locale
+  type: STRING
+  mode: NULLABLE
+  description: Locale of the session's first search event (GA4 `locale` event param)
+- name: user_pseudo_id
+  type: STRING
+  mode: NULLABLE
+  description: GA4 pseudonymous user identifier
+- name: ga_session_id
+  type: INTEGER
+  mode: NULLABLE
+  description: GA4 session identifier (unique per user_pseudo_id)
+- name: is_successful_search
+  type: INTEGER
+  mode: NULLABLE
+  description: 1 if the session viewed a KB article after a search event, else 0
+- name: is_successful_search_1min
+  type: INTEGER
+  mode: NULLABLE
+  description: 1 if a KB view landed within 60 seconds of the closest preceding search, else 0
+- name: is_successful_search_2min
+  type: INTEGER
+  mode: NULLABLE
+  description: 1 if a KB view landed within 120 seconds of the closest preceding search, else 0

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_search_success_kpis/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_search_success_kpis/metadata.yaml
@@ -1,0 +1,11 @@
+friendly_name: SUMO KB Search Success Rate KPIs
+description: >
+  Daily knowledge base search success rate (SSR) KPIs for SUMO, broken down by
+  search locale. SSR is the share of search sessions that go on to view a KB
+  article; the `_1min` / `_2min` variants tighten that to KB views within 60 /
+  120 seconds of a search. Also exposes an overall (all-locale) day-level 14-day
+  moving average and its 14-day-lagged comparison. Built on
+  ga4_search_success_sessions_base_v1.
+owners:
+  - phlee@mozilla.com
+  - mozilla/customer_experience

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_search_success_kpis/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_search_success_kpis/view.sql
@@ -1,0 +1,80 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.sumo_metrics_derived.sumo_search_success_kpis`
+AS
+-- Daily KB search success rate (SSR) for SUMO, by search locale, plus an
+-- overall day-level 14-day moving average and its 14-day-lagged comparison.
+-- Built from the session-grain base table so the success definition lives in
+-- one place.
+WITH daily_search_success_counts AS (
+  SELECT
+    session_date,
+    search_locale,
+    COUNT(DISTINCT CONCAT(user_pseudo_id, '-', CAST(ga_session_id AS STRING))) AS search_sessions,
+    COUNT(
+      DISTINCT IF(
+        is_successful_search = 1,
+        CONCAT(user_pseudo_id, '-', CAST(ga_session_id AS STRING)),
+        NULL
+      )
+    ) AS successful_search_sessions,
+    COUNT(
+      DISTINCT IF(
+        is_successful_search_1min = 1,
+        CONCAT(user_pseudo_id, '-', CAST(ga_session_id AS STRING)),
+        NULL
+      )
+    ) AS successful_search_sessions_1min,
+    COUNT(
+      DISTINCT IF(
+        is_successful_search_2min = 1,
+        CONCAT(user_pseudo_id, '-', CAST(ga_session_id AS STRING)),
+        NULL
+      )
+    ) AS successful_search_sessions_2min
+  FROM
+    `moz-fx-data-shared-prod.sumo_metrics_derived.ga4_search_success_sessions_base_v1`
+  GROUP BY
+    session_date,
+    search_locale
+),
+-- Overall (all-locale) daily SSR with a 14-day moving average and lag.
+day_level AS (
+  SELECT
+    *,
+    LAG(total_ssr_14_ma, 14) OVER (ORDER BY session_date) AS lagged_total_ssr_14_ma
+  FROM
+    (
+      SELECT
+        *,
+        AVG(total_ssr) OVER (
+          ORDER BY
+            session_date
+          ROWS BETWEEN
+            13 PRECEDING
+            AND CURRENT ROW
+        ) AS total_ssr_14_ma
+      FROM
+        (
+          SELECT
+            session_date,
+            SUM(successful_search_sessions) AS total_successful_search_sessions,
+            SUM(search_sessions) AS total_search_sessions,
+            SAFE_DIVIDE(SUM(successful_search_sessions), SUM(search_sessions)) AS total_ssr
+          FROM
+            daily_search_success_counts
+          GROUP BY
+            session_date
+        )
+    )
+)
+SELECT
+  c.*,
+  SAFE_DIVIDE(c.successful_search_sessions, c.search_sessions) AS ssr,
+  SAFE_DIVIDE(c.successful_search_sessions_1min, c.search_sessions) AS ssr_1min,
+  SAFE_DIVIDE(c.successful_search_sessions_2min, c.search_sessions) AS ssr_2min,
+  d.* EXCEPT (session_date)
+FROM
+  daily_search_success_counts c
+LEFT JOIN
+  day_level d
+  ON c.session_date = d.session_date


### PR DESCRIPTION
## Description

Splits the SUMO KB search-success-rate dashboard query into the base-table +
view pattern used across `sumo_metrics_derived`.

- **`ga4_search_success_sessions_base_v1`** — session-grain base table
  (incremental daily, partitioned by `session_date`). Does the heavy GA4 ETL:
  identifies search sessions and flags those that lead to a KB-article view
  (`is_successful_search`, `_1min`, `_2min`).
- **`sumo_search_success_kpis`** — view that aggregates the base table into the
  daily search success rate (SSR) by `search_locale`, plus the overall 14-day
  moving average and 14-day-lagged comparison.

Validated against the original dashboard query `search-success-rate.sql` over a 14-day
window: identical row counts and **0 flag-disagreement rows**. Details on
[DENG-11222](https://mozilla-hub.atlassian.net/browse/DENG-11222).


## Related Tickets & Documents
* DENG-11222


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-11222]: https://mozilla-hub.atlassian.net/browse/DENG-11222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ