### PR TITLE
DENG-10914 - Initiate backfill cfs v3 one year

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3/backfill.yaml
@@ -1,3 +1,21 @@
+2026-06-19:
+  start_date: 2025-06-08
+  end_date: 2026-06-06
+  reason: |-
+    https://mozilla-hub.atlassian.net/browse/DENG-10914
+    Populate the newly added attribution_msstoresignedin column (added in #9485) from the
+    ping that contributed each first-seen record. Custom per-partition query;
+    Doing one year backfill since smaller partition size test ran as expected.
+  watchers:
+  - wichan@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: true
+  override_depends_on_past_null_partition: true
+  ignore_date_partition_offset: false
+  custom_query_path: sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3/backfill_deng10914.sql
+
 2026-06-11:
   start_date: 2026-06-07
   end_date: 2026-06-09


### PR DESCRIPTION
## Description
The smaller partition size backfill test initiated/completed successfully.  Now running one year backfill for more historical data.

## Related Tickets & Documents
* DENG-10914

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
