### PR TITLE
feat(glam): support labeled_memory_distribution

### DIFF
--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -54,6 +54,7 @@ def get_distribution_metrics(
         "custom_distribution",
         "labeled_timing_distribution",
         "labeled_custom_distribution",
+        "labeled_memory_distribution",
     }
     metrics: Dict[str, List[str]] = {metric_type: [] for metric_type in metric_type_set}
     excluded_metrics = get_etl_excluded_probes_quickfix("fenix")


### PR DESCRIPTION
## Description

Adds support to `labeled_memory_distribution` to GLAM ETL.
Tested that the new type shows up in the `daily` query. 

## Related Tickets & Documents
* DENG-10968

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
