### PR TITLE
Fix stage deploy of views referencing wildcard tables

### DIFF
--- a/bigquery_etl/dryrun.py
+++ b/bigquery_etl/dryrun.py
@@ -32,6 +32,7 @@ from urllib.request import Request, urlopen
 import click
 import google.auth
 import yaml
+from google.auth import impersonated_credentials
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.cloud import bigquery
 from google.oauth2.id_token import fetch_id_token
@@ -79,7 +80,16 @@ def get_id_token(dry_run_url=ConfigLoader.get("dry_run", "function"), credential
     if not id_token:
         auth_req = GoogleAuthRequest()
         credentials = credentials or get_credentials(auth_req)
-        if hasattr(credentials, "id_token"):
+        if isinstance(credentials, impersonated_credentials.Credentials):
+            # Impersonated credentials (e.g. a target's impersonate_service_account)
+            # don't expose an OIDC id_token, and fetch_id_token() can't use them;
+            # mint one for the impersonated SA via the IAM API.
+            id_token_credentials = impersonated_credentials.IDTokenCredentials(
+                credentials, target_audience=dry_run_url, include_email=True
+            )
+            id_token_credentials.refresh(auth_req)
+            id_token = id_token_credentials.token
+        elif hasattr(credentials, "id_token"):
             # Get token from default credentials for the current environment created via Cloud SDK run
             id_token = credentials.id_token
         else:

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -894,11 +894,19 @@ def target_ref_for_source(
         target_ds = sanitize_bq_id(f"{prefix}{src_dataset}")
     else:
         target_ds = src_dataset
-    target_table = (
-        sanitize_bq_id(f"{rendered_artifact_prefix}{src_table}")
-        if rendered_artifact_prefix
-        else src_table
-    )
+    if rendered_artifact_prefix:
+        if src_table.endswith("*"):
+            # Preserve the trailing wildcard: sanitizing it to `_` would turn the
+            # ref into a non-existent literal table (and break `_TABLE_SUFFIX`).
+            # Keeping `*` lets the rewritten ref match the stub table
+            # (`…events_wildcard`) as a wildcard.
+            target_table = (
+                sanitize_bq_id(f"{rendered_artifact_prefix}{src_table[:-1]}") + "*"
+            )
+        else:
+            target_table = sanitize_bq_id(f"{rendered_artifact_prefix}{src_table}")
+    else:
+        target_table = src_table
     return target_project, target_ds, target_table
 
 
@@ -933,10 +941,14 @@ def _substitute_3part_ref(
 ) -> str:
     """Replace every occurrence of source 3-part ref with target 3-part ref."""
     src_project, src_dataset, src_table = src
+    # Negative lookahead instead of `\b`: a `\b` after a table name ending in `*`
+    # (a wildcard, e.g. `events_*`) never matches before a backtick, so wildcard
+    # refs would be left un-rewritten. `(?![A-Za-z0-9_])` ends the name correctly
+    # for both normal and `*`-terminated tables.
     pattern = re.compile(
         rf"`?{re.escape(src_project)}`?"
         rf"\.`?{re.escape(src_dataset)}`?"
-        rf"\.`?{re.escape(src_table)}\b`?"
+        rf"\.`?{re.escape(src_table)}(?![A-Za-z0-9_])`?"
     )
     return pattern.sub(f"`{tgt[0]}`.`{tgt[1]}`.`{tgt[2]}`", sql)
 

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -613,6 +613,34 @@ class TestTargetRefForSource:
         )
         assert (proj, ds, tbl) == ("dev-proj", "telemetry_derived", "tbl_v1")
 
+    def test_wildcard_preserves_star_and_matches_stub(self):
+        """A wildcard ref must keep its trailing `*` (not get sanitized to `_`)
+        so the rewritten ref resolves to the stub table, which `_create_target_stub`
+        names with `*` -> `wildcard`. This locks both sides of that invariant."""
+        target = Target(
+            name="stage",
+            project_id="stage-proj",
+            dataset="stage_ds",
+            artifact_prefix="{{ artifact.project_id }}__{{ artifact.dataset_id }}__",
+        )
+        common_args = (
+            target,
+            "stage-proj",
+            "moz-fx-data-marketing-prod",
+            "analytics_1",
+        )
+
+        # rewrite target for the wildcard ref: prefix applied, trailing * kept
+        _, _, ref_tbl = target_ref_for_source(*common_args, "events_*")
+        assert ref_tbl == "moz_fx_data_marketing_prod__analytics_1__events_*"
+
+        # stub is created from name.replace("*", "wildcard")
+        _, _, stub_tbl = target_ref_for_source(*common_args, "events_wildcard")
+        assert stub_tbl == "moz_fx_data_marketing_prod__analytics_1__events_wildcard"
+
+        # invariant: the rewritten `…events_*` wildcard must match the stub table
+        assert ref_tbl.endswith("*") and stub_tbl.startswith(ref_tbl[:-1])
+
 
 class TestSubstitute3PartRef:
     """Test _substitute_3part_ref handles common ref forms."""

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -638,6 +638,18 @@ class TestSubstitute3PartRef:
         )
         assert "`ascholtz-dev`.`test_ds`.`test_tbl`" in out
 
+    def test_wildcard_ref_is_rewritten(self):
+        """Wildcard refs (ending in `*`) must be rewritten, not skipped — a
+        trailing `\\b` never matches after `*`, leaving the ref pointed at prod."""
+        sql = "SELECT * FROM `moz-fx-data-marketing-prod.analytics_1.events_*`"
+        out = _substitute_3part_ref(
+            sql,
+            ("moz-fx-data-marketing-prod", "analytics_1", "events_*"),
+            ("stage-proj", "analytics_1_stage", "events_*"),
+        )
+        assert "moz-fx-data-marketing-prod" not in out
+        assert "`stage-proj`.`analytics_1_stage`.`events_*`" in out
+
 
 class TestNormalizeTableRef:
     def test_information_schema_dataset_prepends_project(self):


### PR DESCRIPTION
## Description

`--target` stage deploys of views referencing wildcard tables (e.g. GA4 `events_*`) 403'd: the wildcard ref wasn't rewritten to the stage stub, so the view validated against the prod source the stage SA can't read. Surfaced by mozilla/private-bigquery-etl#1409.

Two fixes in util/target.py:
- `_substitute_3part_ref`: trailing \b never matches after *, so wildcard refs were left un-rewritten → use (?![A-Za-z0-9_]).
- `target_ref_for_source`: `sanitize_bq_id` turned `events_*` → `events__`  → preserve the trailing * so the ref stays a wildcard matching the stub 

Also: get_id_token now works under target SA impersonation

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
