### PR TITLE
chore(schema): add base schema for telemetry_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -1891,3 +1891,193 @@ fields:
   description: The minor version number of the Windows Service Pack installed on the client. This is almost always 0, with null indicating the
     value was unavailable, typically for non-Windows platforms.
   type: INT64
+- name: os_version
+  description: The full version string of the operating system on which the browser is running (e.g., '10.0', '13.5.1'). Combines major, minor,
+    and patch components into a single human-readable string.
+- name: os_version_major
+  description: The major version number component of the operating system. For example, a value of 10 corresponds to Windows 10 or macOS 10.x,
+    while values like 13–16 correspond to major iOS/macOS releases.
+  type: INT64
+- name: os_version_minor
+  description: The minor version number component of the operating system, representing the second numeric segment of the full OS version string.
+    A value of 0 is by far the most common, indicating that most clients are on a base major release with no minor increment.
+  type: INT64
+- name: osversion
+  description: The operating system version as reported in an alternate or legacy telemetry field, typically expressed as a short version string
+    (e.g., '28', '26.5'). May differ in format from os_version depending on the ping source or platform.
+  type: STRING
+- name: partner_distribution_version
+  description: The version of the partner distribution package used to install or configure the browser. Null when the client is not associated
+    with a partner distribution.
+  type: STRING
+- name: partner_distributor
+  description: The name of the organization or Linux distribution that packaged and distributed the browser (e.g., 'canonical', 'mint', 'fedora').
+    Null for clients that installed Firefox through standard Mozilla channels.
+  type: STRING
+- name: partner_distributor_channel
+  description: The specific distribution channel or sub-product variant used by the partner distributor (e.g., 'ubuntu', 'esrWinFull'). Null or
+    empty when the client did not arrive through a named partner channel.
+  type: STRING
+- name: partner_id
+  description: A short identifier for the top-level partner organization associated with the browser installation (e.g., 'ubuntu', 'mozillaonline',
+    'yandex'). Null when the client has no partner affiliation.
+  type: STRING
+- name: partner_org
+  description: A human-readable label categorizing the browser's distribution partner into a broader organizational group (e.g., 'Linux - Canonical',
+    'Mozilla - China', 'non-distribution'). Used to segment clients by distribution partnership type.
+  type: STRING
+- name: payload_crashDate
+  description: The calendar date on which the crash occurred, as reported in the crash ping payload. Formatted as a date string (e.g., 'YYYY-MM-DD').
+- name: payload_crashTime
+  description: The timestamp at which the crash occurred, as reported in the crash ping payload. Typically expressed as a Unix epoch time string
+    or formatted time value.
+- name: payload_hasCrashEnvironment
+  description: Indicates whether the crash ping payload includes a populated environment block. True means environment metadata (e.g., build,
+    system info) was captured alongside the crash report; false means it was absent.
+- name: payload_metadata_key_value
+  description: A repeated array of key-value struct pairs containing arbitrary metadata fields from the crash ping payload. Each entry represents
+    one metadata annotation submitted with the crash report.
+- name: payload_processType
+  description: The type of browser process that experienced the crash, as reported in the crash ping payload (e.g., 'main', 'content', 'gpu').
+    Used to distinguish crashes across different Firefox process architectures.
+- name: payload_version
+  description: The schema version number of the crash ping payload. Used to identify which version of the payload format was used when the ping
+    was submitted.
+- name: pct_users_profile_age_8_to_365_days
+  description: The proportion of users in the cohort whose Firefox profile age falls between 8 and 365 days at the time of measurement. Expressed
+    as a decimal fraction between 0 and 1.
+  type: FLOAT64
+- name: pct_users_profile_age_less_than_7_days
+  description: The proportion of users in the cohort whose Firefox profile age is fewer than 7 days at the time of measurement, representing relatively
+    new profiles. Expressed as a decimal fraction between 0 and 1.
+  type: FLOAT64
+- name: pct_users_profile_age_over_365_days
+  description: The proportion of users in the cohort whose Firefox profile age exceeds 365 days at the time of measurement, representing long-tenured
+    profiles. Expressed as a decimal fraction between 0 and 1.
+  type: FLOAT64
+- name: ping_sent_metric_date
+  description: Indicates whether a telemetry ping was sent on the metric reference date. True means a ping was successfully submitted for that
+    date; null indicates the data is unavailable or the client was inactive.
+- name: ping_sent_week_4
+  description: Indicates whether a telemetry ping was sent during week 4 of the measurement window. True means the client was active and submitted
+    a ping in that week; false means no ping was received.
+- name: pings_aggregated_by_this_row
+  description: The number of individual telemetry pings that were collapsed into this single aggregated row. Higher values indicate that multiple
+    pings from the same client were merged during aggregation.
+  type: INT64
+- name: placement
+  description: The named slot or location within the Firefox New Tab page where a sponsored or editorial content item was displayed (e.g., 'newtab_spocs',
+    'newtab_stories_1'). Null when no placement is associated with the event.
+  type: STRING
+- name: places_bookmarks_count_mean
+  description: The mean number of bookmarks stored in the user's Places database, averaged over the reporting period. Null when bookmark count
+    data was not available for the client.
+  type: FLOAT64
+- name: places_bookmarks_searchbar_cumulative_searches_sum
+  description: The cumulative total number of searches performed via the bookmarks search bar within the Places library, summed over the reporting
+    period. Null when this interaction was not recorded for the client.
+  type: INT64
+- name: places_library_cumulative_bookmark_searches_sum
+  description: The cumulative total number of bookmark searches performed within the Places library panel, summed over the reporting period. Null
+    when this activity was not recorded for the client.
+  type: INT64
+- name: places_library_cumulative_history_searches_sum
+  description: The cumulative total number of history searches performed within the Places library panel, summed over the reporting period. Null
+    when this activity was not recorded for the client.
+  type: INT64
+- name: places_pages_count_mean
+  description: The mean number of pages stored in the user's browsing history (Places database), averaged over the reporting period. Null when
+    page count data was not available for the client.
+  type: FLOAT64
+- name: places_previousday_visits_mean
+  description: The mean number of page visits recorded in the Places database on the previous day, averaged across days in the reporting period.
+    A value of 0 indicates the user had no recorded visits on the prior day.
+  type: FLOAT64
+- name: places_searchbar_cumulative_filter_count_sum
+  description: The cumulative total number of filter operations applied via the Places search bar, summed over the reporting period. Null when
+    this interaction was not recorded for the client.
+  type: INT64
+- name: places_searchbar_cumulative_searches_sum
+  description: The cumulative total number of searches performed via the Places search bar, summed over the reporting period. Null when this interaction
+    was not recorded for the client.
+  type: INT64
+- name: platform_version
+  description: The version of the browser platform or Gecko engine as reported in telemetry (e.g., '151.0.3'). May differ from the user-facing
+    product version and is used to identify the underlying platform build.
+  type: STRING
+- name: play_store_attribution_campaign
+  description: The UTM campaign name associated with the Google Play Store install referral, identifying the marketing campaign that drove the
+    app installation (e.g., 'firefox-desktop', 'mozilla-org'). Null when no campaign attribution is available.
+  type: STRING
+- name: play_store_attribution_content
+  description: The UTM content parameter from the Google Play Store install referral, used to identify the specific creative or UI element that
+    drove the installation (e.g., 'onboarding-modal', 'firefoxview'). Null when content attribution is unavailable.
+  type: STRING
+- name: play_store_attribution_install_referrer_response
+  description: The raw install referrer string returned by the Google Play Store at the time of installation, containing UTM and other attribution
+    parameters as a URL-encoded query string. Null when no referrer response was captured.
+  type: STRING
+- name: play_store_attribution_medium
+  description: The UTM medium parameter from the Google Play Store install referral, identifying the marketing channel (e.g., 'organic', 'paid').
+    Currently null across all records, indicating this attribution dimension is not yet populated.
+  type: STRING
+- name: play_store_attribution_source
+  description: The UTM source parameter from the Google Play Store install referral, identifying the traffic origin that led to the app installation
+    (e.g., 'google-play', 'google', 'eea-browser-choice'). Null when source attribution is unavailable.
+  type: STRING
+- name: play_store_attribution_term
+  description: The UTM term parameter from the Google Play Store install referral, typically capturing the search keyword that led to the app
+    installation (e.g., 'firefox', 'mozilla firefox'). Null when keyword attribution is unavailable.
+  type: STRING
+- name: play_time_ratio
+  description: The ratio of active play or media engagement time relative to total session time, expressed as a decimal. Values greater than 1
+    are possible and may indicate measurement anomalies or extended background playback.
+  type: FLOAT64
+- name: plugin_hangs_sum
+  description: The total number of plugin hang events recorded during the reporting period. Null when no plugin hang data was reported, which
+    is common as plugin usage has become rare in modern Firefox.
+  type: INT64
+- name: plugins_infobar_allow_sum
+  description: The total number of times the user clicked 'Allow' on a plugin activation infobar during the reporting period. Null across all
+    records, reflecting the deprecation of NPAPI plugin support in Firefox.
+  type: INT64
+- name: plugins_infobar_block_sum
+  description: The total number of times the user clicked 'Block' on a plugin activation infobar during the reporting period. Null across all
+    records, reflecting the deprecation of NPAPI plugin support in Firefox.
+  type: INT64
+- name: plugins_infobar_shown_sum
+  description: The total number of times a plugin activation infobar was displayed to the user during the reporting period. Null when no infobar
+    events were recorded, consistent with the deprecation of legacy plugin support.
+  type: INT64
+- name: plugins_notification_shown_sum
+  description: The total number of times a plugin-related notification was shown to the user during the reporting period. Null when no such notifications
+    were recorded, consistent with the near-complete removal of plugin support.
+  type: INT64
+- name: pocket_clicks
+  description: The total number of times the user clicked on a Pocket recommendation on the New Tab page during the reporting period. A value
+    of 0 indicates the feature was visible but no clicks occurred.
+  type: INT64
+- name: pocket_enabled
+  description: Indicates whether the Pocket integration is enabled in the user's Firefox New Tab page settings. True means Pocket content is turned
+    on; false means it has been disabled by the user.
+  type: BOOLEAN
+- name: pocket_impressions
+  description: The total number of Pocket story impressions recorded on the New Tab page during the reporting period. An impression is counted
+    each time a Pocket recommendation is rendered and visible to the user.
+  type: INT64
+- name: pocket_is_signed_in
+  description: Indicates whether the user is signed in to their Pocket account within Firefox. True means the user is authenticated; false means
+    Pocket is present but the user is not signed in. Null when sign-in state could not be determined.
+  type: BOOLEAN
+- name: pocket_saves
+  description: The total number of items the user saved to Pocket from the New Tab page during the reporting period. A value of 0 indicates no
+    saves occurred.
+  type: INT64
+- name: pocket_sponsored_stories_enabled
+  description: Indicates whether sponsored story recommendations from Pocket are enabled on the user's New Tab page. True means sponsored stories
+    are turned on; false means they have been disabled.
+  type: BOOLEAN
+- name: pocket_story_position
+  description: The zero-based index position of a Pocket story within the New Tab page recommendation grid at the time of the event. Null when
+    no specific story position is associated with the record.
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -945,3 +945,194 @@ fields:
 - name: event_map_values_key
   description: The key component of a key-value pair within the event_map_values array, identifying a specific metadata attribute associated with
     a telemetry event (e.g., 'source', 'trigger', 'networkID'). Keys are used to look up corresponding values in the event's extra metadata.
+- name: event_map_values_value
+  description: The value component of a key-value pair within an event's map of extra attributes. Common values include boolean strings (e.g.
+    'false'), numeric strings, 'unavailable', or empty strings, depending on the attribute being recorded.
+- name: event_method
+  description: The method or action that triggered the event, describing what occurred (e.g. 'detected', 'submitted', 'show'). This categorizes
+    the type of interaction or lifecycle step associated with the event.
+  type: STRING
+- name: event_object
+  description: The UI element or component that was the target of the event (e.g. 'address_form', 'cc_form_v2', 'capture_doorhanger'). This identifies
+    which part of the product the event is associated with.
+  type: STRING
+- name: event_process
+  description: The Firefox process type in which the event was recorded (e.g. 'parent', 'content', 'extension', 'dynamic'). This indicates the
+    browser process context from which the event originated.
+  type: STRING
+- name: event_properties
+  description: An array of structured key-value properties associated with an event, where each value may itself be an array of sub-properties
+    with an ordering index. This captures additional metadata dimensions attached to a single event record.
+  type: RECORD
+- name: event_properties_index
+  description: The positional index of a property entry within the event_properties array, used to preserve or reconstruct ordering of nested
+    property items. Values start at 1 and increase sequentially.
+- name: event_properties_key
+  description: The key name of a property within the event_properties array, identifying the dimension or attribute being described (e.g. 'os',
+    'source', 'session_id', 'reason'). Each key is paired with a corresponding value in the same property struct.
+- name: event_string_value
+  description: An optional free-text string value associated with an event, providing additional context such as an error code or identifier (e.g.
+    'SSL_ERROR_BAD_CERT_DOMAIN'). This field may be null or contain the literal string 'null' when no value is applicable.
+  type: STRING
+- name: event_timestamp
+  description: The time offset in milliseconds from the start of the browser session at which the event occurred. This is a relative timestamp,
+    not an absolute wall-clock time.
+  type: INT64
+- name: events
+  description: A serialized or structured representation of one or more browser events recorded in the telemetry payload. This field serves as
+    a container for event data associated with a given submission.
+- name: experiment
+  description: The slug or identifier of a Nimbus or Normandy experiment the client was enrolled in at the time of the ping. This field is null
+    when the client was not enrolled in any experiment.
+  type: STRING
+- name: experiment_branch
+  description: The branch of an experiment that the client was assigned to (e.g. 'control', 'treatment'). This identifies which variant of the
+    experiment the client experienced.
+  type: STRING
+- name: experiment_id
+  description: The unique identifier for a specific experiment or study the client participated in (e.g. 'daily-briefing-v1', 'e10sCohort'). This
+    is used to join enrollment data across tables.
+  type: STRING
+- name: experiments
+  description: An array of key-value pairs representing all active experiment enrollments for the client at the time of the ping, where the key
+    is the experiment slug and the value is the assigned branch. This captures the full set of concurrent experiment enrollments.
+- name: experiments_key
+  description: The slug or unique identifier of an experiment the client is enrolled in, used as the key in the experiments map (e.g. 'fx-accounts-ping-release-rollout-2').
+    This corresponds to the experiment's canonical name in Nimbus or Normandy.
+- name: experiments_key_value
+  description: A nested array of key-value pairs associated with an experiment entry, capturing additional structured metadata beyond the branch
+    assignment. This may be empty when no extra metadata is available.
+- name: experiments_value
+  description: The branch name assigned to the client for a given experiment enrollment (e.g. 'control', 'treatment-a', 'rollout-branch'). This
+    is the value component of the experiments map keyed by experiment slug.
+- name: experiments_value_branch
+  description: The branch of an experiment that the client was assigned to, stored as a nested field within the experiments value struct (e.g.
+    'control', 'treatment-a', 'rollout-branch'). This is the primary field used to segment clients by experimental condition.
+- name: experiments_value_enrollment_id
+  description: A unique identifier for the client's specific enrollment instance in an experiment, allowing individual enrollment events to be
+    tracked. This field is null for the vast majority of records and '__NO_ENROLLMENT_ID__' when an enrollment ID was expected but not available.
+- name: experiments_value_extra_enrollment_id
+  description: An additional enrollment ID associated with an experiment entry, capturing a secondary or supplementary enrollment identifier for
+    the client. This field is almost always null and is populated only for a small subset of enrollments.
+- name: experiments_value_extra_type
+  description: The type classification of an experiment from an extra or secondary enrollment record, indicating whether it is a Nimbus rollout
+    or a standard Nimbus experiment (e.g. 'nimbus-rollout', 'nimbus-nimbus'). This mirrors the primary type field for supplemental enrollment
+    entries.
+- name: experiments_value_type
+  description: The type or system classification of the experiment enrollment (e.g. 'nimbus-rollout', 'nimbus-nimbus', 'normandy-prefrollout',
+    'normandy-exp'). This identifies the experimentation platform and delivery mechanism that managed the enrollment.
+- name: exposure_count
+  description: The number of times the client was exposed to an experiment treatment during the observation period. A value of 0 indicates the
+    client was enrolled but not yet exposed.
+  type: INT64
+- name: extra_regressors_additive
+  description: The additive contribution of extra regressors (e.g. external signals or covariates) to a time-series forecast model. A value of
+    0.0 indicates no additive regressor effect was applied.
+  type: FLOAT64
+- name: extra_regressors_additive_lower
+  description: The lower bound of the additive extra regressors component from a time-series forecast model, representing the lower end of the
+    uncertainty interval for that contribution. A value of 0.0 indicates no lower-bound regressor effect.
+  type: FLOAT64
+- name: extra_regressors_additive_upper
+  description: The upper bound of the additive extra regressors component from a time-series forecast model, representing the upper end of the
+    uncertainty interval for that contribution. A value of 0.0 indicates no upper-bound regressor effect.
+  type: FLOAT64
+- name: fill_counts
+  description: The total number of form field fill events recorded in the aggregation period. This represents the volume of autofill or user-fill
+    interactions captured across the dataset.
+  type: INT64
+- name: first_bucket
+  description: The lower bound of the first bucket in a histogram, defining the minimum value range captured by the histogram's first bin. Different
+    histograms use different starting bucket sizes (e.g. 1, 50, 1024).
+  type: INT64
+- name: first_document_id
+  description: The document ID (UUID) of the first ping submitted by a client in the relevant period or cohort. This uniquely identifies the initial
+    telemetry submission associated with the record.
+  type: STRING
+- name: first_paint_mean
+  description: The mean time in milliseconds from browser start to first paint, averaged over the relevant aggregation period. A null value indicates
+    no first-paint timing data was available for the record.
+  type: FLOAT64
+- name: first_seen_date
+  description: The calendar date on which the client profile was first observed in telemetry data. This is used to determine client tenure and
+    cohort assignment.
+  type: DATE
+- name: first_seen_year
+  description: The calendar year in which the client profile was first observed in telemetry data, derived from the first_seen_date. This is used
+    for coarser cohort analyses and long-term retention reporting.
+  type: INT64
+- name: first_timestamp
+  description: The timestamp of the earliest event or ping recorded for the client within the relevant period. This field may be null when no
+    qualifying events were observed.
+  type: TIMESTAMP
+- name: flash_usage
+  description: The count of Flash plugin usage events recorded for the client. A value of 0 indicates Flash was present or configured but not
+    actively used during the session.
+  type: INT64
+- name: flash_version
+  description: The version string of the Adobe Flash plugin installed in the browser (e.g. '32.0.0.465'). This field is null when no Flash plugin
+    is detected or when version information is unavailable.
+  type: STRING
+- name: follow_on_search_ad_clicks
+  description: The number of times a user clicked on a search advertisement following an initial search query originating from the browser's search
+    features. A value of 0 indicates the user performed searches but did not click any follow-on ads.
+  type: INT64
+- name: follow_on_search_ad_impressions
+  description: The number of search advertisement impressions shown to the user as a result of follow-on searches initiated from the browser's
+    search features. A value of 0 indicates no ad impressions were recorded for the period.
+  type: INT64
+- name: forecast_date
+  description: The calendar date to which a forecast value corresponds, stored as a string in ISO 8601 format (YYYY-MM-DD). This is the predicted
+    future date within a time-series forecasting output.
+  type: STRING
+- name: forecast_parameters
+  description: A JSON-serialized string containing the model type and hyperparameters used to generate the forecast (e.g. Prophet model settings
+    such as seasonality and changepoint priors). This allows forecast results to be traced back to the exact model configuration that produced
+    them.
+  type: STRING
+- name: form_factor
+  description: The physical form factor of the device running Firefox (e.g. 'desktop', 'phone', 'tablet', 'other'). This field is null when the
+    form factor could not be determined from the telemetry payload.
+  type: STRING
+- name: funnel_date
+  description: The date associated with a funnel analysis snapshot, representing the point in time at which funnel stage counts were computed.
+    Stored as a DATE type.
+  type: DATE
+- name: funnel_derived
+  description: A categorical label describing the acquisition channel or funnel through which a user was obtained (e.g. 'mozorg windows funnel',
+    'mozorg mac funnel', 'partner', 'other'). This is used to segment users by how they came to install Firefox.
+  type: STRING
+- name: fxa_configured
+  description: Indicates whether the client has a Firefox Accounts (FxA) account configured at the time of the ping. True means FxA is set up;
+    false means it is not; null means the status was unknown or the field was not applicable.
+  type: BOOLEAN
+- name: geo_country_code
+  description: The ISO 3166-1 alpha-2 country code derived from the client's IP address at ping submission time. This represents the country-level
+    geographic location of the client.
+  type: STRING
+- name: geo_db_version
+  description: The version timestamp of the GeoIP database used to resolve the client's geographic location, formatted as an ISO 8601 datetime
+    string. This allows geo lookups to be audited and compared across database releases.
+  type: STRING
+- name: geo_subdivision1
+  description: The first-level administrative subdivision (e.g. state, province, or region) of the client's location, derived from the GeoIP database.
+    This field may be null when subdivision-level data is unavailable for the client's geography.
+  type: STRING
+- name: geo_subdivision2
+  description: The second-level administrative subdivision (e.g. county, department, or district) of the client's location, derived from the GeoIP
+    database. This field is null for the majority of records where fine-grained subdivision data is not available.
+  type: STRING
+- name: gfx_compositor
+  description: The graphics compositor backend used by Firefox (e.g. WebRender, OpenGL, or Direct3D) as reported in the client's telemetry environment.
+    This identifies the rendering pipeline active during the session.
+  type: STRING
+- name: gfx_features_advanced_layers_status
+  description: The status of the Advanced Layers graphics feature in Firefox, indicating whether it is available, disabled, blocked, or unavailable
+    on the client's hardware and software configuration. Blocked statuses often include a reason code explaining why the feature was prevented
+    from running.
+  type: STRING
+- name: gfx_features_d2d_status
+  description: The status of the Direct2D (D2D) hardware acceleration feature in Firefox, indicating whether it is available, disabled, blocked,
+    or unavailable on the client's system. Blocked or unavailable statuses typically include a reason code identifying the specific failure or
+    blocklist entry responsible.
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -369,3 +369,201 @@ fields:
   description: The unique identifier of the marketing campaign associated with a user's acquisition event, which may include platform-specific
     campaign codes (e.g., Google Ads or Facebook campaign IDs). Null when no campaign ID is available.
   type: STRING
+- name: category
+  description: A high-cardinality string label grouping the event or metric into a functional area or feature domain (e.g., 'devtools.main', 'doh',
+    'pwmgr'). May be null when no category classification applies to the record.
+  type: STRING
+- name: cdou
+  description: A numeric measure representing the client days of use, reflecting how many days a client has been active within a given period.
+    Higher values indicate more sustained engagement.
+  type: INT64
+- name: channel
+  description: The Firefox release channel through which the client received its build, such as 'release', 'beta', 'aurora', or 'esr'. Used to
+    segment data by product maturity and release train.
+- name: channel_raw
+  description: The raw marketing or traffic acquisition channel through which a user arrived (e.g., 'Organic Search', 'Referral', 'Paid Search',
+    'Direct'). May be null when the acquisition channel could not be determined.
+  type: STRING
+- name: city
+  description: The city associated with the client's IP address or profile geography at the time of the record. May be null when city-level geolocation
+    is unavailable or suppressed.
+  type: STRING
+- name: click_count
+  description: The total number of click interactions recorded for a given entity or surface within the reporting period. A value of zero indicates
+    the entity was present but received no clicks.
+  type: INT64
+- name: client_agg_type
+  description: Describes the aggregation method applied to client-level metric values, such as 'summed_histogram', 'count', 'avg', 'sum', 'min',
+    or 'max'. Determines how individual client observations were combined into the stored aggregate.
+  type: STRING
+- name: client_clock_skew_mean
+  description: The mean difference, in hours, between the client's local clock and the server-side reference time across submissions in the aggregation
+    window. Values near zero indicate accurate client clocks; positive or negative values indicate forward or backward skew, respectively.
+  type: FLOAT64
+- name: client_count
+  description: The number of distinct clients contributing to a given aggregated row or cohort. Useful for understanding the population size behind
+    any aggregated metric.
+  type: INT64
+- name: client_id
+  description: A UUID that uniquely identifies a Firefox client installation. Used to join and deduplicate records across tables at the individual
+    client level.
+  type: STRING
+- name: client_submission_latency_mean
+  description: The mean latency, in seconds, between when a ping was created on the client and when it was received by the ingestion pipeline.
+    Higher values indicate delayed or batched submissions from the client.
+  type: FLOAT64
+- name: clients
+  description: The total count of distinct clients represented in a summary or rollup row. Provides a high-level measure of the active population
+    for a given dimension combination.
+  type: INT64
+- name: cohort_date
+  description: The specific calendar date on which a client or user was first observed, defining their membership in a daily cohort. Used for
+    day-level retention and cohort analysis.
+  type: DATE
+- name: cohort_date_week
+  description: The Monday-aligned week start date of the week in which a client or user was first observed, defining their membership in a weekly
+    cohort. Used for week-level retention and longitudinal analysis.
+  type: DATE
+- name: content
+  description: A string representing the UTM content parameter or creative identifier associated with a marketing touchpoint or link. May be null
+    or URL-encoded when not explicitly set.
+  type: STRING
+- name: contextual_services_quicksuggest_block_dynamic_wikipedia_sum
+  description: An array of key-value pairs summing the number of times a dynamic Wikipedia Quick Suggest result was blocked by the user, keyed
+    by a relevant dimension such as match type or position. Each entry accumulates block counts across the aggregation window.
+  type: RECORD
+- name: contextual_services_quicksuggest_block_nonsponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of block events for non-sponsored best-match Quick Suggest results, keyed by a relevant
+    dimension. Reflects user opt-out signals for this suggestion type.
+  type: RECORD
+- name: contextual_services_quicksuggest_block_nonsponsored_sum
+  description: An array of key-value pairs summing the number of block events for non-sponsored Quick Suggest results, keyed by a relevant dimension.
+    Reflects how often users dismissed or blocked non-sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_block_sponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of block events for sponsored best-match Quick Suggest results, keyed by a relevant
+    dimension. Captures user opt-out interactions with high-prominence sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_block_sponsored_sum
+  description: An array of key-value pairs summing the number of block events for sponsored Quick Suggest results, keyed by a relevant dimension.
+    Reflects how often users dismissed or blocked sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_block_weather_sum
+  description: An array of key-value pairs summing the number of times a weather Quick Suggest result was blocked by the user, keyed by a relevant
+    dimension. Captures opt-out interactions with weather-type suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_click_dynamic_wikipedia_sum
+  description: An array of key-value pairs summing the number of click events on dynamic Wikipedia Quick Suggest results, keyed by a relevant
+    dimension. Measures user engagement with this suggestion type.
+  type: RECORD
+- name: contextual_services_quicksuggest_click_nonsponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of click events on non-sponsored best-match Quick Suggest results, keyed by a relevant
+    dimension. Measures user engagement with high-prominence non-sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_click_nonsponsored_sum
+  description: An array of key-value pairs summing the number of click events on non-sponsored Quick Suggest results, keyed by a relevant dimension.
+    Measures overall click-through engagement with non-sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_click_sponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of click events on sponsored best-match Quick Suggest results, keyed by a relevant
+    dimension. Measures user engagement with high-prominence sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_click_sponsored_sum
+  description: An array of key-value pairs summing the number of click events on sponsored Quick Suggest results, keyed by a relevant dimension.
+    Measures overall click-through engagement with sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_click_sum
+  description: An array of key-value pairs summing the total number of click events across all Quick Suggest result types, keyed by a relevant
+    dimension. Provides an aggregate view of user click engagement with the Quick Suggest feature.
+  type: RECORD
+- name: contextual_services_quicksuggest_click_weather_sum
+  description: An array of key-value pairs summing the number of click events on weather Quick Suggest results, keyed by a relevant dimension.
+    Measures user engagement with weather-type suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_help_dynamic_wikipedia_sum
+  description: An array of key-value pairs summing the number of times users clicked the help link on dynamic Wikipedia Quick Suggest results,
+    keyed by a relevant dimension. Indicates how often users sought more information about this suggestion type.
+  type: RECORD
+- name: contextual_services_quicksuggest_help_nonsponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of help-link interactions on non-sponsored best-match Quick Suggest results, keyed
+    by a relevant dimension. Reflects user curiosity or confusion about this suggestion type.
+  type: RECORD
+- name: contextual_services_quicksuggest_help_nonsponsored_sum
+  description: An array of key-value pairs summing the number of help-link interactions on non-sponsored Quick Suggest results, keyed by a relevant
+    dimension. Tracks how often users accessed help information for non-sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_help_sponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of help-link interactions on sponsored best-match Quick Suggest results, keyed by
+    a relevant dimension. Captures user requests for more information about high-prominence sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_help_sponsored_sum
+  description: An array of key-value pairs summing the number of help-link interactions on sponsored Quick Suggest results, keyed by a relevant
+    dimension. Tracks how often users accessed help information for sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_help_sum
+  description: An array of key-value pairs summing the total number of help-link interactions across all Quick Suggest result types, keyed by
+    a relevant dimension. Provides an aggregate view of user help-seeking behavior within the Quick Suggest feature.
+  type: RECORD
+- name: contextual_services_quicksuggest_help_weather_sum
+  description: An array of key-value pairs summing the number of help-link interactions on weather Quick Suggest results, keyed by a relevant
+    dimension. Captures user requests for more information about weather-type suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_impression_dynamic_wikipedia_sum
+  description: An array of key-value pairs summing the number of times dynamic Wikipedia Quick Suggest results were displayed to users, keyed
+    by a relevant dimension. Measures the reach and visibility of this suggestion type.
+  type: RECORD
+- name: contextual_services_quicksuggest_impression_nonsponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of impressions for non-sponsored best-match Quick Suggest results, keyed by a relevant
+    dimension. Measures how often this high-prominence suggestion type was shown to users.
+  type: RECORD
+- name: contextual_services_quicksuggest_impression_nonsponsored_sum
+  description: An array of key-value pairs summing the number of impressions for non-sponsored Quick Suggest results, keyed by a relevant dimension.
+    Measures the overall display frequency of non-sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_impression_sponsored_bestmatch_sum
+  description: An array of key-value pairs summing the number of impressions for sponsored best-match Quick Suggest results, keyed by a relevant
+    dimension. Measures how often this high-prominence sponsored suggestion type was shown to users.
+  type: RECORD
+- name: contextual_services_quicksuggest_impression_sponsored_sum
+  description: An array of key-value pairs summing the number of impressions for sponsored Quick Suggest results, keyed by a relevant dimension.
+    Measures the overall display frequency of sponsored suggestions.
+  type: RECORD
+- name: contextual_services_quicksuggest_impression_sum
+  description: An array of key-value pairs summing the total number of impressions across all Quick Suggest result types, keyed by a relevant
+    dimension. Provides an aggregate view of the overall reach of the Quick Suggest feature.
+  type: RECORD
+- name: contextual_services_quicksuggest_impression_weather_sum
+  description: An array of key-value pairs summing the number of impressions for weather Quick Suggest results, keyed by a relevant dimension.
+    Measures how often weather-type suggestions were displayed to users.
+  type: RECORD
+- name: contextual_services_topsites_click_sum
+  description: An array of key-value pairs summing the number of click events on Top Sites tiles in the new tab page, keyed by a relevant dimension
+    such as position or tile type. Measures user engagement with the Top Sites feature.
+  type: RECORD
+- name: contextual_services_topsites_impression_sum
+  description: An array of key-value pairs summing the number of impressions recorded for Top Sites tiles on the new tab page, keyed by a relevant
+    dimension. Measures the display frequency and reach of the Top Sites feature.
+  type: RECORD
+- name: corpus_item_id
+  description: A UUID that uniquely identifies a content item within the Pocket or Contextual Services corpus. Used to join engagement metrics
+    back to the canonical content catalog.
+  type: STRING
+- name: count
+  description: A generic integer count representing the number of occurrences of an event, observation, or entity within the scope of the row.
+    The specific thing being counted depends on the table context.
+  type: INT64
+- name: country
+  description: The ISO 3166-1 alpha-2 country code (e.g., 'US', 'DE', 'FR') derived from the client's IP address or profile geography. Used for
+    geographic segmentation of telemetry data.
+  type: STRING
+- name: country_code
+  description: The ISO 3166-1 alpha-2 country code (e.g., 'IN', 'US', 'RU') associated with the record. Equivalent in format to the `country`
+    field and used for geographic filtering and grouping.
+  type: STRING
+- name: country_name
+  description: The full human-readable name of the country associated with the record (e.g., 'United States', 'India', 'Brazil'). Provides a display-friendly
+    alternative to ISO country code fields.
+  type: STRING
+- name: cpu_cores
+  description: The number of logical CPU cores available on the client device as reported by the Firefox telemetry environment. Used to segment
+    performance and hardware capability data.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -2672,3 +2672,197 @@ fields:
   description: Keyed scalar aggregating the total number of searches triggered via tab history navigation (e.g., back/forward to a search results
     page). Each key identifies a search engine, and the value is the summed search count.
   type: RECORD
+- name: search_content_unknown_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of searches initiated from an unknown content
+    source. Each entry represents a distinct engine and its summed search volume.
+  type: RECORD
+- name: search_content_urlbar_handoff_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of searches initiated via a URL bar handoff
+    content source. Each entry represents a distinct engine and its summed search volume.
+  type: RECORD
+- name: search_content_urlbar_persisted_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of searches initiated via a persisted URL
+    bar content source. Each entry represents a distinct engine and its summed search volume.
+  type: RECORD
+- name: search_content_urlbar_searchmode_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of searches initiated while the URL bar was
+    in search mode. Each entry represents a distinct engine and its summed search volume.
+  type: RECORD
+- name: search_content_urlbar_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of searches initiated from the URL bar content
+    source. Each entry represents a distinct engine and its summed search volume.
+  type: RECORD
+- name: search_content_webextension_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of searches initiated via a WebExtension
+    content source. Each entry represents a distinct engine and its summed search volume.
+  type: RECORD
+- name: search_count
+  description: The total number of searches performed during the period. A null value indicates that no search count data was recorded.
+  type: INT64
+- name: search_count_abouthome
+  description: The number of searches initiated from the Firefox about:home page during the period. A value of zero indicates no searches from
+    this entry point.
+  type: INT64
+- name: search_count_alias
+  description: The number of searches triggered via a search engine keyword alias (e.g., typing an engine shortcut in the URL bar) during the
+    period. A value of zero indicates no alias-based searches.
+  type: INT64
+- name: search_count_all
+  description: The total number of searches across all entry points and sources during the period. A value of zero indicates no searches were
+    recorded.
+  type: INT64
+- name: search_count_contextmenu
+  description: The number of searches initiated via the browser context menu (e.g., right-click search) during the period. A value of zero indicates
+    no context menu searches.
+  type: INT64
+- name: search_count_newtab
+  description: The number of searches initiated from the new tab page during the period. A value of zero indicates no searches from this entry
+    point.
+  type: INT64
+- name: search_count_organic
+  description: The number of organic (non-tagged, non-partner) searches performed during the period. A value of zero indicates no organic searches
+    were recorded.
+  type: INT64
+- name: search_count_searchbar
+  description: The number of searches initiated from the dedicated browser search bar during the period. A value of zero indicates no searches
+    from this entry point.
+  type: INT64
+- name: search_count_system
+  description: The number of searches initiated by system-level actions (e.g., OS-level search integration) during the period. A value of zero
+    indicates no system-triggered searches.
+  type: INT64
+- name: search_count_tagged_follow_on
+  description: The number of follow-on searches that were tagged, meaning the user continued searching after an initial tagged search access point.
+    A value of zero indicates no tagged follow-on searches.
+  type: INT64
+- name: search_count_tagged_sap
+  description: The number of searches tagged as Search Access Point (SAP) searches, indicating searches attributed to a partner-configured entry
+    point. A value of zero indicates no tagged SAP searches.
+  type: INT64
+- name: search_count_urlbar
+  description: The number of searches initiated from the URL bar (address bar) during the period. A value of zero indicates no URL bar searches
+    were recorded.
+  type: INT64
+- name: search_count_urlbar_handoff
+  description: The number of searches initiated via a URL bar handoff, where a search typed on the new tab page is handed off to the URL bar.
+    A value of zero indicates no handoff searches.
+  type: INT64
+- name: search_count_urlbar_persisted
+  description: The number of searches initiated from the URL bar while a previously selected search engine was persisted in the search mode. A
+    value of zero indicates no such searches.
+  type: INT64
+- name: search_count_urlbar_searchmode
+  description: The number of searches initiated while the URL bar was explicitly in search mode for a specific engine. A value of zero indicates
+    the search mode entry point was not used.
+  type: INT64
+- name: search_count_webextension
+  description: The number of searches initiated through a WebExtension (browser extension) entry point during the period. A value of zero indicates
+    no extension-triggered searches.
+  type: INT64
+- name: search_counts
+  description: An array of structs recording per-engine, per-source search counts, where each entry captures the search engine identifier, the
+    originating source, and the corresponding search count.
+- name: search_engine
+  description: The identifier of the default or active search engine used (e.g., 'google', 'google-b-d', 'duckduckgo'). A null value indicates
+    no search engine was recorded or applicable.
+  type: STRING
+- name: search_with_ads
+  description: The total number of search result pages that contained advertisements during the period. A null value indicates this metric was
+    not recorded; higher values indicate more ad-bearing search sessions.
+- name: search_with_ads_count_all
+  description: The total count of search result pages containing ads across all search entry points during the period. A null value indicates
+    the metric was not available for the record.
+  type: INT64
+- name: search_withads_about_home_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    from the about:home entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_about_newtab_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    from the new tab page entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_contextmenu_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    via the context menu entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_reload_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages that were
+    reloaded. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_searchbar_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    from the search bar entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_system_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    via a system-level search entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_tabhistory_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages navigated
+    to via tab history. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_unknown_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    from an unknown entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_urlbar_handoff_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    via a URL bar handoff. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_urlbar_persisted_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    via a persisted URL bar search mode. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_urlbar_searchmode_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    while the URL bar was in search mode. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_urlbar_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    from the URL bar entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: search_withads_webextension_sum
+  description: An array of key-value pairs mapping search engine identifiers to the aggregated count of ad-bearing search result pages reached
+    via a WebExtension entry point. Each entry represents a distinct engine and its summed count.
+  type: RECORD
+- name: searches
+  description: The total number of searches performed during the period. A value of zero indicates no search activity was recorded.
+- name: searches_per_user_ratio
+  description: The average number of searches per active user for a given cohort or segment during the period. A value of zero indicates no searches
+    were recorded across the user base.
+  type: FLOAT64
+- name: second_seen_date
+  description: The calendar date on which the client was observed for the second time. A null value indicates the client has not yet been seen
+    a second time within the tracked period.
+  type: DATE
+- name: segment
+  description: A categorical label classifying a user's engagement level based on usage frequency, such as 'core_user', 'regular_user', 'casual_user',
+    'infrequent_user', or 'other'. This segmentation is used to group users by activity patterns.
+  type: STRING
+- name: session_id
+  description: A unique identifier (UUID) representing a single browser session. This ID can be used to link events and activity records belonging
+    to the same session.
+  type: STRING
+- name: session_restored_mean
+  description: The average time in milliseconds for the browser session to be restored. A null value indicates that session restore timing data
+    was not available or not applicable.
+  type: FLOAT64
+- name: session_start_time
+  description: The UTC timestamp marking when a browser session began. This field can be used to understand session timing and compute session
+    duration.
+- name: sessions
+  description: The total number of browser sessions recorded for the client during the period. Higher values indicate more frequent browser restarts
+    or usage intervals.
+  type: INT64
+- name: sessions_per_user
+  description: The average number of browser sessions per active user for a given cohort or segment during the period. Higher values indicate
+    more frequent session starts among users.
+  type: FLOAT64
+- name: sessions_started_on_this_day
+  description: The number of new browser sessions that began on the specific day represented by the record. A value of zero indicates no new sessions
+    were started on that day.
+  type: INT64
+- name: show_tracker_stats_share
+  description: A boolean flag indicating whether the user has enabled the option to share tracker blocking statistics. A value of true means sharing
+    is enabled; false means it is disabled. This field is predominantly null, indicating the setting was not recorded.
+  type: BOOLEAN

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -101,8 +101,7 @@ fields:
   description: The sum of active browser usage hours across all sessions or clients within the aggregation period.
   type: FLOAT64
 - name: active_metric_date
-  description: Indicates whether the record's date falls within the active metric collection window. True means the date is within the active
-    window; false means it is outside it.
+  description: Indicates whether the client was active on the metric (reference) date.
 - name: activity_date_week
   description: The Monday-aligned start date of the ISO week in which the user activity occurred, used for weekly aggregations.
   type: DATE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -2471,3 +2471,204 @@ fields:
   description: A keyed map of counts for how many times a user selected a bookmark suggestion from the address bar dropdown, where each key identifies
     a result position or context and the value is the selection count.
   type: RECORD
+- name: scalar_parent_urlbar_picked_dynamic_sum
+  description: Keyed scalar aggregating the total number of times a dynamic result type was selected from the URL bar dropdown. Each key identifies
+    a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_extension_sum
+  description: Keyed scalar aggregating the total number of times a browser extension-provided result was selected from the URL bar dropdown.
+    Each key identifies a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_formhistory_sum
+  description: Keyed scalar aggregating the total number of times a form history suggestion was selected from the URL bar dropdown. Each key identifies
+    a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_history_sum
+  description: Keyed scalar aggregating the total number of times a browsing history result was selected from the URL bar dropdown. Each key identifies
+    a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_keyword_sum
+  description: Keyed scalar aggregating the total number of times a keyword bookmark result was selected from the URL bar dropdown. Each key identifies
+    a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_remotetab_sum
+  description: Keyed scalar aggregating the total number of times a remote tab (synced tab from another device) result was selected from the URL
+    bar dropdown. Each key identifies a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_searchengine_sum
+  description: Keyed scalar aggregating the total number of times a search engine suggestion result was selected from the URL bar dropdown. Each
+    key identifies a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_searchsuggestion_sum
+  description: Keyed scalar aggregating the total number of times a search suggestion result was selected from the URL bar dropdown. Each key
+    identifies a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_switchtab_sum
+  description: Keyed scalar aggregating the total number of times a switch-to-tab result was selected from the URL bar dropdown. Each key identifies
+    a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_tabtosearch_sum
+  description: Keyed scalar aggregating the total number of times a tab-to-search result was selected from the URL bar dropdown, allowing the
+    user to search directly within a specific site's engine. Each key identifies a search engine or result context, and the value is the summed
+    pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_tip_sum
+  description: Keyed scalar aggregating the total number of times an informational tip result was selected from the URL bar dropdown. Each key
+    identifies a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_topsite_sum
+  description: Keyed scalar aggregating the total number of times a top site result was selected from the URL bar dropdown. Each key identifies
+    a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_unknown_sum
+  description: Keyed scalar aggregating the total number of times a result of an unrecognized or uncategorized type was selected from the URL
+    bar dropdown. Each key identifies a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_visiturl_sum
+  description: Keyed scalar aggregating the total number of times a direct URL visit result was selected from the URL bar dropdown. Each key identifies
+    a search engine or result context, and the value is the summed pick count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_bookmarkmenu_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via the bookmark menu entry point. Each key
+    identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_handoff_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via a handoff interaction (e.g., from the new
+    tab page search box). Each key identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_keywordoffer_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via a keyword offer suggestion. Each key identifies
+    a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_oneoff_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered by clicking a one-off search engine button in
+    the dropdown. Each key identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_other_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via an entry point not captured by other specific
+    categories. Each key identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_shortcut_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via a keyboard shortcut. Each key identifies
+    a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_tabmenu_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via the tab menu. Each key identifies a search
+    engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_tabtosearch_onboard_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via the tab-to-search onboarding prompt shown
+    to first-time users. Each key identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_tabtosearch_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via the tab-to-search feature. Each key identifies
+    a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_topsites_newtab_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered from a top site on the new tab page. Each key
+    identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_topsites_urlbar_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered from a top site suggestion within the URL bar
+    dropdown. Each key identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_touchbar_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered via the macOS Touch Bar. Each key identifies
+    a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scalar_parent_urlbar_searchmode_typed_sum
+  description: Keyed scalar aggregating the total number of times URL bar search mode was entered by the user typing a search engine alias directly
+    into the URL bar. Each key identifies a search engine, and the value is the summed activation count.
+  type: RECORD
+- name: scheduled_corpus_item_id
+  description: A unique identifier (UUID) for a scheduled corpus item, representing a specific piece of content that has been queued for recommendation
+    or delivery to users.
+  type: STRING
+- name: search_access_point
+  description: The location or UI surface from which a search was initiated, such as 'urlbar', 'searchbar', 'contextmenu', or 'urlbar_handoff'.
+    A null value indicates no search access point was recorded for the event.
+  type: STRING
+- name: search_adclicks_about_home_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from the Firefox Home (about:home) page. Each key identifies
+    a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_about_newtab_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from the new tab page (about:newtab). Each key identifies
+    a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_contextmenu_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from a context menu search. Each key identifies a search
+    engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_reload_sum
+  description: Keyed scalar aggregating the total number of search ad clicks occurring when a search results page was reloaded. Each key identifies
+    a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_searchbar_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from the browser search bar. Each key identifies a search
+    engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_system_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from system-level or OS-initiated searches. Each key
+    identifies a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_tabhistory_sum
+  description: Keyed scalar aggregating the total number of search ad clicks occurring when navigating through tab history (e.g., back/forward
+    to a search results page). Each key identifies a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_unknown_sum
+  description: Keyed scalar aggregating the total number of search ad clicks where the originating access point could not be determined. Each
+    key identifies a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_urlbar_handoff_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from searches initiated via URL bar handoff from the
+    new tab page. Each key identifies a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_urlbar_persisted_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from a persisted URL bar search (where the search term
+    is retained in the bar). Each key identifies a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_urlbar_searchmode_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from searches performed while URL bar search mode was
+    active. Each key identifies a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_urlbar_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from the URL bar (address bar). Each key identifies a
+    search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_adclicks_webextension_sum
+  description: Keyed scalar aggregating the total number of search ad clicks originating from a search initiated by a web extension. Each key
+    identifies a search engine, and the value is the summed click count.
+  type: RECORD
+- name: search_cohort
+  description: An identifier for a search experiment cohort that the client was enrolled in, used to track search behavior changes across specific
+    experiment groups. A null value indicates the client was not part of any tracked search cohort.
+  type: STRING
+- name: search_content_about_home_sum
+  description: Keyed scalar aggregating the total number of searches performed from the Firefox Home (about:home) page. Each key identifies a
+    search engine, and the value is the summed search count.
+  type: RECORD
+- name: search_content_about_newtab_sum
+  description: Keyed scalar aggregating the total number of searches performed from the new tab page (about:newtab). Each key identifies a search
+    engine, and the value is the summed search count.
+  type: RECORD
+- name: search_content_contextmenu_sum
+  description: Keyed scalar aggregating the total number of searches performed via the browser context menu. Each key identifies a search engine,
+    and the value is the summed search count.
+  type: RECORD
+- name: search_content_reload_sum
+  description: Keyed scalar aggregating the total number of searches triggered by reloading a search results page. Each key identifies a search
+    engine, and the value is the summed search count.
+  type: RECORD
+- name: search_content_searchbar_sum
+  description: Keyed scalar aggregating the total number of searches performed using the browser's dedicated search bar. Each key identifies a
+    search engine, and the value is the summed search count.
+  type: RECORD
+- name: search_content_system_sum
+  description: Keyed scalar aggregating the total number of searches initiated from system-level or OS-level entry points. Each key identifies
+    a search engine, and the value is the summed search count.
+  type: RECORD
+- name: search_content_tabhistory_sum
+  description: Keyed scalar aggregating the total number of searches triggered via tab history navigation (e.g., back/forward to a search results
+    page). Each key identifies a search engine, and the value is the summed search count.
+  type: RECORD

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -2866,3 +2866,198 @@ fields:
   description: A boolean flag indicating whether the user has enabled the option to share tracker blocking statistics. A value of true means sharing
     is enabled; false means it is disabled. This field is predominantly null, indicating the setting was not recorded.
   type: BOOLEAN
+- name: shutdown_kill_sum
+  description: The total number of times the browser process was forcibly killed during shutdown rather than exiting cleanly. Higher values indicate
+    repeated unclean shutdowns for a client.
+  type: INT64
+- name: signature
+  description: A symbolic crash or error signature identifying the code location responsible for a crash or error event. Used to group similar
+    crashes together for triage and analysis.
+  type: STRING
+- name: silent
+  description: Indicates whether an update or notification was delivered silently without user-visible prompting. True means the action was silent;
+    false means the user was notified.
+  type: BOOLEAN
+- name: smoothed_dau
+  description: A 7-day trailing average of Daily Active Users (DAU), used to smooth out day-to-day fluctuations in usage counts. Expressed as
+    a floating-point value representing the average number of active users per day.
+  type: FLOAT64
+- name: source
+  description: The referring domain or source URL from which a user navigated to a Mozilla property. Null indicates the source was not captured
+    or not applicable.
+  type: STRING
+- name: sponsored_pocket_clicks
+  description: The total number of clicks on sponsored Pocket content tiles within the New Tab page for a given client or period. A value of zero
+    indicates no sponsored Pocket tiles were clicked.
+  type: INT64
+- name: sponsored_pocket_dismissals
+  description: The total number of times a user dismissed a sponsored Pocket content tile on the New Tab page. A value of zero indicates no dismissals
+    occurred.
+  type: INT64
+- name: sponsored_pocket_impressions
+  description: The total number of times sponsored Pocket content tiles were displayed to the user on the New Tab page. A value of zero indicates
+    the tiles were never shown.
+  type: INT64
+- name: sponsored_pocket_saves
+  description: The total number of times a user saved a sponsored Pocket content tile. A value of zero indicates no sponsored Pocket items were
+    saved.
+  type: INT64
+- name: sponsored_topsite_clicks
+  description: The total number of clicks on sponsored top site tiles on the New Tab page for a given client or period. A value of zero indicates
+    no sponsored top site tiles were clicked.
+  type: INT64
+- name: sponsored_topsite_dismissals
+  description: The total number of times a user dismissed a sponsored top site tile on the New Tab page. A value of zero indicates no dismissals
+    occurred.
+  type: INT64
+- name: sponsored_topsite_impressions
+  description: The total number of times sponsored top site tiles were displayed to the user on the New Tab page. A value of zero indicates the
+    tiles were never shown.
+  type: INT64
+- name: sponsored_topsite_tile_clicks
+  description: The total number of clicks specifically on sponsored top site tiles (as distinct from other top site interactions) on the New Tab
+    page. A value of zero indicates no such tile clicks occurred.
+  type: INT64
+- name: sponsored_topsite_tile_dismissals
+  description: The total number of times a user dismissed a sponsored top site tile (tile-level dismissal) on the New Tab page. A value of zero
+    indicates no tile-level dismissals occurred.
+  type: INT64
+- name: sponsored_topsite_tile_impressions
+  description: The total number of times individual sponsored top site tiles were rendered and displayed to the user on the New Tab page. A value
+    of zero indicates no tile-level impressions were recorded.
+  type: INT64
+- name: ssl_handshake_result_failure_sum
+  description: The total number of failed SSL/TLS handshake attempts recorded for a client over a period. A value of zero indicates all handshakes
+    completed successfully with no failures.
+  type: INT64
+- name: ssl_handshake_result_success_sum
+  description: The total number of successful SSL/TLS handshake completions recorded for a client over a period. Null values indicate the metric
+    was not collected or not applicable.
+  type: INT64
+- name: startup_profile_selection_first_ping_only
+  description: The method by which a Firefox profile was selected at startup, recorded only for the first ping of a session. Common values include
+    'default' (the default profile was used) and 'restart' (Firefox restarted with the same profile).
+  type: STRING
+- name: startup_profile_selection_reason
+  description: The reason or method by which a Firefox profile was selected at the start of a session. Common values include 'firstrun-created-default'
+    (a new default profile was created on first run) and 'default' (the existing default profile was selected).
+  type: STRING
+- name: startup_profile_selection_reason_first
+  description: The profile selection reason recorded for the first subsession or ping of a client's activity period. Common values include 'default'
+    and 'profile-selector', indicating how Firefox chose which profile to load.
+  type: STRING
+- name: subchannel
+  description: The advertising subchannel classification for a marketing campaign or traffic source. Values include 'Brand', 'Non-Brand', 'Competitor',
+    'PMax', 'Other', and 'All' (an aggregate across all subchannels).
+  type: STRING
+- name: subdivision1
+  description: The first-level administrative subdivision (e.g., state, province, or region) derived from the client's geographic location, represented
+    as a code. Null indicates the subdivision could not be determined.
+  type: STRING
+- name: submission_date
+  description: The UTC calendar date on which a ping or record was received by Mozilla's ingestion pipeline. Used as the primary partitioning
+    and filtering dimension for date-based analysis.
+- name: submission_timestamp
+  description: The precise UTC timestamp at which a ping or record was received by Mozilla's ingestion pipeline, including microsecond precision.
+    Used for fine-grained temporal analysis within a submission date.
+  type: TIMESTAMP
+- name: submission_timestamp_min
+  description: The earliest submission timestamp observed for a group of pings or records, typically within an aggregation window. Useful for
+    identifying when the first event in a batch was received.
+  type: TIMESTAMP
+- name: submission_year
+  description: The calendar year in which a ping or record was submitted to Mozilla's ingestion pipeline, derived from the submission timestamp.
+    Used for partitioning and year-level aggregations.
+  type: INT64
+- name: subsession_hours_per_user_ratio
+  description: The average number of active browser hours per user within a given aggregation period, calculated as total subsession hours divided
+    by the number of users. Used to measure per-user engagement intensity.
+  type: NUMERIC
+- name: subsession_hours_sum
+  description: The total number of hours spent in active Firefox subsessions for a client or cohort over the aggregation period. Values near 24
+    indicate nearly continuous daily usage.
+  type: NUMERIC
+- name: subsession_id
+  description: A UUID uniquely identifying a single Firefox subsession, which begins at browser start or after a previous subsession ends. Used
+    to join or deduplicate subsession-level telemetry records.
+  type: STRING
+- name: subsession_length
+  description: The duration of a Firefox subsession in seconds, representing the amount of time the browser was active during that subsession.
+  type: INT64
+- name: subsession_start_date
+  description: The local date and time at which a Firefox subsession began, formatted as an ISO 8601 string including timezone offset. Reflects
+    the client's local time rather than UTC.
+  type: STRING
+- name: succeeded
+  description: Indicates whether an operation or process completed successfully. True means the operation succeeded; false means it failed.
+  type: BOOLEAN
+- name: success
+  description: A count or flag indicating successful outcomes for an operation or metric within a given period. Null values indicate the metric
+    was not applicable or not recorded.
+  type: INT64
+- name: sync_configured
+  description: Indicates whether Firefox Sync was enabled and configured on the client's browser. True means Sync was active; false means it was
+    explicitly disabled; null indicates the state was not reported.
+  type: BOOLEAN
+- name: sync_count_desktop
+  description: The number of desktop devices connected to a user's Firefox Sync account. Used to understand multi-device desktop usage patterns.
+  type: INT64
+- name: sync_count_desktop_mean
+  description: The average number of desktop devices connected to Firefox Sync accounts, computed across users in an aggregation group. Null indicates
+    no Sync data was available for the group.
+  type: FLOAT64
+- name: sync_count_desktop_sum
+  description: The total number of desktop devices connected to Firefox Sync accounts, summed across users in an aggregation group. Null indicates
+    no Sync data was available for the group.
+  type: INT64
+- name: sync_count_mobile
+  description: The number of mobile devices connected to a user's Firefox Sync account. Used to understand multi-device mobile usage patterns.
+  type: INT64
+- name: sync_count_mobile_mean
+  description: The average number of mobile devices connected to Firefox Sync accounts, computed across users in an aggregation group. A value
+    of zero indicates users had Sync configured but no mobile devices linked.
+  type: FLOAT64
+- name: sync_count_mobile_sum
+  description: The total number of mobile devices connected to Firefox Sync accounts, summed across users in an aggregation group. A value of
+    zero indicates no mobile devices were linked to Sync accounts in the group.
+  type: INT64
+- name: system_is_wow64
+  description: Indicates whether the Firefox process is running as a 32-bit application under the WOW64 compatibility layer on a 64-bit Windows
+    system. True means WOW64 is active; false means the process is running natively.
+  type: BOOLEAN
+- name: system_memory_mb
+  description: The total amount of physical RAM installed on the client's system, measured in megabytes. Common values correspond to standard
+    memory configurations such as 8 GB, 16 GB, and 32 GB.
+  type: FLOAT64
+- name: tagged_follow_on_search_ad_clicks
+  description: The total number of ad clicks on follow-on searches that were tagged with a Mozilla partner attribution code. Follow-on searches
+    originate from a search results page rather than directly from the browser's search bar.
+  type: INT64
+- name: tagged_follow_on_search_ad_impressions
+  description: The total number of ad impressions on follow-on searches that were tagged with a Mozilla partner attribution code. A value of zero
+    indicates no tagged follow-on search ads were shown.
+  type: INT64
+- name: tagged_search_ad_clicks
+  description: The total number of ad clicks on searches that were tagged with a Mozilla partner attribution code, originating directly from the
+    browser's search entry points. A value of zero indicates no tagged search ads were clicked.
+  type: INT64
+- name: tagged_search_ad_impressions
+  description: The total number of ad impressions on searches that were tagged with a Mozilla partner attribution code, originating directly from
+    the browser's search entry points. A value of zero indicates no tagged search ads were shown.
+  type: INT64
+- name: target
+  description: The product or audience target associated with a metric or forecast, such as 'desktop' or 'mobile'. May also include suffixes indicating
+    the specific metric goal (e.g., 'desktop_DAU', 'mobile_CDOU').
+  type: STRING
+- name: telemetry_enabled
+  description: Indicates whether the user has opted into Firefox telemetry data collection. False means the user has explicitly disabled telemetry;
+    true means it is enabled; null indicates the value was not reported.
+  type: BOOLEAN
+- name: text_recognition_api_performance_count_sum
+  description: The total count of text recognition API calls made during a session or aggregation period. Near-100% null rate indicates this feature
+    is used by a very small fraction of clients.
+  type: INT64
+- name: text_recognition_api_performance_sum
+  description: The cumulative performance measurement (e.g., total duration in milliseconds) of text recognition API calls made during a session
+    or aggregation period. Near-100% null rate reflects rare usage of the text recognition feature.
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -179,3 +179,193 @@ fields:
   description: The human-readable version string of the application as displayed to users, including major, minor, and patch components (e.g.,
     '151.0.1' or '115.36.0esr').
   type: STRING
+- name: app_name
+  description: The name of the Mozilla application that generated the telemetry event (e.g., 'firefox_desktop', 'fenix', 'firefox_ios', 'mozilla_vpn').
+    Used to distinguish telemetry across Mozilla's suite of products.
+  type: STRING
+- name: app_version
+  description: The full version string of the application at the time of the event (e.g., '151.0.2'). Combines major, minor, and patch components
+    into a single human-readable version identifier.
+- name: app_version_is_major_release
+  description: Indicates whether the application version is a major release (true) or a minor/patch release (false). Useful for segmenting analysis
+    by release type.
+  type: BOOLEAN
+- name: app_version_major
+  description: The major version number component of the application version (e.g., 151 for version '151.0.2'). Increments with each major Firefox
+    release cycle.
+  type: NUMERIC
+- name: app_version_minor
+  description: The minor version number component of the application version (e.g., 0 for version '151.0'). Typically 0 for major releases and
+    non-zero for extended support or point releases.
+  type: NUMERIC
+- name: app_version_patch
+  description: The patch-level version number component of the application version (e.g., 2 for version '151.0.2'). Null when the release does
+    not include a patch component.
+  type: NUMERIC
+- name: app_version_patch_revision
+  description: The patch revision sub-component of the application version, providing additional granularity beyond the patch number. Null when
+    not applicable to the release.
+  type: NUMERIC
+- name: apple_model_id
+  description: The Apple hardware model identifier for macOS and iOS devices (e.g., 'MacBookAir10,1', 'Mac16,12'). Null for non-Apple platforms
+    or when the model cannot be determined.
+  type: STRING
+- name: application
+  description: The display name of the Mozilla application (e.g., 'Firefox', 'FirefoxForFireTV', 'Focus'). Represents the branded product name
+    rather than the internal application identifier.
+- name: arch
+  description: The CPU architecture of the device running the application (e.g., 'arm64-v8a', 'armeabi-v7a', 'x86_64'). Commonly used for mobile
+    platform analysis to distinguish ARM and x86 device types.
+  type: STRING
+- name: architecture
+  description: The CPU architecture of the system on which the application is running (e.g., 'x86-64', 'aarch64', 'arm'). Identifies the instruction
+    set architecture of the client device.
+  type: STRING
+- name: asofdate
+  description: The reference date for which the row's data is valid or calculated, formatted as YYYY-MM-DD. Used in time-windowed or snapshot-based
+    tables to indicate the effective date of the record.
+  type: STRING
+- name: attributed
+  description: Indicates whether the client or install event has a known marketing attribution source (true) or was not attributed to any campaign
+    or referral (false).
+  type: BOOLEAN
+- name: attribution_campaign
+  description: The marketing campaign name associated with the Firefox installation, sourced from attribution parameters (e.g., 'SET_DEFAULT_BROWSER').
+    Null when attribution data is unavailable.
+  type: STRING
+- name: attribution_content
+  description: The content variant or creative identifier from the marketing attribution parameters, used to distinguish specific ad placements
+    or page elements (e.g., 'body-download-button'). Null when attribution data is unavailable.
+  type: STRING
+- name: attribution_dlsource
+  description: The download source identifier from attribution parameters, indicating the platform or property from which Firefox was downloaded
+    (e.g., 'mozorg', 'fxdotcom', 'mozillaci'). Null when attribution data is unavailable.
+  type: STRING
+- name: attribution_dltoken
+  description: A unique token assigned at download time to link an installation to a specific download event for attribution tracking. Null when
+    no download token was recorded.
+  type: STRING
+- name: attribution_experiment
+  description: The experiment identifier from attribution parameters, indicating whether the install was part of a specific marketing experiment
+    (e.g., 'download-privacy'). Null when no experiment was associated with the attribution.
+  type: STRING
+- name: attribution_medium
+  description: The marketing medium from attribution parameters describing how the user arrived at the download (e.g., 'referral', 'firefox-desktop').
+    Null when attribution data is unavailable.
+  type: STRING
+- name: attribution_msstoresignedin
+  description: Indicates whether the user was signed in to the Microsoft Store at the time of download. Currently always null, reserved for future
+    Microsoft Store attribution tracking.
+  type: BOOLEAN
+- name: attribution_source
+  description: The referring source from attribution parameters, typically the website or property that directed the user to download Firefox
+    (e.g., 'www.google.com', 'www.bing.com'). Null when attribution data is unavailable.
+  type: STRING
+- name: attribution_ua
+  description: The user agent type of the browser the user was using when they downloaded Firefox, as captured in attribution parameters (e.g.,
+    'chrome', 'edge', 'firefox'). Null when attribution data is unavailable.
+  type: STRING
+- name: attribution_variation
+  description: The A/B test variation from attribution parameters that the user was assigned to during the download funnel (e.g., 'treatment',
+    'control'). Null when no variation was recorded.
+  type: STRING
+- name: average_profile_age
+  description: The average age of Firefox profiles in days across a cohort or aggregation group. Higher values indicate longer-tenured user populations.
+  type: FLOAT64
+- name: avg_hours_usage_daily
+  description: The average number of hours per day the application was actively used. Represents a measure of daily engagement intensity for the
+    client or cohort.
+  type: NUMERIC
+- name: blocklist_enabled
+  description: Indicates whether the Firefox blocklist (used to block known malicious add-ons and plugins) is enabled (true) or disabled (false)
+    on the client.
+  type: BOOLEAN
+- name: bookmark_migrations_quantity_all
+  description: The total number of bookmarks migrated from all external browsers into Firefox. Null when no migration occurred or migration data
+    was not collected.
+  type: INT64
+- name: bookmark_migrations_quantity_chrome
+  description: The number of bookmarks migrated specifically from Google Chrome into Firefox. Null when no Chrome migration occurred or data was
+    not collected.
+  type: INT64
+- name: bookmark_migrations_quantity_edge
+  description: The number of bookmarks migrated specifically from Microsoft Edge into Firefox. Null when no Edge migration occurred or data was
+    not collected.
+  type: INT64
+- name: bookmark_migrations_quantity_safari
+  description: The number of bookmarks migrated specifically from Apple Safari into Firefox. Null when no Safari migration occurred or data was
+    not collected.
+  type: INT64
+- name: bookmarks_added_per_dau
+  description: The ratio of bookmark additions to daily active users (DAU) for a given cohort or time window. Null when there are no active users
+    or the metric cannot be computed.
+  type: FLOAT64
+- name: bookmarks_opened_per_dau
+  description: The ratio of bookmark open events to daily active users (DAU) for a given cohort or time window. Null when there are no active
+    users or the metric cannot be computed.
+  type: FLOAT64
+- name: branch
+  description: The experiment branch to which a client was assigned (e.g., 'control', 'treatment-a', 'rollout'). Used to segment clients for A/B
+    test and rollout analyses.
+  type: STRING
+- name: browser_arch
+  description: The CPU architecture of the browser process. Complements the system architecture field to account for cases where the browser runs
+    under emulation or a different bitness than the OS.
+- name: browser_backup_archive_enabled
+  description: Indicates whether the Firefox browser backup archive feature is enabled (true) or disabled (false). Null when the feature state
+    could not be determined or the feature is unavailable.
+  type: BOOLEAN
+- name: browser_backup_scheduler_enabled
+  description: Indicates whether the Firefox automatic backup scheduler is enabled (true) or disabled (false). Null when the feature state could
+    not be determined or the feature is unavailable.
+  type: BOOLEAN
+- name: browser_name
+  description: The display name of the browser product (e.g., 'Firefox Desktop'). Identifies the browser brand and surface as reported by the
+    client.
+  type: STRING
+- name: browser_version
+  description: The full version string of the browser (e.g., '151.0.2'). Represents the complete, human-readable version of the Firefox browser
+    build.
+  type: STRING
+- name: browser_version_info_is_major_release
+  description: Indicates whether the parsed browser version corresponds to a major release (true) or a minor/patch update (false). Derived from
+    structured version metadata.
+- name: browser_version_info_major_version
+  description: The major version number component extracted from the browser version string (e.g., 151 for '151.0.2'). Represents the primary
+    Firefox release cycle number.
+- name: browser_version_info_minor_version
+  description: The minor version number component extracted from the browser version string (e.g., 0 for '151.0'). Typically 0 for standard releases
+    and non-zero for ESR or point releases.
+- name: browser_version_info_patch_revision
+  description: The patch revision sub-component extracted from the structured browser version metadata. Null when the version does not include
+    a patch revision segment.
+- name: browser_version_info_version
+  description: The full browser version string as parsed into structured version metadata (e.g., '151.0.2', '115.0a1'). Provides a normalized
+    version identifier for joining and filtering.
+- name: bug_1501329_affected
+  description: Indicates whether the client was affected by the Firefox bug tracked as bug 1501329 (true) or confirmed unaffected (false). Null
+    when the affected status could not be determined.
+  type: BOOLEAN
+- name: build_architecture
+  description: The CPU architecture for which the Firefox build was compiled (e.g., 'x86-64', 'aarch64', 'x86'). May differ from the system architecture
+    when running a 32-bit build on a 64-bit OS.
+  type: STRING
+- name: build_channel
+  description: The release channel of the Firefox build (e.g., 'release', 'beta', 'nightly', 'aurora'). Indicates the stage in the Firefox release
+    pipeline from which the build originated.
+  type: STRING
+- name: build_id
+  description: A timestamp-based identifier for the specific Firefox build, formatted as YYYYMMDDHHmmss (e.g., '20260514164700'). Uniquely identifies
+    a compiled build artifact.
+  type: STRING
+- name: build_version
+  description: The version string associated with the specific Firefox build. Identifies the release version of the compiled browser artifact.
+  type: STRING
+- name: campaign
+  description: The marketing campaign name associated with a user's acquisition or install event (e.g., 'SET_DEFAULT_BROWSER', 'non-fx-button').
+    Null when no campaign attribution is available.
+  type: STRING
+- name: campaign_id
+  description: The unique identifier of the marketing campaign associated with a user's acquisition event, which may include platform-specific
+    campaign codes (e.g., Google Ads or Facebook campaign IDs). Null when no campaign ID is available.
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -3425,3 +3425,71 @@ fields:
   description: The XPCOM Application Binary Interface identifier describing the CPU architecture and compiler ABI of the Firefox build, such as
     'x86_64-msvc' or 'aarch64-gcc3'.
   type: STRING
+- name: yearly
+  description: The estimated yearly component of a time-series forecast, representing the annualized trend or aggregated value projected over
+    a full year. This floating-point value can be positive or negative depending on the direction of the trend.
+  type: FLOAT64
+- name: yearly_lower
+  description: The lower bound of the confidence interval for the yearly forecast component, representing the most conservative end of the annual
+    estimate. Values can be negative, indicating a downward projected trend.
+  type: FLOAT64
+- name: yearly_upper
+  description: The upper bound of the confidence interval for the yearly forecast component, representing the most optimistic end of the annual
+    estimate. Values can be negative, indicating the upper bound of a downward projected trend.
+  type: FLOAT64
+- name: yhat
+  description: The point estimate (predicted value) produced by a forecasting model for a given time period. This is the central forecast value
+    before any uncertainty bounds are applied.
+  type: FLOAT64
+- name: yhat_lower
+  description: The lower bound of the forecast prediction interval for the predicted value (yhat), representing the minimum plausible outcome
+    at the model's configured confidence level. Values are always present (non-null) for rows that include a forecast.
+  type: FLOAT64
+- name: yhat_upper
+  description: The upper bound of the forecast prediction interval for the predicted value (yhat), representing the maximum plausible outcome
+    at the model's configured confidence level. Values are always present (non-null) for rows that include a forecast.
+  type: FLOAT64
+- name: yhat_p5
+  description: The 5th percentile of the forecasted value distribution, representing the lower tail of the predicted outcome where 5% of simulated
+    values fall below this threshold. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p10
+  description: The 10th percentile of the forecasted value distribution, indicating that 10% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p20
+  description: The 20th percentile of the forecasted value distribution, indicating that 20% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p30
+  description: The 30th percentile of the forecasted value distribution, indicating that 30% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p40
+  description: The 40th percentile of the forecasted value distribution, indicating that 40% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p50
+  description: The 50th percentile (median) of the forecasted value distribution, representing the midpoint of simulated forecast outcomes. This
+    field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p60
+  description: The 60th percentile of the forecasted value distribution, indicating that 60% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p70
+  description: The 70th percentile of the forecasted value distribution, indicating that 70% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p80
+  description: The 80th percentile of the forecasted value distribution, indicating that 80% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p90
+  description: The 90th percentile of the forecasted value distribution, indicating that 90% of simulated forecast outcomes are expected to fall
+    below this value. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64
+- name: yhat_p95
+  description: The 95th percentile of the forecasted value distribution, representing the upper tail of the predicted outcome where 95% of simulated
+    values fall below this threshold. This field may be null when percentile-level forecast outputs are not computed for a given row.
+  type: FLOAT64

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -1136,3 +1136,196 @@ fields:
     or unavailable on the client's system. Blocked or unavailable statuses typically include a reason code identifying the specific failure or
     blocklist entry responsible.
   type: STRING
+- name: gfx_features_d3d11_status
+  description: The status of the Direct3D 11 graphics feature on the client, indicating whether it is available, unavailable, or blocklisted along
+    with a reason code (e.g., 'available', 'unavailable:FEATURE_FAILURE_D3D11_NEED_HWCOMP', 'blocklisted:FEATURE_FAILURE_UNKNOWN_DEVICE_VENDOR').
+    A null value indicates the status could not be determined.
+  type: STRING
+- name: gfx_features_gpu_process_status
+  description: The status of the GPU process graphics feature on the client, indicating whether it is available, unused, or unavailable along
+    with a reason code (e.g., 'available', 'unused', 'unavailable:FEATURE_FAILURE_OLD_WINDOWS'). A null value indicates the status could not be
+    determined.
+  type: STRING
+- name: graduate_count
+  description: The number of experiments or studies from which a client has graduated during the reporting period. A value of 0 indicates the
+    client has not graduated from any experiments.
+  type: INT64
+- name: has_addon_ratio
+  description: The proportion of sessions or pings in which the client had at least one add-on installed, expressed as a floating-point ratio
+    between 0.0 and 1.0.
+  type: FLOAT64
+- name: has_flash
+  description: Indicates whether the Adobe Flash plugin is installed and available on the client. True means Flash is present; false means it
+    is not.
+- name: histogram
+  description: A JSON-encoded histogram representing the normalized distribution of values across buckets for a given metric. Keys correspond
+    to bucket indices and values represent the proportion of observations in each bucket.
+  type: STRING
+- name: histogram_aggregates
+  description: An array of aggregated histogram records for one or more metrics, each containing bucket configuration, metric metadata, process
+    context, and the aggregated bucket counts. Used for rollup-level histogram analysis across clients and versions.
+  type: RECORD
+- name: histogram_aggregates_agg_type
+  description: The aggregation method applied to the histogram data within a histogram_aggregates entry. The value 'summed_histogram' indicates
+    that bucket counts have been summed across all contributing clients or pings.
+- name: histogram_aggregates_first_bucket
+  description: The lower boundary value of the first bucket in a histogram aggregate entry. This defines the starting point of the histogram's
+    range and varies by metric type.
+- name: histogram_aggregates_key
+  description: An optional sub-key that further categorizes a keyed histogram metric within a histogram_aggregates entry (e.g., a DNS provider
+    name or feature flag identifier). An empty string indicates the histogram is not keyed.
+- name: histogram_aggregates_last_bucket
+  description: The upper boundary value of the last bucket in a histogram aggregate entry. This defines the maximum end of the histogram's range
+    and varies by metric type.
+- name: histogram_aggregates_latest_version
+  description: The most recent Firefox major version number observed among the clients contributing to a given histogram aggregate entry. This
+    reflects the newest version present in the aggregated population.
+- name: histogram_aggregates_metric
+  description: The name of the histogram metric being aggregated within a histogram_aggregates entry (e.g., 'http_connection_close_reason', 'network_dns_end_to_connect_start_exp_ms').
+    This identifies which specific instrumentation probe the data originates from.
+- name: histogram_aggregates_metric_type
+  description: The type classification of the histogram metric in a histogram_aggregates entry, such as 'histogram-exponential', 'histogram-enumerated',
+    'histogram-boolean', 'histogram-categorical', 'histogram-linear', or 'histogram-count'. This determines how bucket boundaries and values should
+    be interpreted.
+- name: histogram_aggregates_num_buckets
+  description: The total number of buckets defined for the histogram in a histogram_aggregates entry. This value determines the resolution of
+    the histogram distribution.
+- name: histogram_aggregates_process
+  description: The Firefox process type from which the histogram data in a histogram_aggregates entry was collected, such as 'parent' (main process),
+    'content' (content process), or 'gpu' (GPU process).
+- name: histogram_parent_devtools_aboutdebugging_opened_count_sum
+  description: The total number of times the 'about:debugging' DevTools panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates the panel was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_animationinspector_opened_count_sum
+  description: The total number of times the DevTools Animation Inspector panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates the panel was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_browserconsole_opened_count_sum
+  description: The total number of times the DevTools Browser Console was opened during the reporting period, summed across all subsessions. A
+    null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_canvasdebugger_opened_count_sum
+  description: The total number of times the DevTools Canvas Debugger panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates the panel was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_computedview_opened_count_sum
+  description: The total number of times the DevTools Computed View (CSS computed styles) panel was opened during the reporting period, summed
+    across all subsessions. A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_custom_opened_count_sum
+  description: The total number of times a custom DevTools panel was opened during the reporting period, summed across all subsessions. A null
+    value indicates no custom panel was opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_developertoolbar_opened_count_sum
+  description: The total number of times the DevTools Developer Toolbar was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_dom_opened_count_sum
+  description: The total number of times the DevTools DOM panel was opened during the reporting period, summed across all subsessions. A null
+    value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_eyedropper_opened_count_sum
+  description: The total number of times the DevTools Eyedropper color picker tool was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_fontinspector_opened_count_sum
+  description: The total number of times the DevTools Font Inspector panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_inspector_opened_count_sum
+  description: The total number of times the DevTools Inspector (HTML/DOM inspector) panel was opened during the reporting period, summed across
+    all subsessions. A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_jsbrowserdebugger_opened_count_sum
+  description: The total number of times the DevTools JavaScript Browser Debugger was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_jsdebugger_opened_count_sum
+  description: The total number of times the DevTools JavaScript Debugger panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_jsprofiler_opened_count_sum
+  description: The total number of times the DevTools JavaScript Profiler panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_layoutview_opened_count_sum
+  description: The total number of times the DevTools Layout View panel (CSS layout inspection) was opened during the reporting period, summed
+    across all subsessions. A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_memory_opened_count_sum
+  description: The total number of times the DevTools Memory panel was opened during the reporting period, summed across all subsessions. A null
+    value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_menu_eyedropper_opened_count_sum
+  description: The total number of times the DevTools Eyedropper was opened via the menu entry during the reporting period, summed across all
+    subsessions. A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_netmonitor_opened_count_sum
+  description: The total number of times the DevTools Network Monitor panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_options_opened_count_sum
+  description: The total number of times the DevTools Options/Settings panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_paintflashing_opened_count_sum
+  description: The total number of times the DevTools Paint Flashing tool was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_picker_eyedropper_opened_count_sum
+  description: The total number of times the DevTools Eyedropper was opened via the color picker UI during the reporting period, summed across
+    all subsessions. A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_responsive_opened_count_sum
+  description: The total number of times the DevTools Responsive Design Mode was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_ruleview_opened_count_sum
+  description: The total number of times the DevTools Rule View (CSS rules inspector) panel was opened during the reporting period, summed across
+    all subsessions. A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_scratchpad_opened_count_sum
+  description: The total number of times the DevTools Scratchpad JavaScript editor was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_scratchpad_window_opened_count_sum
+  description: The total number of times the DevTools Scratchpad was opened as a detached window during the reporting period, summed across all
+    subsessions. A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_shadereditor_opened_count_sum
+  description: The total number of times the DevTools Shader Editor panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_storage_opened_count_sum
+  description: The total number of times the DevTools Storage Inspector panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_styleeditor_opened_count_sum
+  description: The total number of times the DevTools Style Editor panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_webaudioeditor_opened_count_sum
+  description: The total number of times the DevTools Web Audio Editor panel was opened during the reporting period, summed across all subsessions.
+    A null value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_webconsole_opened_count_sum
+  description: The total number of times the DevTools Web Console was opened during the reporting period, summed across all subsessions. A null
+    value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: histogram_parent_devtools_webide_opened_count_sum
+  description: The total number of times the DevTools WebIDE panel was opened during the reporting period, summed across all subsessions. A null
+    value indicates it was not opened or the metric was not recorded.
+  type: INT64
+- name: history_migrations_quantity_all
+  description: The total number of history entries migrated from all supported browsers during a migration event. A value of 0 indicates a migration
+    was attempted but no history entries were transferred; null indicates no migration occurred or the metric was not recorded.
+  type: INT64
+- name: history_migrations_quantity_chrome
+  description: The number of history entries migrated specifically from Google Chrome during a migration event. A value of 0 indicates a Chrome
+    migration was attempted but no entries were transferred; null indicates no Chrome migration occurred or the metric was not recorded.
+  type: INT64
+- name: history_migrations_quantity_edge
+  description: The number of history entries migrated specifically from Microsoft Edge during a migration event. A value of 0 indicates an Edge
+    migration was attempted but no entries were transferred; null indicates no Edge migration occurred or the metric was not recorded.
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -2272,3 +2272,202 @@ fields:
   description: The maximum number of browser windows open simultaneously in any single session during the reporting period, as recorded by the
     parent process engagement scalar. Null when the metric was not collected.
   type: INT64
+- name: scalar_parent_browser_engagement_tab_open_event_count_sum
+  description: The total number of new tab open events recorded in the browser during the reporting period. A higher value indicates more frequent
+    tab-opening activity by the user.
+  type: INT64
+- name: scalar_parent_browser_engagement_total_uri_count_normal_and_private_mode_sum
+  description: The total number of URIs visited across both normal and private browsing modes during the reporting period. This provides a combined
+    measure of overall browsing activity regardless of window type.
+  type: INT64
+- name: scalar_parent_browser_engagement_total_uri_count_sum
+  description: The total number of URIs visited in normal (non-private) browsing mode during the reporting period. This is a key measure of user
+    browsing engagement.
+- name: scalar_parent_browser_engagement_unfiltered_uri_count_sum
+  description: The total count of URIs visited without applying engagement filters (e.g., excluding chrome or about pages) during the reporting
+    period. This unfiltered count includes all navigations, including internal browser pages.
+  type: INT64
+- name: scalar_parent_browser_engagement_unique_domains_count_max
+  description: The maximum number of unique domains visited in any single browsing session during the reporting period. This reflects the breadth
+    of a user's browsing activity at its peak.
+  type: INT64
+- name: scalar_parent_browser_engagement_unique_domains_count_mean
+  description: The average number of unique domains visited per browsing session during the reporting period. This provides a normalized measure
+    of how broadly users browse across different sites.
+  type: FLOAT64
+- name: scalar_parent_browser_engagement_window_open_event_count_sum
+  description: The total number of new browser window open events recorded during the reporting period. A higher value indicates more frequent
+    use of multiple windows.
+  type: INT64
+- name: scalar_parent_browser_ui_interaction_content_context_sum
+  description: A keyed map of interaction counts for content context menu actions in the browser UI, where each key identifies a specific menu
+    item or action and the value is the cumulative count of interactions.
+  type: RECORD
+- name: scalar_parent_browser_ui_interaction_preferences_pane_home_sum
+  description: A keyed map of interaction counts for elements within the Home preferences pane in the browser UI, where each key identifies a
+    specific UI element and the value is the cumulative count of interactions.
+  type: RECORD
+- name: scalar_parent_browser_ui_interaction_textrecognition_error_sum
+  description: The total number of errors encountered during text recognition interactions in the browser UI during the reporting period. A null
+    or zero value indicates no errors were recorded.
+  type: INT64
+- name: scalar_parent_devtools_accessibility_node_inspected_count_sum
+  description: The total number of times an accessibility node was inspected using the DevTools Accessibility panel during the reporting period.
+    A null value indicates the feature was not used.
+  type: INT64
+- name: scalar_parent_devtools_accessibility_opened_count_sum
+  description: The total number of times the DevTools Accessibility panel was opened during the reporting period. A null value indicates the panel
+    was not opened.
+  type: INT64
+- name: scalar_parent_devtools_accessibility_picker_used_count_sum
+  description: The total number of times the accessibility picker tool within DevTools was activated during the reporting period. A null value
+    indicates the picker was not used.
+  type: INT64
+- name: scalar_parent_devtools_accessibility_select_accessible_for_node_sum
+  description: A keyed map of counts representing how many times the 'select accessible object for node' action was triggered in the DevTools
+    Accessibility panel, broken down by node type or context.
+  type: RECORD
+- name: scalar_parent_devtools_accessibility_service_enabled_count_sum
+  description: The total number of times the accessibility service was enabled via DevTools during the reporting period. A null value indicates
+    the service was not enabled through this path.
+  type: INT64
+- name: scalar_parent_devtools_copy_full_css_selector_opened_sum
+  description: The total number of times the 'Copy Full CSS Selector' action was triggered in DevTools during the reporting period. A null value
+    indicates this action was not used.
+  type: INT64
+- name: scalar_parent_devtools_copy_unique_css_selector_opened_sum
+  description: The total number of times the 'Copy Unique CSS Selector' action was triggered in DevTools during the reporting period. A null value
+    indicates this action was not used.
+  type: INT64
+- name: scalar_parent_devtools_toolbar_eyedropper_opened_sum
+  description: The total number of times the eyedropper color picker tool was opened from the DevTools toolbar during the reporting period. A
+    null value indicates the tool was not used.
+  type: INT64
+- name: scalar_parent_dom_contentprocess_troubled_due_to_memory_sum
+  description: The total number of times a DOM content process was flagged as troubled due to low memory conditions during the reporting period.
+    A null value indicates no such events occurred.
+  type: INT64
+- name: scalar_parent_library_link_sum
+  description: A keyed map of counts for link-related actions taken within the browser Library panel, where each key identifies a specific link
+    type or destination and the value is the cumulative count of interactions.
+  type: RECORD
+- name: scalar_parent_library_opened_sum
+  description: A keyed map of counts for the number of times each section of the browser Library panel was opened, where each key identifies a
+    specific library section (e.g., history, bookmarks) and the value is the open count.
+  type: RECORD
+- name: scalar_parent_library_search_sum
+  description: A keyed map of counts for search interactions within the browser Library panel, where each key identifies a specific search context
+    or section and the value is the cumulative number of searches performed.
+  type: RECORD
+- name: scalar_parent_navigator_storage_estimate_count_sum
+  description: The total number of times the Navigator Storage Estimate API was called during the reporting period. A null value indicates the
+    API was not invoked.
+  type: INT64
+- name: scalar_parent_navigator_storage_persist_count_sum
+  description: The total number of times the Navigator Storage Persist API was called during the reporting period. A null value indicates the
+    API was not invoked.
+  type: INT64
+- name: scalar_parent_os_environment_is_taskbar_pinned
+  description: Indicates whether the Firefox application is pinned to the operating system taskbar. True means Firefox is pinned to the taskbar;
+    false means it is not.
+  type: BOOLEAN
+- name: scalar_parent_os_environment_launched_via_desktop
+  description: Indicates whether the browser was launched via a desktop shortcut. True means the session was initiated from a desktop icon; false
+    means another launch method was used.
+  type: BOOLEAN
+- name: scalar_parent_os_environment_launched_via_other
+  description: Indicates whether the browser was launched via a method not covered by the other specific launch-method scalars. True means an
+    unclassified launch mechanism was used; false means it was not.
+  type: BOOLEAN
+- name: scalar_parent_os_environment_launched_via_other_shortcut
+  description: Indicates whether the browser was launched via a shortcut other than the desktop, taskbar, or Start Menu shortcuts. True means
+    such an alternative shortcut was used; false means it was not.
+  type: BOOLEAN
+- name: scalar_parent_os_environment_launched_via_start_menu
+  description: Indicates whether the browser was launched from the operating system Start Menu. True means the session was initiated via the Start
+    Menu; false means another launch method was used.
+  type: BOOLEAN
+- name: scalar_parent_os_environment_launched_via_taskbar
+  description: Indicates whether the browser was launched by clicking its icon on the operating system taskbar. True means the session originated
+    from the taskbar; false means another launch method was used.
+  type: BOOLEAN
+- name: scalar_parent_os_environment_launched_via_taskbar_private
+  description: Indicates whether a Private Browsing window was launched directly from a taskbar shortcut or jump list entry. True means the private
+    window was opened via the taskbar; false means it was not.
+  type: BOOLEAN
+- name: scalar_parent_sidebar_link_sum
+  description: A keyed map of counts for link-related actions taken within the browser sidebar, where each key identifies a specific link type
+    or panel and the value is the cumulative count of interactions.
+  type: RECORD
+- name: scalar_parent_sidebar_opened_sum
+  description: A keyed map of counts for how many times each sidebar panel was opened, where each key identifies a specific sidebar panel (e.g.,
+    bookmarks, history, synced tabs) and the value is the open count.
+  type: RECORD
+- name: scalar_parent_sidebar_search_sum
+  description: A keyed map of counts for search interactions performed within the browser sidebar, where each key identifies a specific sidebar
+    search context and the value is the cumulative number of searches.
+  type: RECORD
+- name: scalar_parent_storage_sync_api_usage_extensions_using_sum
+  description: The total number of extensions that used the Storage Sync API during the reporting period. A null value indicates no extensions
+    invoked this API.
+  type: INT64
+- name: scalar_parent_telemetry_event_counts_sum
+  description: A keyed map of aggregated telemetry event counts, where each key identifies a specific event category and method combination and
+    the value is the cumulative number of times that event was recorded.
+  type: RECORD
+- name: scalar_parent_urlbar_impression_autofill_about_sum
+  description: The total number of times an autofill suggestion for an 'about:' page URL was shown in the address bar during the reporting period.
+    A null value indicates no such impressions occurred.
+  type: INT64
+- name: scalar_parent_urlbar_impression_autofill_adaptive_sum
+  description: The total number of times an adaptive history autofill suggestion was shown in the address bar during the reporting period. Adaptive
+    autofill learns from the user's past selections to prioritize results.
+  type: INT64
+- name: scalar_parent_urlbar_impression_autofill_origin_sum
+  description: The total number of times an origin-based autofill suggestion (completing the domain or host portion of a URL) was shown in the
+    address bar during the reporting period.
+  type: INT64
+- name: scalar_parent_urlbar_impression_autofill_other_sum
+  description: The total number of times an autofill suggestion of an unclassified or miscellaneous type was shown in the address bar during the
+    reporting period. A null value indicates no such impressions occurred.
+  type: INT64
+- name: scalar_parent_urlbar_impression_autofill_preloaded_sum
+  description: The total number of times a preloaded site autofill suggestion was shown in the address bar during the reporting period. Preloaded
+    suggestions come from a curated list of popular sites bundled with the browser.
+  type: INT64
+- name: scalar_parent_urlbar_impression_autofill_url_sum
+  description: The total number of times a full URL autofill suggestion (completing beyond just the origin to include path or query components)
+    was shown in the address bar during the reporting period.
+  type: INT64
+- name: scalar_parent_urlbar_picked_autofill_about_sum
+  description: A keyed map of counts for how many times a user selected an autofill suggestion for an 'about:' page URL from the address bar,
+    broken down by the specific about page or input length key.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_autofill_adaptive_sum
+  description: A keyed map of counts for how many times a user selected an adaptive history autofill suggestion from the address bar, where keys
+    typically represent the character length at which the suggestion was accepted.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_autofill_origin_sum
+  description: A keyed map of counts for how many times a user accepted an origin-based autofill suggestion from the address bar, broken down
+    by the character length at which the suggestion was selected.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_autofill_other_sum
+  description: A keyed map of counts for how many times a user selected an unclassified autofill suggestion from the address bar, broken down
+    by a context or input-length key.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_autofill_preloaded_sum
+  description: A keyed map of counts for how many times a user selected a preloaded site autofill suggestion from the address bar, broken down
+    by the site or input-length key.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_autofill_sum
+  description: A keyed map of aggregate counts for all autofill suggestion types selected by users in the address bar, where each key identifies
+    an autofill category or input-length context and the value is the total selection count.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_autofill_url_sum
+  description: A keyed map of counts for how many times a user accepted a full URL autofill suggestion from the address bar, broken down by the
+    character length or context at which the suggestion was confirmed.
+  type: RECORD
+- name: scalar_parent_urlbar_picked_bookmark_sum
+  description: A keyed map of counts for how many times a user selected a bookmark suggestion from the address bar dropdown, where each key identifies
+    a result position or context and the value is the selection count.
+  type: RECORD

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -567,3 +567,193 @@ fields:
 - name: cpu_cores
   description: The number of logical CPU cores available on the client device as reported by the Firefox telemetry environment. Used to segment
     performance and hardware capability data.
+- name: cpu_count
+  description: The total number of logical CPU cores available on the client device. Higher values indicate multi-core or hyperthreaded processors.
+  type: INT64
+- name: cpu_family
+  description: The processor family identifier as reported by the CPU's CPUID instruction. This numeric code corresponds to a specific generation
+    or architectural family of the processor.
+  type: INT64
+- name: cpu_l2_cache_kb
+  description: The size of the CPU's L2 cache in kilobytes. A value of 0 may indicate the cache size could not be determined.
+  type: INT64
+- name: cpu_l3_cache_kb
+  description: The size of the CPU's L3 cache in kilobytes. A value of 0 may indicate no L3 cache is present or the size could not be determined;
+    null indicates the value was not reported.
+  type: INT64
+- name: cpu_model
+  description: The processor model number as reported by the CPU's CPUID instruction. This numeric identifier distinguishes specific processor
+    models within a family.
+  type: INT64
+- name: cpu_speed
+  description: The reported speed of the CPU as a string value. This may represent a nominal or base clock speed identifier for the processor.
+- name: cpu_speed_mhz
+  description: The clock speed of the CPU in megahertz (MHz). A value of 0 indicates the speed could not be determined or was not reported.
+  type: INT64
+- name: cpu_stepping
+  description: The stepping (revision) number of the processor as reported by CPUID. This identifies a specific hardware revision within a CPU
+    model; null indicates the value was not available.
+  type: INT64
+- name: cpu_vendor
+  description: The CPU vendor string as reported by the CPUID instruction (e.g., 'GenuineIntel', 'AuthenticAMD'). An empty string or null indicates
+    the vendor could not be identified.
+- name: crash_submit_attempt_content_sum
+  description: The total number of crash report submission attempts for content process crashes during the reporting period. Null indicates no
+    content process crash submissions were attempted.
+  type: INT64
+- name: crash_submit_attempt_main_sum
+  description: The total number of crash report submission attempts for main process crashes during the reporting period. Null indicates no main
+    process crash submissions were attempted.
+  type: INT64
+- name: crash_submit_attempt_plugin_sum
+  description: The total number of crash report submission attempts for plugin process crashes during the reporting period. Null indicates no
+    plugin process crash submissions were attempted.
+  type: INT64
+- name: crash_submit_success_content_sum
+  description: The total number of successfully submitted crash reports for content process crashes during the reporting period. A value of 0
+    means submissions were attempted but none succeeded; null indicates no attempts were made.
+  type: INT64
+- name: crash_submit_success_main_sum
+  description: The total number of successfully submitted crash reports for main process crashes during the reporting period. A value of 0 means
+    submissions were attempted but none succeeded; null indicates no attempts were made.
+  type: INT64
+- name: crash_submit_success_plugin_sum
+  description: The total number of successfully submitted crash reports for plugin process crashes during the reporting period. Null indicates
+    no plugin crash submission successes were recorded.
+  type: INT64
+- name: crash_time
+  description: The timestamp at which a crash occurred, represented as a string. This records the wall-clock time of the crash event.
+  type: STRING
+- name: crashes_detected_content_sum
+  description: The total number of detected content process crashes during the reporting period. Null indicates no content process crashes were
+    detected.
+  type: INT64
+- name: crashes_detected_gmplugin_sum
+  description: The total number of detected Gecko Media Plugin (GMP) process crashes during the reporting period. Null indicates no GMP process
+    crashes were detected.
+  type: INT64
+- name: crashes_detected_plugin_sum
+  description: The total number of detected plugin process crashes during the reporting period. Null indicates no plugin process crashes were
+    detected.
+  type: INT64
+- name: crashing_users
+  description: The number or rate of users who experienced a crash within a given reporting dimension. Non-integer values may represent fractional
+    user counts in aggregated or sampled data.
+  type: FLOAT64
+- name: cumulative_new_profiles
+  description: The running total of new browser profiles created up to and including the current reporting period. A value of 0 indicates no new
+    profiles have been created for that segment.
+  type: INT64
+- name: daily_users
+  description: The count of unique users active on a given day within the reporting segment. A value of 0 indicates no active users were recorded
+    for that segment on that day.
+  type: INT64
+- name: date
+  description: The calendar date associated with the record, formatted as a YYYY-MM-DD string. This typically represents the day on which the
+    activity or metric was measured.
+- name: date_from
+  description: The inclusive start date of the reporting or aggregation window. Records in the row apply to activity on or after this date.
+  type: DATE
+- name: date_to
+  description: The inclusive end date of the reporting or aggregation window. Records in the row apply to activity on or before this date.
+  type: DATE
+- name: dau
+  description: Daily Active Users; the count of unique users who were active on a given day. A value of 0 indicates no active users were counted
+    for that dimension on that day.
+  type: INT64
+- name: days_active_bits
+  description: A 28-bit integer bitmask representing the days within a rolling 28-day window on which the user was active. Each bit corresponds
+    to one day, with the most significant bit representing the most recent day.
+  type: INT64
+- name: days_created_profile_bits
+  description: A bitmask representing the days within a rolling window on which a new browser profile was created. Each bit corresponds to one
+    day in the window.
+  type: INT64
+- name: days_had_8_active_ticks_bits
+  description: A bitmask representing the days within a rolling window on which the user had at least 8 active ticks, used as a proxy for meaningful
+    engagement. Each bit corresponds to one day in the window.
+  type: INT64
+- name: days_interacted_bits
+  description: A bitmask representing the days within a rolling window on which the user had at least one interaction with the browser UI. Each
+    bit corresponds to one day in the window.
+  type: INT64
+- name: days_logged_event_bits
+  description: A bitmask representing the days within a rolling window on which at least one telemetry event was logged by the client. Each bit
+    corresponds to one day in the window.
+  type: INT64
+- name: days_opened_dev_tools_bits
+  description: A bitmask representing the days within a rolling window on which the user opened browser developer tools. Each bit corresponds
+    to one day in the window; a value of 0 indicates developer tools were never opened.
+  type: INT64
+- name: days_seen_bits
+  description: A bitmask representing the days within a rolling window on which the client submitted a telemetry ping and was therefore 'seen'.
+    Each bit corresponds to one day in the window.
+  type: INT64
+- name: days_seen_in_experiment
+  description: An array of structs recording, for each experiment and branch the user was enrolled in, a bitmask of the days within the rolling
+    window on which the user was seen. Each struct contains the experiment ID, branch name, and a bits integer.
+  type: RECORD
+- name: days_since_first_seen
+  description: The number of days elapsed since the client was first observed submitting telemetry. A value of 0 indicates the client was first
+    seen on the current reporting day.
+  type: INT64
+- name: days_since_seen
+  description: The number of days elapsed since the client was last observed submitting telemetry. A value of 0 indicates the client was seen
+    on the current reporting day.
+  type: INT64
+- name: days_used_pictureinpicture_bits
+  description: A bitmask representing the days within a rolling window on which the user used the Picture-in-Picture video feature. Each bit corresponds
+    to one day; a value of 0 indicates the feature was not used.
+  type: INT64
+- name: days_viewed_protection_report_bits
+  description: A bitmask representing the days within a rolling window on which the user viewed the Privacy Protections report. Each bit corresponds
+    to one day; a value of 0 indicates the report was never viewed.
+  type: INT64
+- name: days_visited_10_uri_bits
+  description: A bitmask representing the days within a rolling window on which the user visited 10 or more distinct URIs. Each bit corresponds
+    to one day; a value of 0 indicates the threshold was never reached.
+  type: INT64
+- name: days_visited_1_uri_bits
+  description: A bitmask representing the days within a rolling window on which the user visited at least 1 URI. Each bit corresponds to one day;
+    a value of 0 indicates no URI visits were recorded.
+  type: INT64
+- name: days_visited_1_uri_normal_mode_bits
+  description: A bitmask representing the days within a rolling window on which the user visited at least 1 URI in a normal (non-private) browsing
+    window. Each bit corresponds to one day.
+  type: INT64
+- name: days_visited_1_uri_private_mode_bits
+  description: A bitmask representing the days within a rolling window on which the user visited at least 1 URI in a private browsing window.
+    Each bit corresponds to one day; a value of 0 indicates private browsing was not used.
+  type: INT64
+- name: days_visited_5_uri_bits
+  description: A bitmask representing the days within a rolling window on which the user visited 5 or more distinct URIs. Each bit corresponds
+    to one day; a value of 0 indicates the threshold was never reached.
+  type: INT64
+- name: db_version
+  description: The version identifier of the database or data snapshot used to produce the record, expressed as an ISO 8601 UTC timestamp string.
+    This indicates when the underlying reference data was last updated.
+  type: STRING
+- name: default_browser
+  description: Indicates whether Firefox is set as the user's default browser. True means Firefox is the default browser; false means it is not;
+    null indicates the status could not be determined.
+  type: BOOLEAN
+- name: default_percent
+  description: The percentage of users or pings within a reporting segment for which Firefox is set as the default browser. Values range from
+    0.0 to 100.0.
+  type: FLOAT64
+- name: default_private_search_engine
+  description: The identifier of the search engine configured as the default for private browsing windows (e.g., 'google-b-d', 'ddg'). This corresponds
+    to the engine's internal slug as defined in the search configuration.
+  type: STRING
+- name: default_private_search_engine_data_load_path
+  description: The load path indicating how the default private browsing search engine was installed or sourced (e.g., '[app]ddg' for a built-in
+    engine). Null indicates this metadata was not recorded.
+  type: STRING
+- name: default_private_search_engine_data_name
+  description: The human-readable display name of the default private browsing search engine (e.g., 'DuckDuckGo', 'Google'). Null indicates the
+    name was not recorded.
+  type: STRING
+- name: default_private_search_engine_data_origin
+  description: The origin or provenance of the default private browsing search engine configuration. Null indicates this metadata was not recorded
+    or is not applicable.
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -3061,3 +3061,178 @@ fields:
   description: The cumulative performance measurement (e.g., total duration in milliseconds) of text recognition API calls made during a session
     or aggregation period. Near-100% null rate reflects rare usage of the text recognition feature.
   type: INT64
+- name: text_recognition_interaction_timing_count_sum
+  description: The total count of text recognition interaction timing histogram samples recorded. This field is almost always null, indicating
+    the text recognition feature was not used.
+  type: INT64
+- name: text_recognition_interaction_timing_sum
+  description: The sum of interaction timing values (in milliseconds) recorded during text recognition events. This field is almost always null,
+    only populated when the text recognition feature is actively used.
+  type: INT64
+- name: text_recognition_text_length_count_sum
+  description: The total count of text length histogram samples recorded during text recognition interactions. This field is almost always null,
+    indicating the text recognition feature was not used.
+  type: INT64
+- name: text_recognition_text_length_sum
+  description: The sum of character lengths of text processed during text recognition events. This field is almost always null, only populated
+    when the text recognition feature is actively used.
+  type: INT64
+- name: tile_id
+  description: A numeric identifier for a sponsored or curated tile displayed on the New Tab page. A value of -1 typically indicates an unsponsored
+    or organic tile.
+  type: INT64
+- name: time
+  description: The UTC timestamp representing the time associated with the record, truncated to a granularity such as day or hour depending on
+    the table.
+  type: TIMESTAMP
+- name: timestamp
+  description: The precise UTC timestamp indicating when the event or record was ingested or generated, with microsecond-level precision.
+- name: timezone_offset
+  description: The client's local timezone offset from UTC, expressed in minutes. For example, 120 represents UTC+2 and -300 represents UTC-5.
+  type: INT64
+- name: top_addons
+  description: An array of the most prevalent add-ons observed in a population, each entry containing the add-on name and the proportion of users
+    with that add-on installed.
+  type: RECORD
+- name: top_addons_addon_name
+  description: The name of a frequently installed browser add-on, as reported within the top_addons array for a given population segment.
+- name: top_addons_ratio
+  description: The proportion of users in a population segment who have the associated add-on installed, expressed as a decimal fraction between
+    0 and 1.
+- name: top_locales
+  description: An array of the most prevalent browser locales observed in a population, each entry containing the locale string and the proportion
+    of users with that locale.
+  type: RECORD
+- name: top_locales_locale
+  description: A browser locale code (e.g., 'en-US', 'fr') representing one of the most common locales within a given population segment.
+- name: top_locales_ratio
+  description: The proportion of users in a population segment using the associated locale, expressed as a decimal fraction between 0 and 1.
+- name: topic_preferences_set
+  description: Indicates whether the user has explicitly configured topic preferences for content recommendations. True means preferences have
+    been set; false or null means they have not.
+  type: BOOLEAN
+- name: topic_selection_dismissals
+  description: The number of times the user dismissed the topic selection prompt without making a selection. A value of 0 indicates the prompt
+    was never dismissed.
+  type: INT64
+- name: topic_selection_opened
+  description: The number of times the user opened the topic selection interface. A value of 0 indicates the interface was never opened.
+  type: INT64
+- name: topic_selection_updates
+  description: The number of times the user saved or updated their topic selection preferences. A value of 0 indicates no updates were made.
+  type: INT64
+- name: topsite_clicks
+  description: The total number of times the user clicked on any top site entry on the New Tab page. A value of 0 indicates no clicks occurred.
+  type: INT64
+- name: topsite_dismissals
+  description: The total number of times the user dismissed a top site tile on the New Tab page. A value of 0 indicates no dismissals occurred.
+  type: INT64
+- name: topsite_impressions
+  description: The total number of times top site tiles were displayed to the user on the New Tab page. A value of 0 indicates no impressions
+    were recorded.
+  type: INT64
+- name: topsite_tile_clicks
+  description: The total number of clicks on sponsored top site tiles specifically. A value of 0 indicates the user did not click any sponsored
+    tiles.
+  type: INT64
+- name: topsite_tile_dismissals
+  description: The total number of times the user dismissed a sponsored top site tile. A value of 0 indicates no sponsored tile dismissals occurred.
+  type: INT64
+- name: topsite_tile_impressions
+  description: The total number of impressions for sponsored top site tiles on the New Tab page. A value of 0 indicates no sponsored tile impressions
+    were recorded.
+  type: INT64
+- name: topsites_enabled
+  description: Indicates whether the Top Sites feature is enabled on the user's New Tab page. True means the feature is active; false means the
+    user has disabled it.
+  type: BOOLEAN
+- name: topsites_rows
+  description: The number of rows of top site tiles configured to be displayed on the New Tab page. Higher values indicate more rows of tiles
+    visible to the user.
+  type: INT64
+- name: topsites_sponsored_enabled
+  description: Indicates whether sponsored tiles are enabled within the Top Sites section of the New Tab page. True means sponsored tiles are
+    shown; false means they are disabled.
+  type: BOOLEAN
+- name: topsites_sponsored_tiles_configured
+  description: The number of sponsored tile slots configured to be shown in the Top Sites section of the New Tab page. Common values are 2, 3,
+    or 4 slots.
+  type: INT64
+- name: total_hours_sum
+  description: The total number of hours aggregated across a reporting period for the relevant metric. This field is currently unpopulated and
+    always null.
+  type: NUMERIC
+- name: total_sample
+  description: The total size of the sample population considered in the computation, used as a denominator or baseline for proportional calculations.
+- name: total_users
+  description: The total count of users associated with the record or group, representing the full population for the given aggregation.
+  type: INT64
+- name: tou_daily_active_users
+  description: The number of Terms of Use (ToU) daily active users recorded for the given time period and segment. A value of 0 indicates no active
+    users that day.
+  type: INT64
+- name: tou_monthly_active_users
+  description: The number of Terms of Use (ToU) monthly active users recorded for the given time period and segment. A value of 0 indicates no
+    active users that month.
+  type: INT64
+- name: tou_weekly_active_users
+  description: The number of Terms of Use (ToU) weekly active users recorded for the given time period and segment. A value of 0 indicates no
+    active users that week.
+  type: INT64
+- name: trackers_blocked_sum
+  description: The total number of trackers blocked by Firefox's Enhanced Tracking Protection during the reporting period. Null indicates the
+    feature was not active or no data was reported.
+  type: INT64
+- name: trend
+  description: The modeled trend component of a time series metric, representing the smoothed underlying direction of the data after removing
+    seasonality and noise.
+  type: FLOAT64
+- name: trend_lower
+  description: The lower bound of the confidence interval for the modeled trend component of a time series metric.
+  type: FLOAT64
+- name: trend_upper
+  description: The upper bound of the confidence interval for the modeled trend component of a time series metric.
+  type: FLOAT64
+- name: type
+  description: The category of a browser add-on or extension, indicating its nature. Common values include 'extension', 'locale', 'dictionary',
+    and 'service'.
+  type: STRING
+- name: ua_form_factor
+  description: The form factor of the device as derived from the user agent string, such as 'desktop', 'phone', or 'tablet'.
+  type: STRING
+- name: ua_os_family
+  description: The operating system family as parsed from the user agent string, such as 'Windows', 'Mac OS X', or 'Linux'.
+  type: STRING
+- name: unenroll_count
+  description: The total number of times clients successfully unenrolled from a Nimbus experiment or feature rollout during the reporting period.
+  type: INT64
+- name: unenroll_failed_count
+  description: The total number of times an attempt to unenroll a client from a Nimbus experiment or feature rollout failed during the reporting
+    period.
+  type: INT64
+- name: uninstall_same_day_as_install
+  description: Indicates whether the browser or add-on was uninstalled on the same calendar day it was installed. True means the uninstall occurred
+    on the install day; false means it did not.
+  type: BOOLEAN
+- name: uninstall_to_install_ratio
+  description: The ratio of uninstall events to install events over a given period. A value of 1.0 means uninstalls equal installs; values below
+    1.0 indicate more installs than uninstalls.
+  type: FLOAT64
+- name: uninstalls_count
+  description: The total number of uninstall events recorded during the reporting period for the relevant software or add-on.
+  type: INT64
+- name: unit
+  description: The time unit used for the aggregation period of the record. Values are 'day' for daily aggregations and 'month' for monthly aggregations.
+  type: STRING
+- name: update_auto_download
+  description: Indicates whether automatic update downloads are enabled for the browser. True means updates are downloaded automatically; false
+    means the user has disabled automatic downloads.
+  type: BOOLEAN
+- name: update_background
+  description: Indicates whether browser updates are applied in the background without requiring user interaction. True means background updates
+    are enabled; false means they are disabled.
+  type: BOOLEAN
+- name: update_channel
+  description: The release channel from which the browser receives updates, such as 'release', 'beta', 'nightly', or 'esr'. This reflects the
+    user's update track and may include custom or misconfigured values.
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -1,0 +1,181 @@
+fields:
+- name: CLICK_COUNT
+  description: The total number of clicks recorded for a tile or content item. A value of 0 indicates the item was shown but never clicked.
+  type: INT64
+- name: DISMISS_COUNT
+  description: The total number of times a tile or content item was dismissed by the user. A value of 0 indicates the item was never dismissed.
+  type: INT64
+- name: ER
+  description: Engagement rate expressed as a decimal fraction, representing the ratio of user interactions to total impressions for a content
+    item.
+  type: FLOAT64
+- name: HAPPENED_AT
+  description: The calendar date on which the event or activity being measured occurred.
+  type: DATE
+- name: IMPRESSION_COUNT
+  description: The total number of times a tile or content item was displayed to users. Higher values indicate more frequent exposure.
+  type: INT64
+- name: POSITION
+  description: The zero-based index position of a tile or content item within its display grid or list. Lower values indicate positions closer
+    to the top-left of the layout.
+  type: INT64
+- name: SAVE_COUNT
+  description: The total number of times a tile or content item was saved (e.g., to Pocket) by users. A value of 0 indicates the item was never
+    saved.
+  type: INT64
+- name: TILE_ID
+  description: A unique numeric identifier for a sponsored or organic tile displayed in the Firefox New Tab experience. Each distinct tile asset
+    is assigned its own ID.
+  type: INT64
+- name: _GS_FILE_DATE
+  description: 'The date partition string extracted from the source Google Cloud Storage file path, indicating the date the source data file covers
+    (format: date=YYYY-MM-DD).'
+  type: STRING
+- name: _GS_FILE_NAME
+  description: The full path and filename of the source file in Google Cloud Storage from which this row was loaded, including directory structure,
+    date partition, and time partition.
+  type: STRING
+- name: _GS_FILE_ROW_NUMBER
+  description: The 0-based row number of this record within its source Google Cloud Storage file, used to uniquely identify a row within a given
+    file.
+  type: INT64
+- name: _GS_FILE_TIME
+  description: 'The time partition string extracted from the source Google Cloud Storage file path, indicating when the source data file was generated
+    (format: time=HH-MM-SS-mmm or a Unix timestamp).'
+  type: STRING
+- name: _LOADED_AT
+  description: The nanosecond-precision Unix timestamp (as an INT64) recording when this row was loaded into the data warehouse from its source
+    file.
+  type: INT64
+- name: a11y_theme
+  description: A map of accessibility theme settings active in the browser, where each key is a theme identifier and the value indicates whether
+    that theme is enabled.
+  type: RECORD
+- name: aborts_content_sum
+  description: The total number of content-process abort events recorded during a session or aggregation period. A null value indicates no data
+    was collected for this metric.
+  type: INT64
+- name: aborts_gmplugin_sum
+  description: The total number of Gecko Media Plugin (GMP) process abort events recorded during a session or aggregation period. A null value
+    indicates no data was collected for this metric.
+  type: INT64
+- name: aborts_plugin_sum
+  description: The total number of legacy plugin process abort events recorded during a session or aggregation period. A null value indicates
+    no data was collected for this metric.
+  type: INT64
+- name: account_enabled
+  description: Indicates whether the associated user account is active and enabled. True means the account is enabled; false means it has been
+    disabled.
+  type: BOOLEAN
+- name: activated
+  description: Indicates whether a feature or product has been activated for the client. True means it has been activated; false means it has
+    not.
+  type: BOOLEAN
+- name: active_addon_name
+  description: The human-readable display name of an active browser extension or add-on installed by the user.
+  type: STRING
+- name: active_addons
+  description: A structured array of metadata about all active browser add-ons installed on the client, including identifiers, versioning, installation
+    details, and compatibility flags.
+- name: active_addons_count_mean
+  description: The mean number of active add-ons installed across the client's sessions within the aggregation period.
+  type: FLOAT64
+- name: active_clients
+  description: The count of distinct clients that were active during the aggregation period.
+  type: INT64
+- name: active_experiment_branch
+  description: The branch of an active experiment the client was enrolled in (e.g., 'control' or 'treatment'). Null when the client was not part
+    of any active experiment.
+  type: STRING
+- name: active_experiment_id
+  description: The identifier of the active experiment the client was enrolled in. Null when the client was not enrolled in any experiment.
+  type: STRING
+- name: active_hours
+  description: The total number of hours the browser was actively used (i.e., the user was interacting with it) during the measurement period.
+    Null when usage data was not available.
+  type: FLOAT64
+- name: active_hours_per_user_ratio
+  description: The ratio of total active hours to the number of users within an aggregation group, representing the average active hours per user.
+  type: FLOAT64
+- name: active_hours_sum
+  description: The sum of active browser usage hours across all sessions or clients within the aggregation period.
+  type: FLOAT64
+- name: active_metric_date
+  description: Indicates whether the record's date falls within the active metric collection window. True means the date is within the active
+    window; false means it is outside it.
+- name: activity_date_week
+  description: The Monday-aligned start date of the ISO week in which the user activity occurred, used for weekly aggregations.
+  type: DATE
+- name: activity_segment
+  description: A categorical label describing the user's activity level, such as 'core_user', 'regular_user', 'casual_user', 'infrequent_user',
+    or 'other', based on their engagement frequency.
+  type: STRING
+- name: ad_clicks
+  description: The total number of times the user clicked on an advertisement during the measurement period. Null when no ad click data was collected.
+- name: ad_clicks_count_all
+  description: The aggregated count of all ad click events across all ad types recorded for a client or group during the measurement period. Null
+    when no ad click events were observed.
+  type: INT64
+- name: additive_terms
+  description: The sum of all additive component contributions from a time-series forecasting model (e.g., trend, seasonality), representing the
+    combined fitted value before any transformations.
+  type: FLOAT64
+- name: additive_terms_lower
+  description: The lower bound of the uncertainty interval for the sum of additive forecasting model components, representing the pessimistic
+    end of the predicted range.
+  type: FLOAT64
+- name: additive_terms_upper
+  description: The upper bound of the uncertainty interval for the sum of additive forecasting model components, representing the optimistic end
+    of the predicted range.
+  type: FLOAT64
+- name: addon_compatibility_check_enabled
+  description: Indicates whether the browser's add-on compatibility checking feature is enabled. True means compatibility checks are active; false
+    means they have been disabled.
+  type: BOOLEAN
+- name: addon_id
+  description: The unique identifier string for a Firefox browser add-on or extension, typically in the format of a UUID or a reverse-DNS email-style
+    string (e.g., 'formautofill@mozilla.org').
+  type: STRING
+- name: adjust_ad_group
+  description: The name of the Adjust ad group attribution associated with the client's install or event, used for mobile marketing attribution.
+    Null when no paid ad group attribution is available.
+  type: STRING
+- name: adjust_campaign
+  description: The name of the Adjust marketing campaign attributed to the client's install or event. Common values include 'Organic' for non-paid
+    installs and specific campaign names for paid channels.
+  type: STRING
+- name: adjust_creative
+  description: The name of the specific creative (ad unit) within an Adjust campaign attributed to the client's install or event. Null when no
+    creative-level attribution is available.
+  type: STRING
+- name: adjust_network
+  description: The advertising network or acquisition channel attributed to the client's install via Adjust, such as 'Organic', 'Google Ads ACI',
+    or 'Untrusted Devices'. Null when no network attribution is available.
+  type: STRING
+- name: agg_type
+  description: The aggregation type used for the metric data, indicating how the underlying values were combined. The only observed value is 'histogram'.
+  type: STRING
+- name: aggregates
+  description: A key-value map representing aggregated metric values, where each key identifies a histogram bucket or metric dimension and the
+    value holds the corresponding aggregated numeric result.
+  type: RECORD
+- name: aggregates_key
+  description: The key component of an aggregated metric entry, typically representing a histogram bucket label or dimension identifier such as
+    a numeric bucket boundary.
+- name: aggregates_value
+  description: The numeric value component of an aggregated metric entry, representing the aggregated quantity (e.g., count or weight) for the
+    corresponding histogram bucket or dimension key.
+- name: app
+  description: The name or identifier of the Mozilla application associated with the telemetry record (e.g., Firefox, Fenix).
+  type: STRING
+- name: app_build_id
+  description: 'The build identifier string for the application, encoding the date and time when the specific build was compiled (format: YYYYMMDDHHmmSS).'
+  type: STRING
+- name: app_channel
+  description: The release channel of the application build, indicating the target audience and stability level. Possible values include 'release',
+    'beta', and 'nightly'.
+  type: STRING
+- name: app_display_version
+  description: The human-readable version string of the application as displayed to users, including major, minor, and patch components (e.g.,
+    '151.0.1' or '115.36.0esr').
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -2081,3 +2081,194 @@ fields:
   description: The zero-based index position of a Pocket story within the New Tab page recommendation grid at the time of the event. Null when
     no specific story position is associated with the record.
   type: INT64
+- name: pocket_thumb_voting_events
+  description: The total number of Pocket thumb-voting events (thumbs up or thumbs down) recorded for a client. A value of 0 indicates no voting
+    activity occurred.
+  type: INT64
+- name: position
+  description: The zero- or one-based ordinal position of an item within a list or UI surface (e.g., a recommendation card or menu entry). Lower
+    values indicate items displayed earlier or higher in the interface.
+  type: INT64
+- name: previous_build_id
+  description: The Firefox build ID that was installed before the most recent update, formatted as a timestamp string (YYYYMMDDHHmmss). Null when
+    no prior build is known, such as on a fresh installation.
+  type: STRING
+- name: process
+  description: The Firefox process type from which a measurement or event originated, such as 'parent' (the main browser process), 'content' (a
+    content renderer process), or 'gpu' (the GPU process).
+  type: STRING
+- name: process_type
+  description: The type of Firefox process associated with a crash or event, such as 'parent', 'content', 'gpu', 'rdd', 'plugin', 'socket', or
+    'utility'. Null values indicate cases where the process type could not be determined.
+  type: STRING
+- name: product
+  description: The Mozilla product name associated with the record, such as 'Fenix', 'Firefox iOS', 'Focus Android', or 'Fennec'. Identifies the
+    application from which the data originates.
+  type: STRING
+- name: profile_age_in_days
+  description: The age of the Firefox profile in days, calculated as the difference between the current date and the profile creation date. A
+    value of 0 indicates the profile was created on the same day.
+  type: INT64
+- name: profile_created
+  description: A numeric representation of the date on which the Firefox profile was created, typically expressed as days since a reference epoch.
+    Used to track when a user first established their profile.
+  type: INT64
+- name: profile_creation_date
+  description: The date on which the Firefox profile was created, formatted as a YYYYMMDD string. Used to determine profile age and cohort membership.
+- name: profile_date
+  description: The date on which the Firefox profile was created, stored as a DATE type. Used to determine profile age and segment users into
+    cohorts by profile creation time.
+- name: profile_group_id
+  description: A UUID that identifies a group of profiles belonging to the same user or installation context. Null when profile group information
+    is unavailable.
+  type: STRING
+- name: push_api_notify_sum
+  description: The total number of Web Push API notifications delivered to a client during the reporting period. Null when no push notifications
+    were received.
+  type: INT64
+- name: qdau_desktop
+  description: The count of qualified daily active users on desktop for a given segment or dimension. A value of 0 indicates no qualifying activity
+    was observed.
+  type: INT64
+- name: qualified_second_day
+  description: A boolean flag indicating whether a new profile met the qualification criteria for second-day retention. True means the profile
+    returned and qualified on the second day after creation.
+  type: BOOLEAN
+- name: qualified_week4
+  description: A boolean flag indicating whether a new profile met the qualification criteria for week-4 retention. True means the profile had
+    sufficient qualifying activity in the fourth week after creation.
+  type: BOOLEAN
+- name: realm
+  description: The deployment realm or environment to which the client or data record belongs (e.g., a specific server region or infrastructure
+    partition). Used to segment data by operational environment.
+  type: STRING
+- name: reason
+  description: The technical reason or signal associated with an event such as a crash, describing the specific exception type or OS signal (e.g.,
+    'SIGSEGV / SEGV_MAPERR', 'EXCEPTION_BREAKPOINT'). Null when no reason was recorded.
+  type: STRING
+- name: recommendation_id
+  description: A UUID that uniquely identifies a specific content recommendation surfaced to a user. Null when no recommendation is associated
+    with the record.
+  type: STRING
+- name: record_key
+  description: The key component of a key-value pair stored within a keyed metric or map-type field. Identifies which bucket, label, or category
+    a corresponding record_value belongs to.
+- name: record_value
+  description: The numeric value component of a key-value pair stored within a keyed metric or histogram bucket. Represents the measured quantity
+    associated with the corresponding record_key.
+- name: region
+  description: The two-letter ISO 3166-1 country code representing the geographic region of the client or user. Null when the region could not
+    be determined.
+  type: STRING
+- name: regressor_00
+  description: The point estimate for the first regressor variable used in a forecasting or modeling pipeline. A value of 0.0 indicates no contribution
+    from this regressor for that record.
+  type: FLOAT64
+- name: regressor_00_lower
+  description: The lower-bound confidence interval estimate for the first regressor variable in a forecasting or modeling pipeline. A value of
+    0.0 indicates no contribution or an unbounded lower estimate.
+  type: FLOAT64
+- name: regressor_00_upper
+  description: The upper-bound confidence interval estimate for the first regressor variable in a forecasting or modeling pipeline. A value of
+    0.0 indicates no contribution or an unbounded upper estimate.
+  type: FLOAT64
+- name: repeat_profile
+  description: A boolean flag indicating whether the profile has been seen in a previous reporting period, making it a returning rather than new
+    profile. True means the profile is a repeat; false means it is newly observed.
+  type: BOOLEAN
+- name: repeat_profiles
+  description: The count of profiles that have been seen in a previous reporting period (i.e., returning profiles) for a given dimension or segment.
+    Complements new profile counts to provide a full picture of the user base.
+  type: INT64
+- name: resolution
+  description: The resolution or outcome classification associated with a record, such as a crash report or support ticket resolution state. Describes
+    how or whether the underlying issue was addressed.
+- name: retained_week4
+  description: An integer flag (0 or null) indicating whether a profile was retained through week 4 after its creation, where 0 means the profile
+    was not retained. Null indicates the retention window had not yet elapsed.
+- name: retained_week_4
+  description: A boolean flag indicating whether a profile was active during the fourth week after its creation. True means the profile was retained;
+    false means it was not; null indicates the window had not yet elapsed.
+- name: retained_week_4_new_profile
+  description: A boolean flag indicating whether a new profile was retained through the fourth week after creation. True means the new profile
+    returned during week 4; false means it did not.
+  type: BOOLEAN
+- name: retained_week_4_new_profiles
+  description: The count of new profiles that were retained through the fourth week after their creation date, for a given segment or reporting
+    dimension.
+  type: INT64
+- name: return_user
+  description: An integer flag indicating whether a user (profile) returned after their initial activity, where a value of 0 indicates no return
+    was observed. Null indicates the observation window had not yet elapsed.
+  type: INT64
+- name: returned_second_day
+  description: A boolean flag indicating whether a new profile returned and was active on the day after its creation (second-day retention). True
+    means the profile returned; false means it did not.
+  type: BOOLEAN
+- name: row_count
+  description: The number of rows associated with a record or aggregation group, often used to indicate how many raw events or pings were rolled
+    up into a single summary row.
+  type: INT64
+- name: row_source
+  description: The platform origin of a row, either 'Desktop' or 'Mobile', indicating whether the data came from a desktop or mobile Firefox client.
+  type: STRING
+- name: sample_id
+  description: A deterministic sample bucket identifier (0–99) derived from the client_id, used to create reproducible random samples of the user
+    population for analysis or experimentation.
+  type: INT64
+- name: sandbox_effective_content_process_level
+  description: The effective sandbox security level applied to Firefox content processes, represented as an integer where higher values indicate
+    stricter sandboxing. Null when the sandbox level could not be determined.
+  type: INT64
+- name: save_count
+  description: The total number of times a user saved an item (e.g., saved to Pocket or bookmarked) during the reporting period. A value of 0
+    indicates no saves occurred.
+  type: INT64
+- name: scalar_a11y_hcm_background
+  description: The RGBA color value of the background color configured in the operating system's High Contrast Mode accessibility setting, stored
+    as a packed integer. Null when High Contrast Mode is not enabled or the value was not collected.
+  type: INT64
+- name: scalar_a11y_hcm_foreground
+  description: The RGBA color value of the foreground (text) color configured in the operating system's High Contrast Mode accessibility setting,
+    stored as a packed integer. Null when High Contrast Mode is not enabled or the value was not collected.
+  type: INT64
+- name: scalar_combined_webrtc_nicer_stun_retransmits_sum
+  description: The total number of STUN packet retransmissions observed during WebRTC sessions using the NICEr library. Currently always null,
+    indicating this metric is not yet being collected.
+  type: INT64
+- name: scalar_combined_webrtc_nicer_turn_401s_sum
+  description: The total number of 401 (Unauthorized) error responses received from TURN servers during WebRTC sessions using the NICEr library.
+    Currently always null, indicating this metric is not yet being collected.
+  type: INT64
+- name: scalar_combined_webrtc_nicer_turn_403s_sum
+  description: The total number of 403 (Forbidden) error responses received from TURN servers during WebRTC sessions using the NICEr library.
+    Currently always null, indicating this metric is not yet being collected.
+  type: INT64
+- name: scalar_combined_webrtc_nicer_turn_438s_sum
+  description: The total number of 438 (Stale Nonce) error responses received from TURN servers during WebRTC sessions using the NICEr library.
+    Currently always null, indicating this metric is not yet being collected.
+  type: INT64
+- name: scalar_content_navigator_storage_estimate_count_sum
+  description: The total number of times the navigator.storage.estimate() API was called in content processes during the reporting period. Currently
+    always null, indicating this metric is not yet being collected.
+  type: INT64
+- name: scalar_content_navigator_storage_persist_count_sum
+  description: The total number of times the navigator.storage.persist() API was called in content processes during the reporting period. Currently
+    always null, indicating this metric is not yet being collected.
+  type: INT64
+- name: scalar_content_telemetry_event_counts_sum
+  description: A keyed map of telemetry event category-method-object combinations to their total occurrence counts, as recorded from content processes.
+    Each key identifies a distinct event type and the corresponding value is the sum of occurrences.
+  type: RECORD
+- name: scalar_parent_aushelper_websense_reg_version
+  description: The version string of the Websense endpoint security software detected in the Windows registry by the AUS (Application Update Service)
+    helper. Null when Websense is not installed or the version could not be read.
+  type: STRING
+- name: scalar_parent_browser_engagement_max_concurrent_tab_count_max
+  description: The maximum number of browser tabs open simultaneously in any single session during the reporting period, as recorded by the parent
+    process engagement scalar. Null when the metric was not collected.
+  type: INT64
+- name: scalar_parent_browser_engagement_max_concurrent_window_count_max
+  description: The maximum number of browser windows open simultaneously in any single session during the reporting period, as recorded by the
+    parent process engagement scalar. Null when the metric was not collected.
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -997,8 +997,8 @@ fields:
   description: An array of key-value pairs representing all active experiment enrollments for the client at the time of the ping, where the key
     is the experiment slug and the value is the assigned branch. This captures the full set of concurrent experiment enrollments.
 - name: experiments_key
-  description: The slug or unique identifier of an experiment the client is enrolled in, used as the key in the experiments map (e.g. 'fx-accounts-ping-release-rollout-2').
-    This corresponds to the experiment's canonical name in Nimbus or Normandy.
+  description: The slug or unique identifier of an experiment the client is enrolled in, used as the key in the experiments map
+    (e.g. 'fx-accounts-ping-release-rollout-2'). This corresponds to the experiment's canonical name in Nimbus or Normandy.
 - name: experiments_key_value
   description: A nested array of key-value pairs associated with an experiment entry, capturing additional structured metadata beyond the branch
     assignment. This may be empty when no extra metadata is available.
@@ -1181,8 +1181,8 @@ fields:
   description: The most recent Firefox major version number observed among the clients contributing to a given histogram aggregate entry. This
     reflects the newest version present in the aggregated population.
 - name: histogram_aggregates_metric
-  description: The name of the histogram metric being aggregated within a histogram_aggregates entry (e.g., 'http_connection_close_reason', 'network_dns_end_to_connect_start_exp_ms').
-    This identifies which specific instrumentation probe the data originates from.
+  description: The name of the histogram metric being aggregated within a histogram_aggregates entry (e.g., 'http_connection_close_reason',
+    'network_dns_end_to_connect_start_exp_ms'). This identifies which specific instrumentation probe the data originates from.
 - name: histogram_aggregates_metric_type
   description: The type classification of the histogram metric in a histogram_aggregates entry, such as 'histogram-exponential', 'histogram-enumerated',
     'histogram-boolean', 'histogram-categorical', 'histogram-linear', or 'histogram-count'. This determines how bucket boundaries and values should

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -1329,3 +1329,201 @@ fields:
   description: The number of history entries migrated specifically from Microsoft Edge during a migration event. A value of 0 indicates an Edge
     migration was attempted but no entries were transferred; null indicates no Edge migration occurred or the metric was not recorded.
   type: INT64
+- name: history_migrations_quantity_safari
+  description: The number of history entries migrated from Safari into Firefox. A null value indicates that no Safari history migration was attempted
+    or recorded.
+  type: INT64
+- name: holidays
+  description: The estimated holiday effect component from a forecasting model, representing the additive contribution of holiday events to the
+    predicted metric. A value of 0.0 indicates no holiday effect for that period.
+  type: FLOAT64
+- name: holidays_lower
+  description: The lower bound of the confidence interval for the holiday effect component from a forecasting model. A value of 0.0 indicates
+    no holiday effect uncertainty for that period.
+  type: FLOAT64
+- name: holidays_upper
+  description: The upper bound of the confidence interval for the holiday effect component from a forecasting model. A value of 0.0 indicates
+    no holiday effect uncertainty for that period.
+  type: FLOAT64
+- name: id_bucket
+  description: A bucketing identifier (0–19) used to partition clients into evenly distributed groups, typically for sampling or incremental processing
+    purposes.
+  type: INT64
+- name: impression_count
+  description: The total number of times a UI element, recommendation, or piece of content was shown to a user. Higher values indicate repeated
+    exposures.
+  type: INT64
+- name: index
+  description: A positional or ranking identifier associated with a record, such as the position of a search result or suggestion within a list.
+  type: STRING
+- name: install_source
+  description: The source through which the application was installed, such as 'com.android.vending' for the Google Play Store. A null value indicates
+    the install source could not be determined.
+  type: STRING
+- name: install_year
+  description: The calendar year in which the application was first installed on the device. A null value indicates the installation year could
+    not be determined.
+  type: INT64
+- name: installation_first_seen_admin_user
+  description: Indicates whether the user had administrator privileges at the time the installation was first observed. True means admin rights
+    were present; false means they were not.
+  type: BOOLEAN
+- name: installation_first_seen_default_path
+  description: Indicates whether the application was installed in the default installation path when first observed. True means the default path
+    was used; false means a custom path was chosen.
+  type: BOOLEAN
+- name: installation_first_seen_failure_reason
+  description: The reason the installation data could not be retrieved when first observed, such as 'NoError', 'NotFoundError', or 'SyntaxError'.
+    A null value indicates the failure reason was not recorded.
+  type: STRING
+- name: installation_first_seen_from_msi
+  description: Indicates whether the application was installed via an MSI package when first observed. True means an MSI installer was used; false
+    means it was not.
+  type: BOOLEAN
+- name: installation_first_seen_install_existed
+  description: Indicates whether a prior installation of the application already existed on the system when the installation was first observed.
+    True means a previous install was found; false means it was a fresh installation.
+  type: BOOLEAN
+- name: installation_first_seen_installer_type
+  description: The type of installer used when the installation was first observed, such as 'stub', 'full', or 'msix'. A null value indicates
+    the installer type was not available.
+  type: STRING
+- name: installation_first_seen_other_inst
+  description: Indicates whether another non-MSIX installation of the application was present on the system when the installation was first observed.
+    True means another installation was detected; false means it was not.
+  type: BOOLEAN
+- name: installation_first_seen_other_msix_inst
+  description: Indicates whether another MSIX-packaged installation of the application was present on the system when the installation was first
+    observed. True means another MSIX installation was detected; false means it was not.
+  type: BOOLEAN
+- name: installation_first_seen_profdir_existed
+  description: Indicates whether a Firefox profile directory already existed on the system when the installation was first observed. True means
+    a profile directory was found; false means it did not exist.
+  type: BOOLEAN
+- name: installation_first_seen_silent
+  description: Indicates whether the installation was performed silently (without user interaction) when first observed. True means a silent install
+    was used; false means it was an interactive install.
+  type: BOOLEAN
+- name: installation_first_seen_version
+  description: The version of the application that was recorded when the installation was first observed. A null value indicates the version could
+    not be determined at first observation.
+  type: STRING
+- name: installer_type
+  description: The type of installer package used to install the application, either 'full' for a complete installer or 'stub' for a lightweight
+    installer that downloads components during setup.
+  type: STRING
+- name: installs
+  description: The count of new application installations recorded for a given period or segment. A null value indicates the install count was
+    not available for that record.
+  type: INT64
+- name: intensity
+  description: A measure of user engagement intensity, reflecting the frequency or depth of usage within a given period. Higher values indicate
+    more active usage patterns.
+  type: FLOAT64
+- name: ipc_channel_error
+  description: The error message or reason associated with an IPC (Inter-Process Communication) channel failure, such as 'ShutDownKill' or 'GPUProcessKill'.
+    A null value indicates no IPC channel error was recorded.
+  type: STRING
+- name: is_dau
+  description: Indicates whether the client qualifies as a Daily Active User (DAU) for the given date. True means the client meets the DAU criteria;
+    false means it does not.
+  type: BOOLEAN
+- name: is_default_browser
+  description: Indicates whether Firefox is set as the default browser on the client's device. True means it is the default; false means another
+    browser is set as default.
+  type: BOOLEAN
+- name: is_desktop
+  description: Indicates whether the client is running on a desktop platform as opposed to a mobile device. True means the client is on desktop;
+    false means it is on a mobile platform.
+  type: BOOLEAN
+- name: is_new_profile
+  description: Indicates whether the Firefox profile associated with the client was newly created. True means the profile was created recently;
+    false means it is an existing profile.
+  type: BOOLEAN
+- name: is_system
+  description: Indicates whether the add-on or component is a system-level (built-in) item rather than a user-installed one. True means it is
+    a system item; false means it is user-installed.
+  type: BOOLEAN
+- name: is_wow64
+  description: Indicates whether the Firefox process is running as a 32-bit application under the 64-bit Windows-on-Windows (WoW64) compatibility
+    layer. True means WoW64 is in use; false means it is not.
+  type: BOOLEAN
+- name: isp
+  description: The name of the Internet Service Provider associated with the client's IP address. This field provides a granular ISP identification
+    and may include regional carriers.
+  type: STRING
+- name: isp_name
+  description: The canonical name of the Internet Service Provider associated with the client's network connection. This is a normalized or deduplicated
+    version of the ISP identifier.
+  type: STRING
+- name: isp_organization
+  description: The organization name associated with the client's IP address block, as registered with regional internet registries. This may
+    differ from the ISP name when the organization is a reseller or enterprise.
+  type: STRING
+- name: key
+  description: A string identifier representing the specific action, search engine, or event type associated with a record, such as a search entry
+    point or provider key. An empty string indicates no specific key was recorded.
+  type: STRING
+- name: last_bucket
+  description: The upper boundary value of the last bucket in a histogram distribution. This defines the maximum range of the histogram's final
+    bin.
+  type: INT64
+- name: latest_version
+  description: The most recent major version number of the Firefox browser available or tracked at the time of the record. Used to compare client
+    versions against the current release.
+- name: latest_version_ratio
+  description: The proportion of clients or events associated with the latest Firefox version relative to all versions in the cohort. A higher
+    value indicates greater adoption of the current release.
+  type: FLOAT64
+- name: legacy_telemetry_client_count
+  description: The number of distinct legacy telemetry client IDs associated with a given entity or record. Values greater than one may indicate
+    multiple installations or ID collisions.
+  type: INT64
+- name: legacy_telemetry_client_id
+  description: The unique client identifier used in Firefox's legacy telemetry system, formatted as a UUID. This is used to track individual browser
+    installations across telemetry pings.
+  type: STRING
+- name: linkage_first_seen_date
+  description: The earliest date on which a linkage between two identifiers (e.g., client ID and another ID) was first observed in the data. Used
+    to track when a relationship was established.
+  type: DATE
+- name: linkage_last_seen_date
+  description: The most recent date on which a linkage between two identifiers was observed in the data. Used to determine how recently a relationship
+    was active.
+  type: DATE
+- name: linked_client_id
+  description: A UUID representing a Firefox client that has been linked or associated with another identifier, such as a Glean client ID or a
+    profile ID. Used to join records across different telemetry systems.
+  type: STRING
+- name: locale
+  description: The language and region locale of the Firefox browser or application, such as 'en' for English or 'fr' for French. A null value
+    indicates the locale could not be determined.
+  type: STRING
+- name: logins_migrations_quantity_all
+  description: The total number of saved login entries migrated into Firefox from all supported browsers. A null value indicates no login migration
+    data was recorded.
+  type: INT64
+- name: logins_migrations_quantity_chrome
+  description: The number of saved login entries migrated into Firefox from Google Chrome. A null value indicates no Chrome login migration data
+    was recorded.
+  type: INT64
+- name: logins_migrations_quantity_edge
+  description: The number of saved login entries migrated into Firefox from Microsoft Edge. A null value indicates no Edge login migration data
+    was recorded.
+  type: INT64
+- name: logins_migrations_quantity_safari
+  description: The number of saved login entries migrated into Firefox from Safari. A null value indicates no Safari login migration data was
+    recorded.
+  type: INT64
+- name: major_version
+  description: The major version number of the Firefox browser (e.g., 128, 151), representing the primary release train. Used to segment clients
+    by their browser generation.
+  type: INT64
+- name: mau
+  description: The count of days within the past 28-day window that a client was active, used as a proxy for Monthly Active User (MAU) engagement.
+    Higher values indicate more frequent monthly usage.
+  type: INT64
+- name: max_subsession_counter
+  description: The highest subsession counter value recorded for a client within a given day, indicating how many browser subsessions occurred.
+    A value of 1 means only one subsession was recorded.
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -1527,3 +1527,171 @@ fields:
   description: The highest subsession counter value recorded for a client within a given day, indicating how many browser subsessions occurred.
     A value of 1 means only one subsession was recorded.
   type: INT64
+- name: media_play_time_ms_audio_sum
+  description: Total cumulative time in milliseconds that audio media was played during a session. This field is null when no audio playback occurred.
+  type: INT64
+- name: media_play_time_ms_video_sum
+  description: Total cumulative time in milliseconds that video media was played during a session. This field is null when no video playback occurred.
+  type: INT64
+- name: medium
+  description: The marketing or traffic medium through which a user arrived, such as 'referral', 'cpc', or 'firefox-desktop'. Used to classify
+    the acquisition channel for attribution purposes.
+  type: STRING
+- name: memory_gb
+  description: The total amount of physical memory available on the client device, expressed in gigabytes. Used to characterize device hardware
+    capability.
+- name: memory_mb
+  description: The total amount of physical memory available on the client device, expressed in megabytes. Used to characterize device hardware
+    capability at finer granularity than memory_gb.
+  type: INT64
+- name: metadata_app_version
+  description: The version string of the application that submitted the ping, as reported in the submission metadata. This may differ from the
+    user-facing display version.
+  type: STRING
+- name: metadata_first_seen_date_source_ping
+  description: The type of ping that was used to establish the first-seen date for a client profile. Possible values include 'new_profile', 'main',
+    and 'shutdown'.
+- name: metadata_geo_city
+  description: The city resolved from the client's IP address at ping ingestion time using a GeoIP database. This field is frequently null when
+    city-level resolution is unavailable.
+- name: metadata_geo_country
+  description: The two-letter ISO 3166-1 alpha-2 country code resolved from the client's IP address at ping ingestion time. Represents the geographic
+    country of origin for the submission.
+- name: metadata_geo_db_version
+  description: The version timestamp of the GeoIP database used to resolve the client's geographic location at ingestion time. Formatted as an
+    ISO 8601 timestamp string.
+- name: metadata_geo_subdivision1
+  description: The first-level geographic subdivision (e.g., state or province) resolved from the client's IP address at ping ingestion time.
+    Frequently null when subdivision-level resolution is unavailable.
+- name: metadata_geo_subdivision2
+  description: The second-level geographic subdivision resolved from the client's IP address at ping ingestion time. Frequently null when this
+    level of geographic resolution is unavailable.
+- name: metadata_header_date
+  description: The raw HTTP Date header value sent by the client at ping submission time, formatted as an RFC 7231 HTTP date string. May be null
+    if the header was not present in the request.
+- name: metadata_header_dnt
+  description: The value of the HTTP Do Not Track (DNT) header sent by the client, where '1' indicates the user has opted into DNT. Null when
+    the header was not present in the request.
+- name: metadata_header_parsed_date
+  description: The parsed and normalized timestamp derived from the HTTP Date header sent at ping submission time. Null when the Date header was
+    absent or could not be parsed.
+- name: metadata_header_parsed_x_lb_tags_tls_cipher_hex
+  description: The hexadecimal TLS cipher suite identifier extracted from the load balancer's X-LB-Tags header, indicating the cipher negotiated
+    for the client's TLS connection. Common values include '1301' for TLS_AES_128_GCM_SHA256.
+- name: metadata_header_parsed_x_lb_tags_tls_version
+  description: The TLS protocol version extracted from the load balancer's X-LB-Tags header, indicating the version negotiated for the client's
+    connection. Observed values include 'TLSv1.3' and 'TLSv1.2'.
+- name: metadata_header_parsed_x_source_tags
+  description: An array of source tag strings parsed from the X-Source-Tags HTTP header, used to annotate the origin or routing path of a ping
+    submission. May be an empty array when no tags are present.
+- name: metadata_header_x_debug_id
+  description: The value of the X-Debug-Id HTTP header sent with the ping, used to identify debug or test submissions. Typically null for production
+    pings.
+- name: metadata_header_x_foxsec_ip_reputation
+  description: The IP reputation score or classification provided by the FoxSec system, attached via the X-FoxSec-IP-Reputation HTTP header at
+    ingestion time. Typically null when no reputation data is available.
+- name: metadata_header_x_lb_tags
+  description: The raw value of the X-LB-Tags HTTP header as set by the load balancer, containing TLS version and cipher suite information for
+    the client connection (e.g., 'TLSv1.3, 1301').
+- name: metadata_header_x_pingsender_version
+  description: The version of the PingSender component that submitted the ping, as reported in the X-PingSender-Version HTTP header. Null when
+    the ping was not submitted via PingSender.
+- name: metadata_header_x_source_tags
+  description: The raw value of the X-Source-Tags HTTP header sent with the ping submission, used to label the source or routing context. Typically
+    null when the header is absent.
+- name: metadata_header_x_telemetry_agent
+  description: The User-Agent-style string identifying the telemetry SDK and runtime environment used to submit the ping (e.g., 'Glean/67.2.0
+    (Rust on Windows)'). Indicates the Glean SDK version and host platform.
+- name: metadata_isp_db_version
+  description: The version timestamp of the ISP database used to resolve the client's internet service provider information at ingestion time.
+    Formatted as an ISO 8601 timestamp string.
+- name: metadata_isp_name
+  description: The name of the internet service provider resolved from the client's IP address at ping ingestion time. Represents the commercial
+    ISP name associated with the submitting client.
+- name: metadata_isp_organization
+  description: The organization name associated with the client's IP address as resolved from the ISP database at ingestion time. May differ slightly
+    from metadata_isp_name for the same network operator.
+- name: metadata_reported_main_ping
+  description: Indicates whether a main ping was reported for this client profile record. True means a main ping was received; false means it
+    was not.
+- name: metadata_reported_new_profile_ping
+  description: Indicates whether a new_profile ping was reported for this client profile record. True means a new_profile ping was received; false
+    means it was not.
+- name: metadata_reported_shutdown_ping
+  description: Indicates whether a shutdown ping was reported for this client profile record. True means a shutdown ping was received; false means
+    it was not.
+- name: metadata_user_agent_browser
+  description: The browser name parsed from the User-Agent HTTP header of the ping submission request, such as 'Firefox' or 'Chrome'. Null when
+    the User-Agent header is absent or unrecognized.
+- name: metadata_user_agent_os
+  description: The operating system name and version parsed from the User-Agent HTTP header of the ping submission request, such as 'Windows 10'
+    or 'Android'. Null when the User-Agent header is absent or unrecognized.
+- name: metadata_user_agent_version
+  description: The browser version number parsed from the User-Agent HTTP header of the ping submission request. Null when the User-Agent header
+    is absent or cannot be parsed.
+- name: metric
+  description: The name of the telemetry metric or histogram being recorded, such as 'gc_ms' or 'thread_wakeup'. Used to identify which specific
+    measurement a row represents.
+  type: STRING
+- name: metric_date
+  description: The calendar date associated with the metric observation or aggregation window. Used to partition and filter metric data by time.
+  type: DATE
+- name: metric_name
+  description: A short, human-readable label identifying the type of metric being tracked, such as 'uri_count' or 'active_ticks'. Used to distinguish
+    among different measurement concepts within the same dataset.
+  type: STRING
+- name: metric_type
+  description: The collection methodology or storage format of the metric, such as 'histogram-exponential', 'scalar', or 'keyed-scalar'. Determines
+    how the metric values should be interpreted and aggregated.
+  type: STRING
+- name: metrics
+  description: A nested struct containing all Glean metric values reported in a ping, organized by metric type (e.g., boolean, string, quantity,
+    timespan). Each sub-field corresponds to a specific named metric collected by the application.
+  type: RECORD
+- name: min_subsession_counter
+  description: The minimum subsession counter value observed for a client within the aggregation period, indicating the earliest subsession sequence
+    number. A value of 1 typically corresponds to the first subsession of a browser session.
+  type: INT64
+- name: monthly_users
+  description: The count of distinct active users observed within a rolling monthly window. Used to measure monthly active user (MAU) trends.
+  type: INT64
+- name: moz_crash_reason
+  description: A human-readable string describing the reason for a Mozilla crash, such as an OOM condition or a blocking shutdown step. Null when
+    no specific crash reason was recorded.
+  type: STRING
+- name: multiplicative_terms
+  description: The multiplicative component of a forecasting or modeling decomposition, representing the combined multiplicative factor applied
+    to the baseline. A value of 0.0 indicates no multiplicative adjustment.
+  type: FLOAT64
+- name: multiplicative_terms_lower
+  description: The lower bound of the confidence interval for the multiplicative terms in a forecasting or decomposition model. A value of 0.0
+    indicates no lower-bound adjustment is estimated.
+  type: FLOAT64
+- name: multiplicative_terms_upper
+  description: The upper bound of the confidence interval for the multiplicative terms in a forecasting or decomposition model. A value of 0.0
+    indicates no upper-bound adjustment is estimated.
+  type: FLOAT64
+- name: n_created_pictureinpicture
+  description: The number of times a Picture-in-Picture video window was created during the observation period. A value of 0 indicates the feature
+    was not used; null indicates the data was not collected.
+  type: INT64
+- name: n_logged_event
+  description: The total number of events logged for a client or session during the observation period. Reflects the volume of tracked user interactions
+    or system events recorded.
+  type: INT64
+- name: n_viewed_protection_report
+  description: The number of times the Firefox Privacy Protections report was viewed during the observation period. A value of 0 indicates the
+    report was not opened.
+  type: INT64
+- name: name
+  description: A human-readable name string associated with the entity being described, such as an add-on or extension name. May be null or a
+    placeholder string when the name is unavailable or not yet resolved.
+  type: STRING
+- name: nbr_clients_uninstalling
+  description: The count of distinct clients that uninstalled the application or a component during the observation period. Used to track uninstall
+    volume and churn.
+  type: INT64
+- name: nbr_cpu_cores
+  description: The number of logical CPU cores available on the client device. Used to characterize device hardware capability and segment clients
+    by compute capacity.
+  type: INT64

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -3236,3 +3236,192 @@ fields:
   description: The release channel from which the browser receives updates, such as 'release', 'beta', 'nightly', or 'esr'. This reflects the
     user's update track and may include custom or misconfigured values.
   type: STRING
+- name: update_count
+  description: The number of browser updates that were applied. A value of 0 indicates no updates were applied during the period.
+  type: INT64
+- name: update_enabled
+  description: Indicates whether automatic browser updates are enabled for the client. True means updates are turned on; false means they have
+    been disabled.
+  type: BOOLEAN
+- name: update_failed_count
+  description: The number of browser update attempts that failed. A value of 0 indicates all update attempts succeeded or no updates were attempted.
+  type: INT64
+- name: uri_count
+  description: The total number of URIs visited by the client during the reporting period. Null values indicate the metric was not recorded for
+    that row.
+  type: INT64
+- name: uri_method
+  description: The HTTP method used in a URI request (e.g., GET, POST). Identifies the type of action performed in the request.
+  type: STRING
+- name: uris_per_user
+  description: The average number of URIs visited per user over the reporting period. Null values indicate insufficient data to compute the average.
+  type: FLOAT64
+- name: usage
+  description: A categorical label describing the type of Firefox Desktop activity observed, such as any activity, visiting 5 or more URIs, or
+    opening Developer Tools.
+  type: STRING
+- name: user_agent
+  description: The browser or user agent type used to access a resource, with values such as firefox, chrome, edge, ie, or other. Null indicates
+    the user agent was not captured.
+  type: STRING
+- name: user_cancelled
+  description: Indicates whether a user explicitly cancelled an operation or prompt. True means the user cancelled; false means they did not.
+    Null indicates the field was not applicable or not recorded.
+- name: user_pref_app_shield_optoutstudies_enabled
+  description: The user's preference setting for opting out of Shield studies, stored as a string boolean. A value of 'true' means the user has
+    opted in to studies; 'false' means they have opted out.
+  type: STRING
+- name: user_pref_browser_newtabpage_enabled
+  description: The user's preference setting controlling whether the browser's New Tab Page is enabled, stored as a string boolean. A value of
+    'false' indicates the new tab page has been disabled by the user.
+  type: STRING
+- name: user_pref_browser_search_region
+  description: The geographic region code associated with the user's browser search preference, typically an ISO 3166-1 alpha-2 country code such
+    as 'US' or 'DE'.
+  type: STRING
+- name: user_pref_browser_search_suggest_enabled
+  description: The user's preference setting for whether search suggestions are enabled in the browser, stored as a string boolean. A value of
+    'false' means the user has disabled search suggestions.
+  type: STRING
+- name: user_pref_browser_urlbar_quicksuggest_data_collection_enabled
+  description: The user's preference controlling whether data collection for the urlbar Quick Suggest feature is enabled, stored as a string boolean.
+    A value of 'false' means the user has opted out of data collection for Quick Suggest.
+  type: STRING
+- name: user_pref_browser_urlbar_quicksuggest_onboarding_dialog_choice
+  description: The choice the user made when presented with the Quick Suggest onboarding dialog, such as closing it or selecting 'not now' or
+    'reject'. Null indicates the dialog was not shown or no choice was recorded.
+  type: STRING
+- name: user_pref_browser_urlbar_show_search_suggestions_first
+  description: The user's preference for whether search suggestions are displayed before browsing history in the urlbar, stored as a string boolean.
+    A value of 'false' means search suggestions are not prioritized first.
+  type: STRING
+- name: user_pref_browser_urlbar_suggest_bestmatch
+  description: The user's preference controlling whether the Best Match feature is enabled in the urlbar, stored as a string boolean. A value
+    of 'true' means Best Match suggestions are shown.
+  type: STRING
+- name: user_pref_browser_urlbar_suggest_quicksuggest
+  description: The user's legacy preference setting for whether Quick Suggest results are shown in the urlbar, stored as a string boolean. Null
+    indicates the preference was not set or not applicable.
+  type: STRING
+- name: user_pref_browser_urlbar_suggest_quicksuggest_nonsponsored
+  description: The user's preference controlling whether non-sponsored Quick Suggest results are shown in the urlbar, stored as a string boolean.
+    A value of 'false' means non-sponsored suggestions are disabled.
+  type: STRING
+- name: user_pref_browser_urlbar_suggest_quicksuggest_sponsored
+  description: The user's preference controlling whether sponsored Quick Suggest results are shown in the urlbar, stored as a string boolean.
+    A value of 'false' means sponsored suggestions are disabled.
+  type: STRING
+- name: user_pref_browser_urlbar_suggest_searches
+  description: The user's preference for whether search suggestions are shown in the urlbar, stored as a string boolean. A value of 'false' indicates
+    the user has disabled urlbar search suggestions.
+  type: STRING
+- name: user_pref_browser_widget_in_navbar
+  description: The user's preference indicating whether a specific browser widget is displayed in the navigation bar, stored as a string boolean.
+    A value of 'true' means the widget is present in the navbar.
+  type: STRING
+- name: users
+  description: The count of distinct users associated with a given record or group. Represents the number of unique clients contributing to an
+    aggregated measurement.
+  type: INT64
+- name: validation_failed_count
+  description: The number of validation checks that failed for a given record or session. A value of 0 indicates all validation checks passed.
+  type: INT64
+- name: value
+  description: A generic integer value associated with a measurement, event, or metric. The specific meaning depends on the context of the surrounding
+    fields.
+- name: vendor
+  description: The organization that produced the browser or software being measured. In this dataset the value is consistently 'Mozilla'.
+  type: STRING
+- name: version
+  description: The version string of the software, add-on, or component being measured. Follows standard versioning conventions such as major.minor.patch.
+- name: visited_5_uri_dau
+  description: The number of distinct users who visited 5 or more URIs on a given day, used as a daily active user engagement metric. A value
+    of 0 indicates no qualifying users were observed that day.
+  type: INT64
+- name: visited_5_uri_mau
+  description: The number of distinct users who visited 5 or more URIs within the past 28 days, used as a monthly active user engagement metric.
+    A value of 0 indicates no qualifying users were observed that month.
+  type: INT64
+- name: visited_5_uri_wau
+  description: The number of distinct users who visited 5 or more URIs within a 7-day window, used as a weekly active user engagement metric.
+    A value of 0 indicates no qualifying users were observed that week.
+  type: INT64
+- name: visits
+  description: The number of visits or sessions recorded for a given record. Null values indicate the visit count was not available or applicable
+    for that row.
+  type: INT64
+- name: visits_with_default_ui
+  description: The number of urlbar or search visits in which the default UI configuration was presented to the user without any experimental
+    treatment applied.
+  type: INT64
+- name: visits_with_non_impression_engagement
+  description: The number of urlbar visits where the user engaged with a result beyond a passive impression, such as clicking or interacting with
+    a suggestion. A value of 0 indicates no such engagements occurred.
+  type: INT64
+- name: visits_with_non_search_engagement
+  description: The number of urlbar visits where the user engaged with a non-search result, such as navigating to a URL or selecting a bookmark
+    suggestion. A value of 0 indicates all engagements were search-type.
+  type: INT64
+- name: wallpaper_clicks
+  description: The number of times a user clicked on a wallpaper or background element in the browser's New Tab Page. A value of 0 indicates no
+    wallpaper clicks occurred during the period.
+  type: INT64
+- name: wau
+  description: The count of weekly active users, representing the number of distinct clients active within a 7-day rolling window. A value of
+    0 indicates no activity was recorded in that week.
+  type: INT64
+- name: weather_widget_change_display_to_detailed
+  description: The number of times a user switched the New Tab Page weather widget from the simple view to the detailed view. A value of 0 indicates
+    the display was never changed to detailed during the period.
+  type: INT64
+- name: weather_widget_change_display_to_simple
+  description: The number of times a user switched the New Tab Page weather widget from the detailed view back to the simple view. A value of
+    0 indicates the display was never changed to simple during the period.
+  type: INT64
+- name: weather_widget_clicks
+  description: The number of times a user clicked on the weather widget displayed on the New Tab Page. A value of 0 indicates no clicks on the
+    weather widget were recorded.
+  type: INT64
+- name: web_notification_shown_sum
+  description: The total number of web notifications shown to the user during the reporting period. Null values, which are nearly universal, indicate
+    the metric was not recorded or not applicable.
+  type: INT64
+- name: weekly
+  description: A floating-point metric value aggregated or forecasted on a weekly basis. Typically represents a modeled or computed estimate rather
+    than a raw event count.
+  type: FLOAT64
+- name: weekly_lower
+  description: The lower bound of a confidence or credible interval for a weekly metric estimate. Used alongside weekly and weekly_upper to express
+    uncertainty in a modeled weekly value.
+  type: FLOAT64
+- name: weekly_upper
+  description: The upper bound of a confidence or credible interval for a weekly metric estimate. Used alongside weekly and weekly_lower to express
+    uncertainty in a modeled weekly value.
+  type: FLOAT64
+- name: weekly_users
+  description: The count of distinct users active within a given 7-day window. A value of 0 indicates no users were observed as active during
+    that week.
+  type: INT64
+- name: window_end
+  description: The UTC timestamp marking the end of a time window used for aggregation or analysis. Together with window_start, it defines the
+    closed interval over which metrics are computed.
+  type: TIMESTAMP
+- name: window_start
+  description: The UTC timestamp marking the beginning of a time window used for aggregation or analysis. Together with window_end, it defines
+    the interval over which metrics are computed.
+  type: TIMESTAMP
+- name: windows_build_number
+  description: The Windows OS build number of the client's operating system, such as 19045 for a specific Windows 10 release. Null values indicate
+    the client was not running a Windows operating system.
+- name: windows_ubr
+  description: The Windows Update Build Revision (UBR) number, which identifies the specific cumulative update applied on top of the base Windows
+    build. Null values indicate the client is not on Windows or the value was not collected.
+  type: INT64
+- name: windows_version
+  description: A human-readable label for the client's Windows operating system version, such as 'Windows 10' or 'Windows 11'. Null values indicate
+    the client was not running a Windows OS.
+  type: STRING
+- name: xpcom_abi
+  description: The XPCOM Application Binary Interface identifier describing the CPU architecture and compiler ABI of the Firefox build, such as
+    'x86_64-msvc' or 'aarch64-gcc3'.
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -757,3 +757,191 @@ fields:
   description: The origin or provenance of the default private browsing search engine configuration. Null indicates this metadata was not recorded
     or is not applicable.
   type: STRING
+- name: default_private_search_engine_data_submission_url
+  description: The submission URL template for the user's default private browsing search engine, used to construct search queries in private
+    windows. This field is almost always null, indicating it is only populated when a distinct private search engine is explicitly configured.
+  type: STRING
+- name: default_search
+  description: The identifier of the user's default search engine, as reported by the client. Values such as 'unknown' indicate cases where the
+    engine could not be identified or mapped to a known engine.
+  type: STRING
+- name: default_search_engine
+  description: The internal identifier of the user's default search engine (e.g., 'google-b-d', 'baidu'), which encodes both the engine and any
+    partner or distribution-specific configuration. This field represents the engine key as recognized by Firefox's search service.
+  type: STRING
+- name: default_search_engine_data_load_path
+  description: The load path indicating how and from where the default search engine definition was loaded, such as from the built-in application
+    bundle ('[app]') or an add-on ('[addon]'). This field helps distinguish between pre-packaged, extension-provided, and other engine sources.
+  type: STRING
+- name: default_search_engine_data_name
+  description: The human-readable display name of the user's default search engine as reported by the browser (e.g., 'Google', 'DuckDuckGo', '百度').
+    This field reflects the localized name of the engine as configured on the client.
+  type: STRING
+- name: default_search_engine_data_origin
+  description: Indicates how the default search engine was established, with values such as 'default' (set by the application), 'verified' (confirmed
+    via policy or signature), 'unverified', or 'invalid'. This field is predominantly null when origin information is not captured or applicable.
+  type: STRING
+- name: default_search_engine_data_submission_url
+  description: The base URL template used to submit queries to the user's default search engine, including any partner or distribution-specific
+    tracking parameters (e.g., 'client=firefox-b-d'). This URL is constructed by the browser when initiating a search.
+  type: STRING
+- name: device
+  description: A string identifying the device on which the browser is running, typically in 'Manufacturer-Model' format (e.g., 'iPhone14,5',
+    'MediaTek-SMART TV'). This field is used to distinguish hardware types across the client population.
+  type: STRING
+- name: device_model
+  description: The model identifier of the device on which the browser is running (e.g., 'iPhone14,5'). This field may be null for desktop or
+    unrecognized device types where model information is unavailable.
+  type: STRING
+- name: devtools_toolbox_opened_count_sum
+  description: The total number of times the Firefox Developer Tools toolbox was opened during the reporting period. A null value indicates the
+    metric was not collected or the toolbox was never opened for that record.
+  type: INT64
+- name: dismiss_count
+  description: The number of times a user dismissed a prompt, notification, or UI element during the reporting period. A value of zero indicates
+    the element was never dismissed.
+  type: INT64
+- name: display_version
+  description: The user-facing version string of the Firefox application as displayed in the UI (e.g., '151.0.2', '115.31.0esr'). This may differ
+    from the internal build version and includes ESR and other release-track suffixes.
+  type: STRING
+- name: disqualification_count
+  description: The number of times a client or session was disqualified from a study, experiment, or targeting cohort during the reporting period.
+    A value of zero indicates no disqualifications occurred.
+  type: INT64
+- name: distribution_id
+  description: An identifier for the Firefox distribution package the client is running, such as 'default' for the standard Mozilla build or partner-specific
+    identifiers like 'canonical-002' or 'mozilla-MSIX'. This field is null when no distribution identifier is available.
+  type: STRING
+- name: distribution_model
+  description: A categorical label describing the channel or method through which the Firefox distribution was delivered to the user (e.g., 'non-distribution',
+    'OS pre-installed', 'OEM pre-installed', 'secondary store'). This field classifies how the client obtained the browser.
+  type: STRING
+- name: distribution_version
+  description: The version string of the distribution package, which may differ from the Firefox application version and indicates the specific
+    release of the partner or vendor distribution. This field is frequently null when no distribution versioning is applicable.
+  type: STRING
+- name: distributor
+  description: The name of the organization or project responsible for distributing this Firefox build (e.g., 'canonical', 'mozillaonline', 'mint').
+    This field is null for standard Mozilla-distributed builds where no third-party distributor is involved.
+  type: STRING
+- name: distributor_channel
+  description: The specific channel or mechanism through which the distributor delivered Firefox to the end user (e.g., 'ubuntu', 'mainWinStub',
+    'firefox'). This field complements the distributor field and is null for non-partner distributions.
+  type: STRING
+- name: doc_type
+  description: The type of telemetry document or ping that generated the record (e.g., 'main', 'crash', 'event'). This field identifies the schema
+    and content category of the originating ping.
+  type: STRING
+- name: document_id
+  description: A unique UUID identifying an individual telemetry ping submission. This identifier is used to deduplicate records and trace a specific
+    ping through the data pipeline.
+  type: STRING
+- name: dom_parentprocess_private_window_used
+  description: Indicates whether a private browsing window was used in the parent DOM process during the session. A value of true means at least
+    one private window was opened; false means no private window activity was detected.
+  type: BOOLEAN
+- name: domains_per_user
+  description: The average number of distinct domains visited per user during the reporting period. This metric is used to characterize browsing
+    breadth across the user population.
+  type: FLOAT64
+- name: downloads
+  description: The number of file downloads initiated by the user during the reporting period. A value of zero indicates no downloads were started.
+  type: INT64
+- name: ds
+  description: The datestamp (as a UTC timestamp) representing the date partition or time dimension associated with the record. This field is
+    commonly used for time-series partitioning and filtering.
+  type: TIMESTAMP
+- name: durations
+  description: The total duration, in seconds, associated with a session, event, or activity during the reporting period. A value of zero indicates
+    no measurable duration was recorded.
+- name: e10s_cohort
+  description: The Electrolysis (e10s) multi-process experiment cohort to which the client was assigned. This field is deprecated and is null
+    in all current records, as the e10s rollout has been completed.
+  type: STRING
+- name: e10s_enabled
+  description: Indicates whether the Electrolysis (e10s) multi-process architecture was enabled for the Firefox session. A value of true means
+    the browser was running in multi-process mode; false means it was running in single-process mode.
+  type: BOOLEAN
+- name: endpoint
+  description: The telemetry or data pipeline endpoint to which the ping was submitted. This field identifies the ingestion target for the record.
+  type: STRING
+- name: engine_data_load_path
+  description: The load path describing how and from where a search engine definition was loaded, such as from the built-in application bundle
+    ('[app]'), an add-on ('[addon]'), or other sources. This field is used to identify the origin mechanism for a specific search engine configuration.
+  type: STRING
+- name: engine_data_name
+  description: The human-readable display name of a search engine as configured on the client (e.g., 'Google', 'DuckDuckGo', 'Bing'). This field
+    reflects the localized or user-visible name of the engine.
+  type: STRING
+- name: engine_data_origin
+  description: Indicates how a particular search engine configuration was established, with values such as 'default' (set by the application),
+    'verified', 'unverified', or 'invalid'. This field is null when origin information is not available for the engine.
+  type: STRING
+- name: engine_data_submission_url
+  description: The base URL template used to submit queries to a specific search engine, including any partner or distribution tracking parameters.
+    This URL is used by the browser when constructing search requests for the given engine.
+  type: STRING
+- name: enroll_count
+  description: The number of times the client was enrolled into experiments or Normandy studies during the reporting period. A value of zero indicates
+    no enrollments occurred.
+  type: INT64
+- name: enroll_failed_count
+  description: The number of times an attempt to enroll the client into an experiment or Normandy study failed during the reporting period. A
+    value of zero indicates all enrollment attempts succeeded or none were made.
+  type: INT64
+- name: env_build_arch
+  description: The CPU architecture for which the Firefox binary was compiled (e.g., 'x86-64', 'aarch64', 'x86'). This field describes the instruction
+    set architecture of the build, not necessarily the host hardware.
+  type: STRING
+- name: env_build_id
+  description: The build ID of the Firefox application, expressed as a timestamp string in the format 'YYYYMMDDHHmmSS' (e.g., '20260520211922').
+    This uniquely identifies the specific compiled build of the browser.
+  type: STRING
+- name: env_build_platform_version
+  description: The version of the underlying Gecko platform on which Firefox was built (e.g., '151.0.1', '115.36.0'). This may differ from the
+    application's user-facing version in certain release configurations such as ESR.
+  type: STRING
+- name: env_build_version
+  description: The version string of the Firefox build as reported by the environment (e.g., '151.0.1', '115.36.0'). This field represents the
+    application version associated with the compiled binary.
+  type: STRING
+- name: env_build_xpcom_abi
+  description: The XPCOM Application Binary Interface (ABI) string describing the target platform and compiler used for the Firefox build (e.g.,
+    'x86_64-msvc', 'aarch64-gcc3'). This field identifies the binary compatibility target of the build.
+  type: STRING
+- name: environment
+  description: A label or identifier representing the deployment or operational environment context associated with the record (e.g., production,
+    staging). This field provides context about the environment from which the data originated.
+- name: environment_settings_intl_accept_languages
+  description: The list of languages specified in the browser's Accept-Language header preference setting, indicating the user's preferred languages
+    for web content in order of priority.
+- name: environment_settings_intl_app_locales
+  description: The list of locale codes representing the active application locales in use by the Firefox browser (e.g., ['en-US', 'fr']). These
+    are the locales actually applied to the browser UI.
+- name: environment_settings_intl_available_locales
+  description: The list of locale codes for all languages available in the Firefox installation. This represents the full set of locales packaged
+    with the browser build.
+- name: environment_settings_intl_regional_prefs_locales
+  description: The list of locale codes representing the user's regional preferences as configured in the browser settings. These locales influence
+    formatting of dates, numbers, and other region-specific content.
+- name: environment_settings_intl_requested_locales
+  description: The list of locale codes that the user has explicitly requested for the Firefox UI. These represent the user's preferred language
+    settings before locale resolution and fallback logic is applied.
+- name: environment_settings_intl_system_locales
+  description: The list of locale codes configured at the operating system level on the user's device. These system locales may influence browser
+    behavior and default language selection.
+- name: event
+  description: A string identifying a specific telemetry event recorded during the session, typically in 'action.object' format (e.g., 'trigger.reason',
+    'saw_toggle.toggle'). This field categorizes the type of interaction or occurrence being tracked.
+  type: STRING
+- name: event_category
+  description: The category grouping for a telemetry event, used to classify events by feature area or subsystem (e.g., 'address', 'creditcard',
+    'form_autocomplete'). This field is the top-level namespace for organizing event data.
+  type: STRING
+- name: event_map_values
+  description: An array of key-value pairs providing additional metadata or attributes associated with a telemetry event. Each entry contains
+    a string key and a string value that further describes the context of the event.
+- name: event_map_values_key
+  description: The key component of a key-value pair within the event_map_values array, identifying a specific metadata attribute associated with
+    a telemetry event (e.g., 'source', 'trigger', 'networkID'). Keys are used to look up corresponding values in the event's extra metadata.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -1695,3 +1695,199 @@ fields:
   description: The number of logical CPU cores available on the client device. Used to characterize device hardware capability and segment clients
     by compute capacity.
   type: INT64
+- name: nbr_events
+  description: The total number of events recorded in a given context. A value of 1 indicates a single event occurred, with higher values representing
+    multiple events aggregated together.
+  type: INT64
+- name: nbr_unique_clients_uninstalling
+  description: The count of distinct clients that uninstalled Firefox during the relevant period. Each client is counted only once regardless
+    of how many uninstall signals were received.
+  type: INT64
+- name: nbr_unique_users
+  description: The count of distinct users observed within the relevant aggregation period or segment. Each user is counted only once.
+  type: INT64
+- name: new_profile_metric_date
+  description: A boolean flag indicating whether the record corresponds to the date on which a new profile was created. True means the metric
+    date coincides with a new profile creation event; False means it does not.
+  type: BOOLEAN
+- name: new_profile_rate
+  description: The rate at which new profiles are being created, expressed as a floating-point value. This is typically computed as a ratio or
+    proportion relative to a baseline population or time window.
+  type: FLOAT64
+- name: new_profile_ratio
+  description: The proportion of profiles that are new relative to the total profile count in the aggregation window. A value of 0.0 indicates
+    no new profiles in the cohort.
+  type: FLOAT64
+- name: new_profiles
+  description: The number of newly created Firefox profiles observed within the aggregation period. A value of 0 indicates no new profiles were
+    created for that record's segment.
+  type: INT64
+- name: new_profiles_metric_date
+  description: The count of new profiles attributed to the specific metric date for the record. Used to track profile creation volume on a given
+    date within an aggregated dataset.
+  type: INT64
+- name: newtab_homepage_category
+  description: A categorical classification of the page configured as the browser homepage, such as 'enabled' (the default new tab), 'search-engine',
+    'disabled', 'social-media', 'extension', or 'known-hijacker-v3'. Null indicates the value was not available or not applicable.
+  type: STRING
+- name: newtab_newtab_category
+  description: A categorical classification of the page configured as the new tab page, such as 'enabled' (the default Firefox new tab), 'extension',
+    'disabled', or 'other'. Null indicates the value was unavailable.
+  type: STRING
+- name: newtab_open_source
+  description: The URL source from which a new tab was opened, such as 'about:newtab', 'about:home', or 'about:welcome'. A value of 'other' covers
+    unrecognized sources, and null indicates the source was not captured.
+  type: STRING
+- name: newtab_search_enabled
+  description: A boolean flag indicating whether the search bar is enabled on the new tab page. True means search is enabled; False means it is
+    disabled. Null indicates the setting was not available.
+  type: BOOLEAN
+- name: newtab_visit_count
+  description: The total number of new tab page visits recorded for the client within the aggregation period. Higher values indicate more frequent
+    new tab usage.
+  type: INT64
+- name: newtab_visit_ended_at
+  description: A timestamp (in milliseconds or seconds relative to session start) indicating when a new tab page visit ended. A value of 0 typically
+    represents visits with no recorded end time, and null indicates the end time was not captured.
+  type: INT64
+- name: newtab_visit_id
+  description: A unique identifier for a single new tab page visit, formatted as a UUID. This ID can be used to join or deduplicate events associated
+    with the same visit session.
+  type: STRING
+- name: newtab_visit_started_at
+  description: A timestamp indicating when a new tab page visit began, in milliseconds or seconds relative to a reference point. A value of 0
+    commonly represents visits where the start time was not meaningfully recorded, and null indicates the start time was unavailable.
+  type: INT64
+- name: newtab_weather_widget_enabled
+  description: A boolean flag indicating whether the weather widget on the new tab page is enabled for the client. True means the widget is enabled;
+    False means it is disabled. Null indicates the setting was not recorded.
+  type: BOOLEAN
+- name: non_norm_aggregates
+  description: An array of key-value pairs representing non-normalized aggregate metric values. Each entry contains a string key identifying the
+    bucket or dimension and a float value representing the aggregate count or measurement.
+  type: RECORD
+- name: non_norm_aggregates_key
+  description: The key component of a non-normalized aggregate entry, typically representing a histogram bucket index or named dimension. Used
+    to identify which specific bucket or segment the associated value belongs to.
+- name: non_norm_aggregates_value
+  description: The numeric value component of a non-normalized aggregate entry, representing the raw aggregated measurement (e.g., count or sum)
+    for the corresponding key. A value of 0.0 indicates no activity was recorded for that bucket.
+- name: non_norm_histogram
+  description: A JSON-encoded string representing a non-normalized histogram for a telemetry metric, where keys are bucket labels or indices and
+    values are counts. This preserves the raw histogram structure before any normalization is applied.
+  type: STRING
+- name: normalized_app_name
+  description: A human-readable, standardized name for the Firefox application that submitted the telemetry, such as 'Firefox Desktop', 'Fenix',
+    'Firefox iOS', or 'Focus Android'. This normalizes across different app identifiers.
+  type: STRING
+- name: normalized_channel
+  description: The standardized release channel of the Firefox application, such as 'release', 'beta', 'nightly', 'esr', or 'aurora'. 'Other'
+    is used when the channel does not match a known value.
+  type: STRING
+- name: normalized_country_code
+  description: The ISO 3166-1 alpha-2 country code representing the country associated with the client's IP address at the time of submission,
+    such as 'US', 'DE', or 'BR'.
+  type: STRING
+- name: normalized_os
+  description: The standardized operating system name for the client device, such as 'Windows', 'Mac', or 'Linux'. This normalizes raw OS strings
+    into a consistent set of values.
+  type: STRING
+- name: normalized_os_version
+  description: The standardized version string of the client's operating system, such as '10.0' for Windows 10 or '6.8.0' for a Linux kernel version.
+    Provides a normalized representation across different OS reporting formats.
+  type: STRING
+- name: num_buckets
+  description: The number of buckets in a histogram metric definition. This determines the granularity of the histogram and is part of the histogram's
+    structural metadata.
+  type: INT64
+- name: num_clients_active_on_day
+  description: The number of distinct clients that were active on a given day within the cohort or segment. A value of 0 indicates no clients
+    were active on that day.
+  type: INT64
+- name: num_clients_in_cohort
+  description: The total number of distinct clients belonging to the defined cohort at the time of aggregation. Used as a denominator in retention
+    and engagement calculations.
+  type: INT64
+- name: numeric_index
+  description: A sequential integer index used to order or identify records within an aggregated or ranked dataset. Values are unique and typically
+    assigned in ascending order.
+  type: INT64
+- name: oom_allocation_size
+  description: The size (in bytes) of the memory allocation that triggered an out-of-memory (OOM) condition, represented as a string. Null indicates
+    the allocation size was not available, which is the common case as OOM events are relatively rare.
+  type: STRING
+- name: organic_pocket_clicks
+  description: The number of times a user clicked on an organic (non-sponsored) Pocket recommendation on the new tab page within the aggregation
+    period. A value of 0 indicates no clicks occurred.
+  type: INT64
+- name: organic_pocket_dismissals
+  description: The number of times a user dismissed an organic (non-sponsored) Pocket recommendation on the new tab page within the aggregation
+    period. A value of 0 indicates no dismissals occurred.
+  type: INT64
+- name: organic_pocket_impressions
+  description: The number of times organic (non-sponsored) Pocket recommendations were displayed to the user on the new tab page within the aggregation
+    period. A value of 0 indicates no impressions were recorded.
+  type: INT64
+- name: organic_pocket_saves
+  description: The number of times a user saved an organic (non-sponsored) Pocket recommendation from the new tab page within the aggregation
+    period. A value of 0 indicates no saves occurred.
+  type: INT64
+- name: organic_search_count
+  description: The number of organic (non-paid) searches performed by the client within the aggregation period. Null indicates the value was not
+    available for the record, while 0 indicates the client performed no organic searches.
+  type: INT64
+- name: organic_topsite_clicks
+  description: The number of times a user clicked on an organic (non-sponsored) top site tile on the new tab page within the aggregation period.
+    A value of 0 indicates no clicks occurred.
+  type: INT64
+- name: organic_topsite_dismissals
+  description: The number of times a user dismissed an organic (non-sponsored) top site tile on the new tab page within the aggregation period.
+    A value of 0 indicates no dismissals occurred.
+  type: INT64
+- name: organic_topsite_impressions
+  description: The number of times organic (non-sponsored) top site tiles were displayed to the user on the new tab page within the aggregation
+    period. A value of 0 indicates no impressions were recorded.
+  type: INT64
+- name: organic_topsite_tile_clicks
+  description: The number of times a user clicked on a specific organic (non-sponsored) top site tile on the new tab page. This is a more granular
+    click metric compared to the broader organic_topsite_clicks field.
+  type: INT64
+- name: organic_topsite_tile_dismissals
+  description: The number of times a user dismissed a specific organic (non-sponsored) top site tile on the new tab page. A value of 0 indicates
+    no tile-level dismissals occurred.
+  type: INT64
+- name: organic_topsite_tile_impressions
+  description: The number of times a specific organic (non-sponsored) top site tile was displayed to the user on the new tab page. A value of
+    0 indicates the tile was not shown during the aggregation period.
+  type: INT64
+- name: os
+  description: The raw operating system name as reported by the client, such as 'Windows_NT', 'Darwin', 'Linux', 'Android', or 'iOS'. This is
+    the unprocessed OS string before normalization.
+- name: os_environment_is_taskbar_pinned_any
+  description: A boolean flag indicating whether Firefox is pinned to the Windows taskbar in any configuration (regular or private browsing).
+    True means Firefox is pinned to the taskbar; False means it is not.
+  type: BOOLEAN
+- name: os_environment_is_taskbar_pinned_private
+  description: A boolean flag indicating whether the Firefox Private Browsing shortcut is specifically pinned to the Windows taskbar. True means
+    it is pinned; False means it is not.
+  type: BOOLEAN
+- name: os_environment_is_taskbar_pinned_private_any
+  description: A boolean flag indicating whether a Firefox Private Browsing shortcut is pinned to the Windows taskbar in any taskbar configuration.
+    True means at least one such pin exists; False means none exist.
+  type: BOOLEAN
+- name: os_grouped
+  description: A coarsely grouped operating system label that categorizes clients into broad OS families; 'Windows', 'Mac', 'Linux', or 'Other'.
+    This provides a simplified OS dimension for high-level segmentation.
+  type: STRING
+- name: os_name
+  description: The standardized name of the operating system on the client device, such as 'Windows', 'Mac', 'Linux', or 'Android'. Similar to
+    normalized_os but may reflect a slightly different normalization source.
+  type: STRING
+- name: os_service_pack_major
+  description: The major version number of the Windows Service Pack installed on the client, such as 0 (no service pack), 1, or 2. Null indicates
+    the value was not available, typically for non-Windows platforms.
+  type: INT64
+- name: os_service_pack_minor
+  description: The minor version number of the Windows Service Pack installed on the client. This is almost always 0, with null indicating the
+    value was unavailable, typically for non-Windows platforms.
+  type: INT64


### PR DESCRIPTION
## Base Schema

Generated `telemetry_derived.yaml` with descriptions for 926 shared fields.
