### PR TITLE
[DENG-11252] Authorize firefox_desktop.hang_report view for hang-repo…

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/hang_report/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/hang_report/metadata.yaml
@@ -1,0 +1,7 @@
+labels:
+  authorized: true
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-11252
+  - workgroup:dataplatform/hang-report-collection


### PR DESCRIPTION
…rt-collection

## Description

Make `firefox_desktop.hang_report` authorized so access to the underlying stable table can be granted.  Depends on https://github.com/mozilla/global-platform-admin/pull/6708

## Related Tickets & Documents
* DENG-11252

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
