### PR TITLE
chore: move firefox install to final run command installing dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,8 @@ RUN mkdir -p /usr/share/man/man1 && apt-get update -qqy && apt-get install -qqy 
 COPY --from=google-cloud-sdk /google-cloud-sdk /google-cloud-sdk
 ENV PATH /google-cloud-sdk/bin:$PATH
 COPY --from=python-deps /usr/local /usr/local
-# some jobs require a browser to be installed
-RUN playwright install --with-deps firefox
 COPY .bigqueryrc /root/
 COPY . .
-RUN pip install .
+RUN pip install . \
+  && python -m playwright install --with-deps firefox  # some jobs require a browser to be installed
 ENTRYPOINT ["/app/script/entrypoint"]


### PR DESCRIPTION
# chore: move firefox install to final run command installing dependencies

It seems now when building the image firefox does not always get installed as intended. Moving the install command to the final run command installing dependencies. Locally this seems to be working more consistently now.