### PR TITLE
chore(DENG-11222): Complete Backfill for ga4_search_success_sessions_base_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/ga4_search_success_sessions_base_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: Initial backfill to populate ga4_search_success_sessions_base_v1 (DENG-11222).
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: true
   override_depends_on_past_end_date: false


### PR DESCRIPTION
## Description

This PR completes the backfill for `ga4_search_success_sessions_base_v1` from this PR: https://github.com/mozilla/bigquery-etl/pull/9585. The backfill staging table: `moz-fx-data-shared-prod.backfills_staging_derived.sumo_metrics_derived__ga4_search_success_sessions_base_v1_2026_06_16` has been validated and shows dates from `2024-04-10` to `2026-6-15` as expected.

## Related Tickets & Documents
* DENG-11222

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
