### PR TITLE
AIMOD-1214 part 2  -Propensity v2 backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v2/backfill.yaml
@@ -1,0 +1,17 @@
+2026-06-18:
+  start_date: 2026-06-01
+  end_date: 2026-06-17
+  reason: Backfill newtab_merino_propensity_v2 from 2026-06-01 to establish history.
+  watchers:
+  - rrando@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  ignore_date_partition_offset: false
+  query_script_entrypoint: main
+  query_script_date_arg: date
+  query_script_args:
+  - --project=moz-fx-data-shared-prod
+  - --destination_dataset=backfills_staging_derived
+  - --destination_table=telemetry_derived__newtab_merino_propensity_v2_2026_06_18

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_propensity_v2/backfill.yaml
@@ -1,6 +1,6 @@
 2026-06-18:
   start_date: 2026-06-01
-  end_date: 2026-06-17
+  end_date: 2026-06-16
   reason: Backfill newtab_merino_propensity_v2 from 2026-06-01 to establish history.
   watchers:
   - rrando@mozilla.com


### PR DESCRIPTION
## Description
A few weeks of backfill for PR https://github.com/mozilla/bigquery-etl/pull/9445

New Tab layouts changed significantly for the World Cup widgets, so having older snapshots from before then is helpful.

Data already exists for 2026-06-17 so maybe we'll need to update the end date.