### PR TITLE
Add ESR version gates to norm.is_mozillaonline UDF

### DIFF
--- a/sql/mozfun/norm/is_mozillaonline/metadata.yaml
+++ b/sql/mozfun/norm/is_mozillaonline/metadata.yaml
@@ -5,9 +5,12 @@ description: |
   on distribution_id and app_version.
 
   A client is considered MozillaOnline if distribution_id is 'MozillaOnline'
-  (case-insensitive) and app_version is prior to 151.0.3, which is when the
-  MozillaOnline migration shipped (June 2, 2026). Users on 151.0.3+ are
-  post-migration canonical Firefox users and return FALSE.
+  (case-insensitive) and app_version is below the migration threshold for
+  its channel. Migration thresholds: release 151.0.3 (June 2, 2026),
+  ESR 140: 140.12.0 (June 16, 2026), ESR 115: 115.37.0 (June 16, 2026).
+  Users at or above these versions are post-migration canonical Firefox
+  users and return FALSE. Release and ESR versions are disambiguated by
+  minor version (release never exceeded 140.0.4 or 115.0.3).
 
   Returns FALSE if distribution_id or app_version is NULL or if distribution_id
   is not 'MozillaOnline'. Returns TRUE if distribution_id is 'MozillaOnline'

--- a/sql/mozfun/norm/is_mozillaonline/udf.sql
+++ b/sql/mozfun/norm/is_mozillaonline/udf.sql
@@ -1,8 +1,7 @@
 CREATE OR REPLACE FUNCTION norm.is_mozillaonline(distribution_id STRING, app_version STRING)
 RETURNS BOOL AS (
-  -- MozillaOnline migration shipped in 151.0.3 (June 2, 2026).
-  -- Users on 151.0.3+ reporting distribution_id = 'MozillaOnline' are
-  -- post-migration canonical Firefox users; treat them as non-MozillaOnline.
+  -- MozillaOnline migration thresholds: release 151.0.3, ESR 140: 140.12.0, ESR 115: 115.37.0.
+  -- Users at or above these versions are post-migration; treat as non-MozillaOnline.
   CASE
     WHEN distribution_id IS NULL
       OR app_version IS NULL
@@ -12,12 +11,29 @@ RETURNS BOOL AS (
     ELSE IFNULL(
         (
           SELECT
-            v.major_version < 151
-            OR (
-              v.major_version = 151
-              AND v.minor_version = 0
-              AND (v.patch_revision < 3 OR v.patch_revision IS NULL)
-            )
+            CASE
+              -- Malformed version: fall through to IFNULL → TRUE
+              WHEN v.major_version IS NULL
+                THEN NULL
+              -- ESR 115 migration: 115.37.0+ (release 115 topped at 115.0.3)
+              WHEN v.major_version = 115
+                AND v.minor_version >= 37
+                THEN FALSE
+              -- ESR 140 migration: 140.12.0+ (release 140 topped at 140.0.4)
+              WHEN v.major_version = 140
+                AND v.minor_version >= 12
+                THEN FALSE
+              -- Pre-release-migration: all versions below 151
+              WHEN v.major_version < 151
+                THEN TRUE
+              -- Release migration boundary: 151.0.0–151.0.2 are pre-migration
+              WHEN v.major_version = 151
+                AND v.minor_version = 0
+                AND (v.patch_revision < 3 OR v.patch_revision IS NULL)
+                THEN TRUE
+              -- 151.0.3+: post-migration
+              ELSE FALSE
+            END
           FROM
             UNNEST([norm.browser_version_info(app_version)]) AS v
         ),
@@ -38,6 +54,22 @@ SELECT
   assert.true(norm.is_mozillaonline('MozillaOnline', '151.0')),
   -- Minor version bump (151.1): FALSE (post-migration)
   assert.false(norm.is_mozillaonline('MozillaOnline', '151.1')),
+  -- ESR 115 at migration version: FALSE
+  assert.false(norm.is_mozillaonline('MozillaOnline', '115.37.0')),
+  -- ESR 115 pre-migration: TRUE
+  assert.true(norm.is_mozillaonline('MozillaOnline', '115.36.0')),
+  -- ESR 115 post-migration: FALSE
+  assert.false(norm.is_mozillaonline('MozillaOnline', '115.38.0')),
+  -- ESR 140 at migration version: FALSE
+  assert.false(norm.is_mozillaonline('MozillaOnline', '140.12.0')),
+  -- ESR 140 pre-migration: TRUE
+  assert.true(norm.is_mozillaonline('MozillaOnline', '140.11.0')),
+  -- ESR 140 post-migration: FALSE
+  assert.false(norm.is_mozillaonline('MozillaOnline', '140.13.0')),
+  -- Release 115 (not ESR): TRUE
+  assert.true(norm.is_mozillaonline('MozillaOnline', '115.0.3')),
+  -- Release 140 (not ESR): TRUE
+  assert.true(norm.is_mozillaonline('MozillaOnline', '140.0.4')),
   -- Well before migration: TRUE
   assert.true(norm.is_mozillaonline('MozillaOnline', '115.0')),
   -- Case-insensitive distribution_id: TRUE


### PR DESCRIPTION
## Summary
- Updated `mozfun.norm.is_mozillaonline` to add ESR migration thresholds: ESR 115 at 115.37.0 and ESR 140 at 140.12.0. Clients at or above these versions are classified as post-migration canonical Firefox users.
- No changes to the `desktop_active_users` view — the UDF update propagates automatically.

## Background
The MozillaOnline migration that shipped for release Firefox in 151.0.3 (June 2, 2026) also shipped for ESR channels on June 16, 2026: ESR 115 at 115.37.0 and ESR 140 at 140.12.0. Without updating the UDF, these ESR clients would continue to be classified as MozillaOnline after the migration, since their major versions (115, 140) fall below the existing < 151 gate.

ESR and release versions can be disambiguated by minor version alone. Release Firefox 115 topped out at 115.0.3 and release 140 at 140.0.4, while ESR increments the minor version for each dot release (115.1, 115.2, ..., 115.37). Any client reporting minor >= 37 on major 115 or minor >= 12 on major 140 is on the ESR track.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**