### PR TITLE
Reduce CI diff noise from stable_views

### DIFF
--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -375,24 +375,20 @@ def write_view_if_not_exists(
 
     metadata_file = target_dir / "metadata.yaml"
     should_write_metadata = False
-    # append metadata if existing metadata doesn't have name and description
     if metadata_file.exists():
+        # Combine the generated and checked-in metadata, preferring the checked-in fields
         with metadata_file.open() as f:
-            existing_metadata = yaml.load(f, Loader=yaml.FullLoader)
-            if labels:
-                if existing_labels := existing_metadata.get("labels"):
-                    existing_labels.update(labels)
-                else:
-                    existing_metadata["labels"] = labels
-            if (
-                "friendly_name" not in existing_metadata
-                and "description" not in existing_metadata
-            ):
-                should_write_metadata = True
-                metadata_content += yaml.dump(existing_metadata)
-            elif labels:
-                should_write_metadata = True
-                metadata_content = yaml.dump(existing_metadata)
+            existing_metadata = yaml.load(f, Loader=yaml.FullLoader) or {}
+        template_metadata = yaml.safe_load(metadata_content) or {}
+        merged = {**template_metadata, **existing_metadata}
+        if labels:
+            merged["labels"] = {
+                **merged.get("labels", {}),
+                **labels,
+            }
+        if merged != existing_metadata:
+            should_write_metadata = True
+            metadata_content = yaml.dump(merged)
     elif labels:
         metadata_content += yaml.dump({"labels": labels})
 

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -389,7 +389,7 @@ def write_view_if_not_exists(
         merged = {**template_metadata, **existing_metadata}
         if labels:
             merged["labels"] = {
-                **merged.get("labels", {}),
+                **(merged.get("labels") or {}),
                 **labels,
             }
         if merged != existing_metadata:

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -78,9 +78,14 @@ FROM
   `{target}`
 """
 
-VIEW_METADATA_TEMPLATE = """\
+VIEW_METADATA_HEADER = """\
 # Generated via ./bqetl generate stable_views
 ---
+"""
+
+VIEW_METADATA_TEMPLATE = (
+    VIEW_METADATA_HEADER
+    + """\
 friendly_name: Historical Pings for `{document_namespace}/{document_type}`
 description: |-
   A historical view of pings sent for the
@@ -93,6 +98,7 @@ description: |-
 
   Clustering fields: `normalized_channel`, `sample_id`
 """
+)
 
 
 def write_dataset_metadata_if_not_exists(
@@ -378,7 +384,7 @@ def write_view_if_not_exists(
     if metadata_file.exists():
         # Combine the generated and checked-in metadata, preferring the checked-in fields
         with metadata_file.open() as f:
-            existing_metadata = yaml.load(f, Loader=yaml.FullLoader) or {}
+            existing_metadata = yaml.safe_load(f) or {}
         template_metadata = yaml.safe_load(metadata_content) or {}
         merged = {**template_metadata, **existing_metadata}
         if labels:
@@ -388,7 +394,9 @@ def write_view_if_not_exists(
             }
         if merged != existing_metadata:
             should_write_metadata = True
-            metadata_content = yaml.dump(merged)
+            metadata_content = VIEW_METADATA_HEADER + yaml.dump(
+                merged, sort_keys=False
+            )
     elif labels:
         metadata_content += yaml.dump({"labels": labels})
 


### PR DESCRIPTION
## Description

The stable_views generator currently appends fields from a checked-in metadata.yaml if it exists but it seems to be causing noisy CI diffs https://github.com/mozilla/private-bigquery-etl/blob/bqetl-diff/pr-9606/sql.diff. The change here is to merge the dicts and take the checked-in values if they collide with the generator template. The latest diffs in this pr are empty so it should be better.  This is still potentially problematic if in the CI `bqetl metadata update` ran before sql generation and filled out the placeholder values, but I don't think that's a new problem.

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
