### PR TITLE
chore(DENG-11162): update ownership metadata for KPI related tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry/desktop_active_users/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry/desktop_active_users/metadata.yaml
@@ -3,5 +3,7 @@ description: |-
   Data used for reporting DAU, WAU, and MAU KPIs.
   Based on legacy telemetry data.
   Rows are at a client ID, submission date grain.
+owners:
+  - phlee@mozilla.com
 labels:
   legacy: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_first_seen_v3/metadata.yaml
@@ -25,7 +25,7 @@ description: |-
   This version of clients_first_seen (v3) has more columns than clients_first_seen_v2. Some were forgotten
   in v2, some are recorded only in the new_profiles_ping.
 owners:
-- mhirose@mozilla.com
+- phlee@mozilla.com
 labels:
   application: firefox
   incremental: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/clients_last_seen_v2/metadata.yaml
@@ -14,7 +14,7 @@ description: |-
   which merges in fields based on the `event` ping.
   See https://github.com/mozilla/bigquery-etl/issues/1761
 owners:
-- kwindau@mozilla.com
+- phlee@mozilla.com
 labels:
   level: bronze
   application: firefox


### PR DESCRIPTION
## Description

This adds up-to-date information about who owns which tables for KPI related things as audited in [this doc](https://docs.google.com/document/d/1L9Vfw_cbCVcFb_eoXXRQUILxNHQDyi6ODFU6rTMCbdo/edit?tab=t.0#heading=h.2gj3xry1y76i).

## Related Tickets & Documents
* DENG-11162

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
