### PR TITLE
feat(DENG-9789): add filter to firefoxdotcom views to only include data after 2025-07-16 (after test phase)

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
@@ -29,3 +29,6 @@ LEFT JOIN
   AND wns.page_location_locale = map.locale
 WHERE
   REGEXP_CONTAINS(s.ga_client_id || '-' || s.ga_session_id, r"^[0-9]+\.{1}[0-9]+\-{1}[0-9]+$")
+  -- Excluding events from the testing phase.
+  AND wns.event_date >= "2025-07-16"
+  AND s.session_date >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/firefox_whatsnew_summary/view.sql
@@ -29,3 +29,5 @@ LEFT JOIN
   AND wns.page_location_locale = map.locale
 WHERE
   REGEXP_CONTAINS(s.ga_client_id || '-' || s.ga_session_id, r"^[0-9]+\.{1}[0-9]+\-{1}[0-9]+$")
+  -- Excluding events from the testing phase.
+  AND wns.event_date >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_clients/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_clients/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_clients_v1`
+WHERE
+  -- Excluding events from the testing phase.
+  first_seen_date >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_sessions/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/ga_sessions/view.sql
@@ -7,3 +7,5 @@ FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.ga_sessions_v2`
 WHERE
   REGEXP_CONTAINS(ga_client_id || '-' || ga_session_id, r"^[0-9]+\.{1}[0-9]+\-{1}[0-9]+$")
+  -- Excluding events from the testing phase.
+  AND session_date >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/site_engagement_events/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/site_engagement_events/view.sql
@@ -13,3 +13,5 @@ JOIN
   AND e.ga_session_id = s.ga_session_id
 WHERE
   REGEXP_CONTAINS(s.ga_client_id || '-' || s.ga_session_id, r"^[0-9]+\.[0-9]+\-[0-9]+$")
+  -- Excluding events from the testing phase.
+  AND event_date >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_downloads/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_downloads/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_downloads_v1`
+WHERE
+  -- Excluding events from the testing phase.
+  submission_date >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_events_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_events_metrics/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_events_metrics_v1`
+WHERE
+  -- Excluding events from the testing phase.
+  `date` >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_hits/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_hits/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_hits_v1`
+WHERE
+  -- Excluding events from the testing phase.
+  `date` >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_landing_page_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_landing_page_metrics/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_landing_page_metrics_v1`
+WHERE
+  -- Excluding events from the testing phase.
+  `date` >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_page_metrics/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/www_site_page_metrics/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.www_site_page_metrics_v1`
+WHERE
+  -- Excluding events from the testing phase.
+  `date` >= "2025-07-16"

--- a/sql/moz-fx-data-shared-prod/firefoxdotcom/wwww_site_metrics_summary/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefoxdotcom/wwww_site_metrics_summary/view.sql
@@ -5,3 +5,6 @@ SELECT
   *
 FROM
   `moz-fx-data-shared-prod.firefoxdotcom_derived.wwww_site_metrics_summary_v1`
+WHERE
+  -- Excluding events from the testing phase.
+  `date` >= "2025-07-16"


### PR DESCRIPTION
# feat(DENG-9789): add filter to firefoxdotcom views to only include data after 2025-07-16 (after test phase)

This change adds a date filter to all firefoxdotcom GA based views to only return data after `"2025-07-16"`. Anything prior is treated as test data and not useful for analysis.

Doing this on the view level should be sufficient here since views are meant to be used when producing a new dataset or dashboard downstream.