### PR TITLE
Bug 2034599 - Backfill glean_per_metric_logical_bytes_stored_v1 (last 90 days)

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/glean_per_metric_logical_bytes_stored_v1/backfill.yaml
@@ -1,0 +1,12 @@
+2026-06-15:
+  start_date: 2026-03-17
+  end_date: 2026-06-14
+  reason: Backfill last 90 days of per-metric logical bytes for the telemetry cost
+    projection framework.
+  watchers:
+  - tlong@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

Backfill 90 days of data into glean_per_metric_logical_bytes_stored_v1 for dashboard validation and prototyping

## Related Tickets & Documents
* Bug 2034599

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
