### PR TITLE
feat(glam): aggregate static labeled_counter as categorical histograms

### DIFF
--- a/bigquery_etl/glam/client_side_sampled_metrics.py
+++ b/bigquery_etl/glam/client_side_sampled_metrics.py
@@ -9,22 +9,12 @@ from typing import Iterable, List, Optional
 
 from google.cloud import bigquery
 
+from .utils import _PRODUCT_TO_APP_NAME
+
 PROJECT_ID = "moz-fx-data-shared-prod"
 DATASET = "telemetry_derived"
 TABLE_NAME = "sampled_metrics_v1"
 EXPECTED_SAMPLE_RATE = 0.1  # For now, we only support 10% sampling.
-
-_PRODUCT_TO_APP_NAME = {
-    "firefox_desktop": "firefox_desktop",
-    # Experimenter doesn't distinguish Fenix variants; all map to appName=fenix.
-    # Variants follow the Play Store app-id history
-    # (see https://github.com/mozilla/telemetry-airflow/blob/2caa0865f017afa0743c94df02666c9af3d66862/dags/glam_fenix.py#L47-L56).
-    "org_mozilla_fenix": "fenix",
-    "org_mozilla_fenix_nightly": "fenix",
-    "org_mozilla_firefox": "fenix",
-    "org_mozilla_firefox_beta": "fenix",
-    "org_mozilla_fennec_aurora": "fenix",
-}
 
 
 def _run_bq_query(query: str):

--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -11,7 +11,7 @@ from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.probe_filters import get_etl_excluded_probes_quickfix
 
 from .client_side_sampled_metrics import get as get_sampled_metrics
-from .utils import get_schema, ping_type_from_table
+from .utils import get_schema, is_static_labeled_counter, ping_type_from_table
 
 ATTRIBUTES = ",".join(
     [
@@ -55,6 +55,9 @@ def get_distribution_metrics(
         "labeled_timing_distribution",
         "labeled_custom_distribution",
         "labeled_memory_distribution",
+        # Static labeled_counters are categorical histograms (Glean's replacement
+        # for Legacy Telemetry's histogram-categorical) and are processed here.
+        "labeled_counter",
     }
     metrics: Dict[str, List[str]] = {metric_type: [] for metric_type in metric_type_set}
     excluded_metrics = get_etl_excluded_probes_quickfix("fenix")
@@ -78,6 +81,12 @@ def get_distribution_metrics(
             if metric_type not in metric_type_set:
                 continue
             for field in metric_field["fields"]:
+                # Only static labeled_counters (predefined `labels`) are
+                # categorical histograms; dynamic ones stay in the scalar pipeline.
+                if metric_type == "labeled_counter" and not is_static_labeled_counter(
+                    product, field["name"]
+                ):
+                    continue
                 if field["name"] in sampled_metrics.get(metric_type, []):
                     found_sampled_metrics[metric_type].append(field["name"])
                 elif field["name"] not in excluded_metrics:
@@ -99,7 +108,15 @@ def get_metrics_sql(metrics: Dict[str, List[str]]) -> dict[str, str]:
     labeled = []
     unlabeled = []
     for name, metric_type, value_path in sorted(items):
-        if metric_type.startswith("labeled"):
+        if metric_type == "labeled_counter":
+            # A static labeled_counter's key/value array IS the categorical
+            # histogram (label -> count), so feed it in directly (no `.values`)
+            # as an unlabeled histogram. get_distribution_metrics filters out
+            # dynamic labeled_counters (no predefined `labels`).
+            unlabeled.append(
+                f"""('', "{name}", "{metric_type}", metrics.{metric_type}.{name})"""
+            )
+        elif metric_type.startswith("labeled"):
             labeled.append(f"""
                 (
                     "{name}",

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -12,7 +12,7 @@ from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.probe_filters import get_etl_excluded_probes_quickfix
 
 from .client_side_sampled_metrics import get as get_sampled_metrics
-from .utils import get_schema, ping_type_from_table
+from .utils import get_schema, is_static_labeled_counter, ping_type_from_table
 
 ATTRIBUTES = ",".join(
     [
@@ -138,6 +138,12 @@ def get_scalar_metrics(
             if metric_type not in metric_type_set[scalar_type]:
                 continue
             for field in metric_field["fields"]:
+                # Static labeled_counters are categorical histograms; they move to
+                # the histogram pipeline. Dynamic (open-ended) ones stay scalar.
+                if metric_type == "labeled_counter" and is_static_labeled_counter(
+                    product, field["name"]
+                ):
+                    continue
                 if field["name"] in sampled_metrics.get(metric_type, []):
                     found_sampled_metrics[metric_type].append(field["name"])
                 elif field["name"] not in excluded_metrics:

--- a/bigquery_etl/glam/templates/probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/probe_counts_v1.sql
@@ -39,7 +39,24 @@
   );
 
 {% endif %}
-WITH probe_counts AS (
+WITH
+{% if not is_scalar %}
+-- Static labeled_counters are processed as categorical histograms: their label
+-- set is the bucket set. Collect it per metric from the data so that labels
+-- absent from a given combo are still zero-filled below.
+categorical_buckets AS (
+  SELECT
+    metric,
+    ARRAY_AGG(DISTINCT record.key) AS buckets
+  FROM
+    {{ source_table }}
+  WHERE
+    metric_type = 'labeled_counter'
+  GROUP BY
+    metric
+),
+{% endif %}
+probe_counts AS (
   SELECT
     {{ attributes }},
     {{ aggregate_attributes }},
@@ -83,20 +100,33 @@ WITH probe_counts AS (
       CAST(ROUND(SUM(record.value)) AS INT64) AS total_users,
       mozfun.glam.histogram_fill_buckets_dirichlet(
         mozfun.map.sum(ARRAY_AGG(record)),
-        mozfun.glam.histogram_buckets_cast_string_array(
-          udf_get_buckets(metric_type, MIN(range_min), MAX(range_max), bucket_count)
-        ),
+        CASE
+          -- Categorical labeled_counter: use the label set as buckets directly.
+          WHEN metric_type = 'labeled_counter'
+            THEN ANY_VALUE(categorical_buckets.buckets)
+          ELSE mozfun.glam.histogram_buckets_cast_string_array(
+              udf_get_buckets(metric_type, MIN(range_min), MAX(range_max), bucket_count)
+            )
+        END,
         CAST(ROUND(SUM(record.value)) AS INT64)
       ) AS aggregates,
       mozfun.glam.histogram_fill_buckets(
         mozfun.map.sum(ARRAY_AGG(non_norm_record)),
-        mozfun.glam.histogram_buckets_cast_string_array(
-          udf_get_buckets(metric_type, MIN(range_min), MAX(range_max), bucket_count)
-        )
+        CASE
+          WHEN metric_type = 'labeled_counter'
+            THEN ANY_VALUE(categorical_buckets.buckets)
+          ELSE mozfun.glam.histogram_buckets_cast_string_array(
+              udf_get_buckets(metric_type, MIN(range_min), MAX(range_max), bucket_count)
+            )
+        END
       ) AS non_norm_aggregates
     {% endif %}
   FROM
     {{ source_table }}
+    {% if not is_scalar %}
+    LEFT JOIN categorical_buckets
+      USING (metric)
+    {% endif %}
   GROUP BY
     {{ attributes }},
     {% if is_scalar %}

--- a/bigquery_etl/glam/templates/probe_counts_v1.sql
+++ b/bigquery_etl/glam/templates/probe_counts_v1.sql
@@ -47,7 +47,8 @@ WITH
 categorical_buckets AS (
   SELECT
     metric,
-    ARRAY_AGG(DISTINCT record.key) AS buckets
+    -- ORDER BY for a stable label order (matches the ordered udf_get_buckets path).
+    ARRAY_AGG(DISTINCT record.key ORDER BY record.key) AS buckets
   FROM
     {{ source_table }}
   WHERE

--- a/bigquery_etl/glam/utils.py
+++ b/bigquery_etl/glam/utils.py
@@ -14,21 +14,26 @@ CustomDistributionMeta = namedtuple(
     ["name", "type", "range_min", "range_max", "bucket_count", "histogram_type"],
 )
 
-# Glean Dictionary is the source of truth for metric metadata (incl. the static
-# `labels` list). The per-metric file name matches the BigQuery column form, so
-# stable-table schema field names can be looked up directly.
-GLEAN_DICTIONARY_DATA_URL = "https://dictionary.telemetry.mozilla.org/data"
-# ETL product (stable-table dataset prefix) -> Glean Dictionary app name. Fenix
-# variants share the "fenix" app; mirrors _PRODUCT_TO_APP_NAME in
-# client_side_sampled_metrics.
-_GLEAN_DICTIONARY_PRODUCT_MAP = {
+# ETL product (stable-table dataset prefix) -> canonical Glean app name.
+_PRODUCT_TO_APP_NAME = {
     "firefox_desktop": "firefox_desktop",
+    # Experimenter doesn't distinguish Fenix variants; all map to appName=fenix.
+    # Variants follow the Play Store app-id history
+    # (see https://github.com/mozilla/telemetry-airflow/blob/2caa0865f017afa0743c94df02666c9af3d66862/dags/glam_fenix.py#L47-L56).
     "org_mozilla_fenix": "fenix",
     "org_mozilla_fenix_nightly": "fenix",
     "org_mozilla_firefox": "fenix",
     "org_mozilla_firefox_beta": "fenix",
     "org_mozilla_fennec_aurora": "fenix",
 }
+
+# Glean Dictionary is the source of truth for static labeled_counter labels: it is
+# more complete/fresh than GleanPing.get_probes() (which lags for recent or
+# dependency-sourced metrics, e.g. it omits dns.trr_http3_0rtt_state). The
+# per-metric file name matches the BigQuery column form, so stable-table schema
+# field names look up directly. The Dictionary uses the same app names as
+# Experimenter, so the product -> app mapping uses _PRODUCT_TO_APP_NAME.
+GLEAN_DICTIONARY_DATA_URL = "https://dictionary.telemetry.mozilla.org/data"
 
 _glean_metric_metadata_cache: dict = {}
 
@@ -110,22 +115,33 @@ def get_custom_distribution_metadata(product_name) -> List[CustomDistributionMet
 def get_glean_metric_metadata(
     product: Optional[str], probe_name: str
 ) -> Optional[dict]:
-    """Return Glean Dictionary metadata for a metric, or None if unavailable."""
+    """Return Glean Dictionary metadata for a metric, or None if it is absent.
+
+    None means the metric is genuinely not in the Dictionary (HTTP 404) or the
+    product is unmapped. Network errors, timeouts and non-404 HTTP statuses are
+    raised rather than swallowed: treating them as "absent" would silently route
+    a static labeled_counter into the scalar pipeline, and the scalar and
+    histogram generators look this up independently, so an intermittent outage
+    could land a metric in both pipelines or neither.
+    """
     cache_key = (product, probe_name)
     if cache_key in _glean_metric_metadata_cache:
         return _glean_metric_metadata_cache[cache_key]
 
-    app = _GLEAN_DICTIONARY_PRODUCT_MAP.get(product) if product is not None else None
-    meta = None
-    if app is not None:
-        try:
-            url = f"{GLEAN_DICTIONARY_DATA_URL}/{app}/metrics/data_{probe_name}.json"
-            resp = requests.get(url, timeout=10)
-            resp.raise_for_status()
-            info = resp.json()
-            meta = {"type": info.get("type"), "labels": info.get("labels") or []}
-        except Exception:
-            meta = None
+    app = _PRODUCT_TO_APP_NAME.get(product) if product is not None else None
+    if app is None:
+        _glean_metric_metadata_cache[cache_key] = None
+        return None
+
+    url = f"{GLEAN_DICTIONARY_DATA_URL}/{app}/metrics/data_{probe_name}.json"
+    resp = requests.get(url, timeout=10)
+    if resp.status_code == 404:
+        meta = None
+    else:
+        # Anything other than 404 must fail loudly, not be treated as absent.
+        resp.raise_for_status()
+        info = resp.json()
+        meta = {"type": info.get("type"), "labels": info.get("labels") or []}
 
     _glean_metric_metadata_cache[cache_key] = meta
     return meta

--- a/bigquery_etl/glam/utils.py
+++ b/bigquery_etl/glam/utils.py
@@ -4,14 +4,33 @@ import json
 import subprocess
 from collections import namedtuple
 from itertools import combinations
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
+import requests
 from mozilla_schema_generator.glean_ping import GleanPing
 
 CustomDistributionMeta = namedtuple(
     "CustomDistributionMeta",
     ["name", "type", "range_min", "range_max", "bucket_count", "histogram_type"],
 )
+
+# Glean Dictionary is the source of truth for metric metadata (incl. the static
+# `labels` list). The per-metric file name matches the BigQuery column form, so
+# stable-table schema field names can be looked up directly.
+GLEAN_DICTIONARY_DATA_URL = "https://dictionary.telemetry.mozilla.org/data"
+# ETL product (stable-table dataset prefix) -> Glean Dictionary app name. Fenix
+# variants share the "fenix" app; mirrors _PRODUCT_TO_APP_NAME in
+# client_side_sampled_metrics.
+_GLEAN_DICTIONARY_PRODUCT_MAP = {
+    "firefox_desktop": "firefox_desktop",
+    "org_mozilla_fenix": "fenix",
+    "org_mozilla_fenix_nightly": "fenix",
+    "org_mozilla_firefox": "fenix",
+    "org_mozilla_firefox_beta": "fenix",
+    "org_mozilla_fennec_aurora": "fenix",
+}
+
+_glean_metric_metadata_cache: dict = {}
 
 
 def run(command, **kwargs) -> str:
@@ -86,6 +105,43 @@ def get_custom_distribution_metadata(product_name) -> List[CustomDistributionMet
         custom.append(meta)
 
     return custom
+
+
+def get_glean_metric_metadata(
+    product: Optional[str], probe_name: str
+) -> Optional[dict]:
+    """Return Glean Dictionary metadata for a metric, or None if unavailable."""
+    cache_key = (product, probe_name)
+    if cache_key in _glean_metric_metadata_cache:
+        return _glean_metric_metadata_cache[cache_key]
+
+    app = _GLEAN_DICTIONARY_PRODUCT_MAP.get(product) if product is not None else None
+    meta = None
+    if app is not None:
+        try:
+            url = f"{GLEAN_DICTIONARY_DATA_URL}/{app}/metrics/data_{probe_name}.json"
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            info = resp.json()
+            meta = {"type": info.get("type"), "labels": info.get("labels") or []}
+        except Exception:
+            meta = None
+
+    _glean_metric_metadata_cache[cache_key] = meta
+    return meta
+
+
+def is_static_labeled_counter(product: Optional[str], probe_name: str) -> bool:
+    """Return whether a metric is a labeled_counter with predefined (static) `labels`.
+
+    These are Glean's replacement for Legacy Telemetry categorical histograms and
+    are processed in the histogram pipeline; dynamic (open-ended) labeled_counters
+    have no static `labels` and stay in the scalar pipeline.
+    """
+    meta = get_glean_metric_metadata(product, probe_name)
+    if not meta:
+        return False
+    return meta.get("type") == "labeled_counter" and bool(meta.get("labels"))
 
 
 def compute_datacube_groupings(


### PR DESCRIPTION
## Description

Static (with a static set of labels) `labeled_counter` is Glean's replacement for Legacy Telemetry's `histogram_categorical`. Because it's a `counter` it was being aggregated along with other counters, which leads to low-signal visualizations on GLAM. This PR aggregates static `labeled_counter`s in the `distribution` path. 

## Related Tickets & Documents
* DENG-7764
* https://github.com/mozilla/glam/issues/3524

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
