### PR TITLE
chore(schema): add field descriptions for telemetry_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/applications_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/applications_v1/schema.yaml
@@ -12,7 +12,9 @@ fields:
 - mode: NULLABLE
   name: app_id
   type: STRING
-  description: App ID
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+    field: app_id
 - mode: NULLABLE
   name: app_name
   type: STRING

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cfs_ga4_attr_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cfs_ga4_attr_v1/schema.yaml
@@ -472,6 +472,8 @@ fields:
 - name: ga4_distinct_campaigns_from_event_params
   type: STRING
   mode: REPEATED
+  description: All distinct campaign names extracted from GA4 event parameters for the web session linked
+    to this Firefox install.
 - name: ga4_first_source_from_event_params
   type: STRING
   mode: NULLABLE
@@ -479,6 +481,8 @@ fields:
 - name: ga4_distinct_sources_from_event_params
   type: STRING
   mode: REPEATED
+  description: All distinct traffic sources extracted from GA4 event parameters for the web session linked
+    to this Firefox install.
 - name: ga4_first_medium_from_event_params
   type: STRING
   mode: NULLABLE
@@ -486,6 +490,8 @@ fields:
 - name: ga4_distinct_mediums_from_event_params
   type: STRING
   mode: REPEATED
+  description: All distinct traffic mediums extracted from GA4 event parameters for the web session linked
+    to this Firefox install.
 - name: ga4_first_content_from_event_params
   type: STRING
   mode: NULLABLE
@@ -493,6 +499,8 @@ fields:
 - name: ga4_distinct_contents_from_event_params
   type: STRING
   mode: REPEATED
+  description: All distinct UTM content values extracted from GA4 event parameters for the web session linked
+    to this Firefox install.
 - name: ga4_first_term_from_event_params
   type: STRING
   mode: NULLABLE
@@ -500,6 +508,8 @@ fields:
 - name: ga4_distinct_terms_from_event_params
   type: STRING
   mode: REPEATED
+  description: All distinct search terms extracted from GA4 event parameters for the web session linked
+    to this Firefox install.
 - name: ga4_first_experiment_id_from_event_params
   type: STRING
   mode: NULLABLE
@@ -507,6 +517,8 @@ fields:
 - name: ga4_distinct_experiment_ids_from_event_params
   type: STRING
   mode: REPEATED
+  description: All distinct experiment IDs extracted from GA4 event parameters for the web session linked
+    to this Firefox install.
 - name: ga4_first_experiment_branch_from_event_params
   type: STRING
   mode: NULLABLE
@@ -514,6 +526,8 @@ fields:
 - name: ga4_distinct_experiment_branches_from_event_params
   type: STRING
   mode: REPEATED
+  description: All distinct experiment branch names extracted from GA4 event parameters for the web session
+    linked to this Firefox install.
 - name: ga4_first_gad_campaignid_from_event_params
   type: STRING
   mode: NULLABLE
@@ -553,6 +567,8 @@ fields:
 - name: ga4_gclid_array
   type: STRING
   mode: REPEATED
+  description: All Google Click IDs (gclid) recorded in the GA4 session linked to this install; multiple
+    values occur when several ad clicks are attributed to the same session.
 - name: ga4_had_download_event
   type: BOOLEAN
   mode: NULLABLE
@@ -568,6 +584,8 @@ fields:
 - name: ga4_all_reported_install_targets
   type: STRING
   mode: REPEATED
+  description: All reported install target strings from GA4 events for the linked session (e.g., 'product_download',
+    'firefox_download'); captures the full history when multiple download events occur.
 - name: ga4_stub_session_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
@@ -3492,3 +3492,10 @@ fields:
   description: The 95th percentile of the forecasted value distribution, representing the upper tail of the predicted outcome where 95% of simulated
     values fall below this threshold. This field may be null when percentile-level forecast outputs are not computed for a given row.
   type: FLOAT64
+- name: app_id
+  description: The Glean application ID (e.g., 'firefox.desktop', 'org.mozilla.fenix'). Null for legacy
+    telemetry applications.
+- name: histogram_aggregates_bucket_range_first_bucket
+  description: The lower bound of the first bucket in the histogram's bucket range.
+- name: histogram_aggregates_bucket_range_last_bucket
+  description: The upper bound of the last bucket in the histogram's bucket range.


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.telemetry_derived`

> Generated by the metadata agent pipeline on 2026-06-24.

### Summary

| | |
|---|---|
| Tables updated | 2 |
| Fields described | 21 |
| Probe-matched | 0 / 21 |
| Contradictions flagged | 0 |

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `applications_v1` | 11 | 0/11 |
| `cfs_ga4_attr_v1` | 10 | 0/10 |

### Contradictions Found

_None_

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Contradictions investigated before merging
