### PR TITLE
DENG-11307: Metadata completeness - Expand firefox_accounts_derived dataset yaml

### DIFF
--- a/bigquery_etl/schema/firefox_accounts_derived.yaml
+++ b/bigquery_etl/schema/firefox_accounts_derived.yaml
@@ -3,7 +3,10 @@ fields:
 # GCP Cloud Logging fields, sourced from
 # https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
 
-# Top-level scalars
+- name: timestamp
+  type: TIMESTAMP
+  description: The time the event described by the log entry occurred, as reported by
+    the originating FxA service.
 
 - name: logName
   type: STRING
@@ -41,19 +44,464 @@ fields:
   type: STRING
   description: The log entry payload, represented as a Unicode string (UTF-8).
 
-# Top-level payload and labels (parent only; sub-fields are user-defined)
-
 - name: jsonPayload
   type: RECORD
   description: The log entry payload, represented as a structure that is expressed as a
     JSON object.
+  fields:
+  - name: pid
+    type: FLOAT
+    description: Process ID of the FxA service instance that generated the log entry.
+  - name: timestamp
+    type: FLOAT
+    description: Application-level event timestamp as a Unix epoch nanoseconds float,
+      as reported by the FxA service. Distinct from the top-level Cloud Logging
+      `timestamp`.
+  - name: envversion
+    type: STRING
+    description: Log envelope version used by the FxA logging framework.
+  - name: logger
+    type: STRING
+    description: Name of the logger or component that emitted the log entry
+      (e.g., 'fxa-auth-server', 'fxa-content-server').
+  - name: severity
+    type: FLOAT
+    description: Application-level numeric log severity from the FxA service payload,
+      using syslog-style levels (6=informational, 2=critical). Distinct from the
+      top-level Cloud Logging `severity` STRING field. Null in some tables.
+  - name: type
+    type: STRING
+    description: Log entry type classifier (e.g., 'amplitudeEvent'). Up to 15 distinct
+      values observed across tables.
+  - name: msg
+    type: STRING
+    description: Log message string from the FxA service payload.
+  - name: message
+    type: STRING
+    description: Structured log message from the FxA service payload. Null in most tables.
+  - name: name
+    type: STRING
+    description: Name field from the log payload, identifying the process or subsystem
+      (e.g., 'customs-server', 'configure-sentry'). Null in many tables.
+  - name: statuscode
+    type: STRING
+    description: HTTP or application status code from the log payload. Null in most tables.
+  - name: level
+    type: STRING
+    description: Log severity level. Numeric Bunyan-style in some tables (30=info,
+      50=error); string level name in others. Null in most tables.
+  - name: useragent
+    type: STRING
+    description: User agent string from the log payload.
+  - name: hostname
+    type: STRING
+    description: Hostname of the server or container that generated the log entry.
+  - name: status
+    type: FLOAT
+    description: HTTP or application status value from the log payload.
+  - name: v
+    type: FLOAT
+    description: Payload schema version number used by the FxA logging framework.
+  - name: bytes_sent
+    type: FLOAT
+    description: Number of bytes sent in the HTTP response.
+  - name: log_type
+    type: STRING
+    description: Log type classification for the FxA service event.
+  - name: op
+    type: STRING
+    description: Operation type from the log payload. Null in most tables.
+  - name: referrer
+    type: STRING
+    description: HTTP referrer URL from the log payload.
+  - name: remote_addr
+    type: STRING
+    description: Remote IP address of the client making the request.
+  - name: remote_user
+    type: STRING
+    description: Authenticated remote user identifier from the log payload. Null in most
+      tables.
+  - name: request
+    type: STRING
+    description: Full HTTP request line (method, path, protocol) from the log payload.
+  - name: request_time
+    type: FLOAT
+    description: Time taken to process the request, in seconds.
+  - name: trace
+    type: STRING
+    description: Distributed tracing identifier from the application log payload.
+  - name: user_agent
+    type: STRING
+    description: User agent string identifying the browser and OS making the request.
+  - name: x_forwarded_for
+    type: STRING
+    description: X-Forwarded-For header value containing the client IP and any intermediate
+      proxy addresses.
+  - name: x_forwarded_proto
+    type: STRING
+    description: X-Forwarded-Proto header value indicating the originating protocol
+      (e.g., 'https').
+  - name: fields
+    type: RECORD
+    description: Application-level structured event data from the FxA service.
+    fields:
+    - name: user_id
+      type: STRING
+      description: SHA-256 hashed FxA user identifier, hex-encoded.
+    - name: device_id
+      type: STRING
+      description: SHA-256 hashed FxA device identifier, hex-encoded.
+    - name: err
+      type: STRING
+      description: Error details associated with the event, if any.
+    - name: msg
+      type: STRING
+      description: Log message string from the structured event payload.
+    - name: app_version
+      type: STRING
+      description: Firefox Accounts application version at the time of the event
+        (e.g., '152.1', '195.0').
+    - name: error
+      type: STRING
+      description: Error message or details associated with the event.
+    - name: event
+      type: STRING
+      description: Amplitude event name.
+    - name: event_properties
+      type: STRING
+      description: Structured event properties for the amplitude event, as a JSON string.
+    - name: event_type
+      type: STRING
+      description: Event type string identifying the category of event
+        (e.g., 'fxa_email - bounced', 'fxa_login - complete').
+    - name: op
+      type: STRING
+      description: Operation or action type associated with the event.
+    - name: stack
+      type: STRING
+      description: Stack trace string. Populated on error events.
+    - name: time
+      type: FLOAT
+      description: Event time as a Unix epoch milliseconds float. Null in some tables.
+    - name: user_properties
+      type: STRING
+      description: Structured user properties for the amplitude event, as a JSON string.
+    - name: language
+      type: STRING
+      description: BCP 47 language tag for the user's locale at the time of the event
+        (e.g., 'en-US', 'de').
+    - name: message
+      type: STRING
+      description: Log message from the event payload.
+    - name: method
+      type: STRING
+      description: HTTP method associated with the request (e.g., 'GET', 'POST').
+    - name: path
+      type: STRING
+      description: URL path of the request (e.g., '/v1/account/login').
+    - name: remoteaddresschain
+      type: STRING
+      description: Forwarding chain of client IP addresses from X-Forwarded-For headers.
+    - name: session_id
+      type: FLOAT
+      description: Identifier for the user's FxA session, represented as an epoch
+        millisecond timestamp.
+    - name: status
+      type: FLOAT
+      description: HTTP or application status code for the event. Null in some tables.
+    - name: t
+      type: FLOAT
+      description: Elapsed time in milliseconds for the operation. Null in some tables.
+    - name: device_model
+      type: STRING
+      description: Device model associated with the event (e.g., 'iPhone14,3', 'Pixel 6').
+    - name: os_name
+      type: STRING
+      description: Operating system name from the event payload (e.g., 'Windows', 'iOS',
+        'Android').
+    - name: os_version
+      type: STRING
+      description: Operating system version string from the event payload.
+    - name: port
+      type: FLOAT
+      description: Network port number associated with the request.
+    - name: useragent
+      type: STRING
+      description: Raw user agent string from the request.
+    - name: agent
+      type: STRING
+      description: User agent string from the event payload.
+    - name: email
+      type: STRING
+      description: Hashed or redacted email identifier associated with the event.
+        Present only when the event is tied to a specific account action; null for
+        anonymous or pre-login flows. Stored as raw bytes (hashed) in admin server
+        tables. Not a raw email address.
+    - name: uid
+      type: STRING
+      description: Raw FxA user identifier. Null in most tables; use `user_id` for the
+        hashed version.
+    - name: clientid
+      type: STRING
+      description: Client identifier associated with the event.
+    - name: config
+      type: STRING
+      description: Configuration metadata associated with the event. Null in most tables.
+    - name: country
+      type: STRING
+      description: Country associated with the event, as a full country name
+        (e.g., 'United States').
+    - name: region
+      type: STRING
+      description: Geographic region associated with the event (e.g., 'California').
+    - name: code
+      type: STRING
+      description: Code field from the event payload (e.g., OAuth authorization code,
+        error code).
+    - name: errno
+      type: FLOAT
+      description: FxA error number. See FxA errno documentation for values
+        (e.g., 102 for unknown account, 110 for invalid auth token).
+    - name: host
+      type: STRING
+      description: Hostname of the server handling the request.
+    - name: originaltransactionid
+      type: STRING
+      description: Original transaction identifier for subscription or payment events.
+    - name: originaltransactionids
+      type: STRING
+      description: Stringified list of original transaction identifiers. Null in most
+        records.
+    - name: payload
+      type: STRING
+      description: Raw payload string from the event. Null in most tables.
+    - name: poolstats
+      type: STRING
+      description: Database connection pool statistics as a JSON string, including pool
+        UUID, connection limit, and active/free connection counts.
+    - name: purchasetoken
+      type: STRING
+      description: Google Play Store purchase token for in-app purchase events.
+    - name: query
+      type: STRING
+      description: URL query parameters associated with the request.
+    - name: template
+      type: STRING
+      description: Email or notification template identifier
+        (e.g., 'verifyEmail', 'newDeviceLogin').
+    - name: id
+      type: STRING
+      description: Unique identifier for the event record. Null in some tables.
+    - name: locale
+      type: STRING
+      description: BCP 47 locale string (e.g., 'en-US', 'fr-FR').
+    - name: reason
+      type: STRING
+      description: Reason associated with the event (e.g., 'disconnect', 'unverified').
+    - name: request
+      type: STRING
+      description: Request metadata associated with the event. Null in most tables.
+    - name: service
+      type: STRING
+      description: Service or relying party identifier associated with the event.
+    - name: subscriptionid
+      type: STRING
+      description: Subscription identifier for subscription-related events.
+    - name: to
+      type: STRING
+      description: Destination or recipient field. Null in most tables.
+    - name: action
+      type: STRING
+      description: Action type associated with the event. Null in most tables.
+    - name: body
+      type: STRING
+      description: Request or response body. Null in most tables.
+    - name: name
+      type: STRING
+      description: Name field from the event payload. Null in most tables.
+    - name: profilechangedat
+      type: FLOAT
+      description: Unix epoch timestamp of the last profile change for the user.
+    - name: response
+      type: STRING
+      description: Response data associated with the event. Null in most tables.
+    - name: result
+      type: STRING
+      description: Result or outcome of the operation. Null in most tables.
+    - name: statuscode
+      type: FLOAT
+      description: HTTP or application status code from the event payload.
+    - name: url
+      type: STRING
+      description: URL associated with the event. Null in most tables.
+    - name: bundle
+      type: STRING
+      description: Bundle identifier. Reserved field; null in most observed records.
+    - name: client_id
+      type: STRING
+      description: Client identifier for the relying party application that initiated
+        the FxA authentication flow (e.g., Firefox Sync, Firefox Monitor). Null in
+        tables where `clientid` is used instead.
+    - name: clientaddress
+      type: STRING
+      description: Client IP address as logged by the FxA service.
+    - name: closed
+      type: BOOLEAN
+      description: Boolean flag indicating a closed connection or session. Null in most
+        tables.
+    - name: contentlength
+      type: FLOAT
+      description: HTTP Content-Length header value in bytes.
+    - name: context
+      type: STRING
+      description: Context string for the event (e.g., OAuth flow context such as
+        'fx_desktop_v3').
+    - name: countrycode
+      type: STRING
+      description: Two-letter ISO 3166-1 country code associated with the event
+        (e.g., 'US', 'DE').
+    - name: errorcode
+      type: STRING
+      description: Application-level error code. Null in most tables.
+    - name: joierrors
+      type: STRING
+      description: Joi schema validation error messages, populated when request
+        validation fails.
+    - name: referer
+      type: STRING
+      description: HTTP referer URL from the event payload.
+    - name: userid
+      type: STRING
+      description: User identifier from the event payload. Null in most tables; use
+        top-level `user_id` for the hashed identifier.
+    - name: cause
+      type: STRING
+      description: Cause or underlying reason for an error event. Null in most tables.
+    - name: data
+      type: STRING
+      description: Generic data field from the event payload. Null in most tables.
+    - name: directory
+      type: STRING
+      description: Directory path from the event payload. Null in most tables.
+    - name: domain
+      type: STRING
+      description: Domain string associated with the event (e.g., an email domain).
+    - name: flow_id
+      type: STRING
+      description: Flow identifier for the authentication or account creation session.
+        See top-level `flow_id`.
+    - name: flow_time
+      type: FLOAT
+      description: Elapsed time in milliseconds within the current authentication flow.
+        Null in most tables.
+    - name: flowbegintime
+      type: FLOAT
+      description: Unix epoch timestamp of when the authentication flow began. Null in
+        most tables.
+    - name: flowid
+      type: STRING
+      description: Flow identifier. Null in most tables; see top-level `flow_id`.
+    - name: invoiceid
+      type: STRING
+      description: Invoice identifier for subscription billing events.
+    - name: lang
+      type: STRING
+      description: Language code from the event payload. See `jsonPayload.fields.language`
+        for the primary language field.
+    - name: param
+      type: STRING
+      description: Parameter field from the event payload. Null in most tables.
+    - name: params
+      type: STRING
+      description: Request parameters from the event. Null in most tables.
+    - name: success
+      type: BOOLEAN
+      description: Boolean indicating whether the operation succeeded.
+    - name: templateversion
+      type: FLOAT
+      description: Email template version number. Null in most tables.
+    - name: type
+      type: STRING
+      description: Event type classifier within the fields payload.
+    - name: user
+      type: BYTES
+      description: SHA-256 hashed user identifier in bytes format, from the FxA admin
+        server logs.
+    - name: version
+      type: STRING
+      description: Version string from the event payload. Null in most tables.
 
 - name: labels
   type: RECORD
   description: A map of key, value pairs that provides additional information about the
     log entry.
-
-# httpRequest (HttpRequest type)
+  fields:
+  - name: compute_googleapis_com_resource_name
+    type: STRING
+    description: GCP Compute resource name (compute.googleapis.com/resource_name),
+      identifying the VM or node that generated the log entry.
+  - name: k8s_pod_app_kubernetes_io_component
+    type: STRING
+    description: Kubernetes pod label app.kubernetes.io/component, identifying the
+      component role within the application (e.g., 'auth', 'content').
+  - name: k8s_pod_app_kubernetes_io_instance
+    type: STRING
+    description: Kubernetes pod label app.kubernetes.io/instance, identifying the
+      specific deployment instance.
+  - name: k8s_pod_app_kubernetes_io_name
+    type: STRING
+    description: Kubernetes pod label app.kubernetes.io/name, identifying the
+      application name.
+  - name: k8s_pod_pod_template_hash
+    type: STRING
+    description: Kubernetes pod template hash label, used to track pod revisions across
+      rolling deployments.
+  - name: k8s_pod_deployment
+    type: STRING
+    description: Kubernetes deployment name label for the pod that generated the log
+      entry.
+  - name: application
+    type: STRING
+    description: Application label identifying the FxA application (e.g., 'fxa').
+  - name: env
+    type: STRING
+    description: Deployment environment label (e.g., 'prod', 'stage').
+  - name: k8s_pod_batch_kubernetes_io_controller_uid
+    type: STRING
+    description: Kubernetes batch controller UID (batch.kubernetes.io/controller-uid).
+      Null for non-batch workloads.
+  - name: k8s_pod_batch_kubernetes_io_job_name
+    type: STRING
+    description: Kubernetes batch job name (batch.kubernetes.io/job-name). Null for
+      non-batch workloads.
+  - name: k8s_pod_controller_uid
+    type: STRING
+    description: Kubernetes pod controller UID. Null in most records.
+  - name: k8s_pod_env_code
+    type: STRING
+    description: Kubernetes pod environment code label (e.g., 'prod').
+  - name: k8s_pod_job_name
+    type: STRING
+    description: Kubernetes pod job name. Populated only for scheduled job pods.
+  - name: k8s_pod_redis
+    type: STRING
+    description: Kubernetes pod label for Redis workloads. Null in most records.
+  - name: logging_gke_io_top_level_controller_name
+    type: STRING
+    description: GKE top-level controller name (e.g., the Deployment name) managing
+      the pod that generated the log entry.
+  - name: logging_gke_io_top_level_controller_type
+    type: STRING
+    description: GKE top-level controller type managing the pod (e.g., 'Deployment',
+      'CronJob').
+  - name: stack
+    type: STRING
+    description: Stack label from the log metadata (e.g., 'default'). Present in some
+      tables; null in others.
+  - name: type
+    type: STRING
+    description: Type label from the log metadata indicating the log source category
+      (e.g., 'admin_panel'). Present in some tables; null in others.
 
 - name: httpRequest
   type: RECORD
@@ -110,8 +558,6 @@ fields:
     type: STRING
     description: 'Protocol used for the request. Examples: "HTTP/1.1", "HTTP/2".'
 
-# operation (LogEntryOperation type)
-
 - name: operation
   type: RECORD
   description: Information about an operation associated with the log entry, if
@@ -132,8 +578,6 @@ fields:
     type: BOOLEAN
     description: Set this to True if this is the last log entry in the operation.
 
-# resource (MonitoredResource type; resource.labels.* deferred)
-
 - name: resource
   type: RECORD
   description: The monitored resource that produced this log entry.
@@ -142,8 +586,37 @@ fields:
     type: STRING
     description: The monitored resource type. For example, the type of a Compute Engine
       VM instance is `gce_instance`.
-
-# sourceLocation (LogEntrySourceLocation type)
+  - name: labels
+    type: RECORD
+    description: GCP resource metadata labels attached to the log entry by Cloud Logging.
+    fields:
+    - name: project_id
+      type: STRING
+      description: GCP project ID of the log source.
+    - name: cluster_name
+      type: STRING
+      description: Kubernetes cluster name where the FxA service is running
+        (e.g., 'fxa-prod').
+    - name: container_name
+      type: STRING
+      description: Container name within the pod that generated the log entry.
+    - name: location
+      type: STRING
+      description: GCP region of the log source (e.g., 'us-west1').
+    - name: namespace_name
+      type: STRING
+      description: Kubernetes namespace of the pod that generated the log entry
+        (e.g., 'fxa').
+    - name: pod_name
+      type: STRING
+      description: Kubernetes pod name that generated the log entry.
+    - name: instance_id
+      type: STRING
+      description: Cloud instance identifier of the node that generated the log entry
+        (e.g., 'i-xxxxxxxxxxxxxxxxx').
+    - name: zone
+      type: STRING
+      description: Availability zone of the resource (e.g., 'us-west-1').
 
 - name: sourceLocation
   type: RECORD
@@ -162,8 +635,6 @@ fields:
     description: Human-readable name of the function or method being invoked, with
       optional context such as the class or package name.
 
-# split (LogSplit type)
-
 - name: split
   type: RECORD
   description: Information indicating this LogEntry is part of a sequence of multiple log
@@ -181,8 +652,6 @@ fields:
     description: The total number of log entries that the original LogEntry was split
       into.
 
-# errorGroups (LogErrorGroup type; REPEATED)
-
 - mode: REPEATED
   name: errorGroups
   type: RECORD
@@ -192,3 +661,201 @@ fields:
     type: STRING
     description: The id is a unique identifier for a particular error group; it is the
       last part of the error group resource name.
+
+- name: apphub
+  type: RECORD
+  description: GCP App Hub metadata associated with this log entry.
+  fields:
+  - name: application
+    type: RECORD
+    description: App Hub application context.
+    fields:
+    - name: container
+      type: STRING
+      description: App Hub application container. Null in most observed FxA records.
+    - name: id
+      type: STRING
+      description: App Hub application identifier. Null in most observed FxA records.
+    - name: location
+      type: STRING
+      description: App Hub application location. Null in most observed FxA records.
+  - name: service
+    type: RECORD
+    description: App Hub service context.
+    fields:
+    - name: criticalityType
+      type: STRING
+      description: App Hub service criticality classification. Null in all observed FxA
+        records.
+    - name: environmentType
+      type: STRING
+      description: App Hub service environment type (e.g., 'PRODUCTION'). Null in all
+        observed FxA records.
+    - name: id
+      type: STRING
+      description: App Hub service identifier. Null in most observed FxA records.
+  - name: workload
+    type: RECORD
+    description: App Hub workload context.
+    fields:
+    - name: criticalityType
+      type: STRING
+      description: App Hub workload criticality classification. Null in all observed FxA
+        records.
+    - name: environmentType
+      type: STRING
+      description: App Hub workload environment type. Null in most observed FxA records.
+    - name: id
+      type: STRING
+      description: App Hub workload identifier. Null in most observed FxA records.
+
+- name: apphubDestination
+  type: RECORD
+  description: GCP App Hub destination metadata associated with this log entry.
+  fields:
+  - name: application
+    type: RECORD
+    description: App Hub destination application context.
+    fields:
+    - name: container
+      type: STRING
+      description: App Hub destination application container. Null in all observed FxA
+        records.
+    - name: id
+      type: STRING
+      description: App Hub destination application identifier. Null in all observed FxA
+        records.
+    - name: location
+      type: STRING
+      description: App Hub destination application location. Null in all observed FxA
+        records.
+  - name: service
+    type: RECORD
+    description: App Hub destination service context.
+    fields:
+    - name: criticalityType
+      type: STRING
+      description: App Hub destination service criticality classification. Null in all
+        observed FxA records.
+    - name: environmentType
+      type: STRING
+      description: App Hub destination service environment type. Null in all observed FxA
+        records.
+    - name: id
+      type: STRING
+      description: App Hub destination service identifier. Null in all observed FxA
+        records.
+  - name: workload
+    type: RECORD
+    description: App Hub destination workload context.
+    fields:
+    - name: criticalityType
+      type: STRING
+      description: App Hub destination workload criticality classification. Null in all
+        observed FxA records.
+    - name: environmentType
+      type: STRING
+      description: App Hub destination workload environment type. Null in all observed FxA
+        records.
+    - name: id
+      type: STRING
+      description: App Hub destination workload identifier. Null in all observed FxA
+        records.
+
+- name: apphubSource
+  type: RECORD
+  description: GCP App Hub source metadata associated with this log entry.
+  fields:
+  - name: application
+    type: RECORD
+    description: App Hub source application context.
+    fields:
+    - name: container
+      type: STRING
+      description: App Hub source application container. Null in most observed FxA records.
+    - name: id
+      type: STRING
+      description: App Hub source application identifier. Null in most observed FxA records.
+    - name: location
+      type: STRING
+      description: App Hub source application location. Null in most observed FxA records.
+  - name: service
+    type: RECORD
+    description: App Hub source service context.
+    fields:
+    - name: criticalityType
+      type: STRING
+      description: App Hub source service criticality classification. Null in all observed
+        FxA records.
+    - name: environmentType
+      type: STRING
+      description: App Hub source service environment type. Null in all observed FxA
+        records.
+    - name: id
+      type: STRING
+      description: App Hub source service identifier. Null in most observed FxA records.
+  - name: workload
+    type: RECORD
+    description: App Hub source workload context.
+    fields:
+    - name: criticalityType
+      type: STRING
+      description: App Hub source workload criticality classification. Null in all observed
+        FxA records.
+    - name: environmentType
+      type: STRING
+      description: App Hub source workload environment type. Null in all observed FxA
+        records.
+    - name: id
+      type: STRING
+      description: App Hub source workload identifier. Null in most observed FxA records.
+
+
+- name: user_id
+  type: STRING
+  description: SHA-256 hashed Firefox Accounts user identifier (uid), hex-encoded. Primary
+    key for joining user-level tables.
+
+- name: submission_date
+  type: DATE
+  description: Date the record was ingested into the pipeline, used as the partition key.
+    Derived from the event timestamp.
+
+- name: flow_id
+  type: STRING
+  description: Unique identifier tracking a single end-to-end authentication or account
+    creation flow. Used to correlate all events belonging to the same user session.
+
+- name: service
+  type: STRING
+  description: The Mozilla service or OAuth relying party associated with the event
+    (e.g., 'sync', 'pocket-web', 'fenix', 'amo-web').
+
+- name: country
+  type: STRING
+  description: Country associated with the user or event, as a full country name
+    (e.g., 'United States', 'Germany').
+
+- name: language
+  type: STRING
+  description: BCP 47 language tag representing the user's preferred language
+    (e.g., 'en-US', 'de', 'fr').
+
+- name: os_name
+  type: STRING
+  description: Operating system name (e.g., 'Windows', 'Mac OS X', 'Android', 'iOS').
+
+- name: os_version
+  type: STRING
+  description: Operating system version string (e.g., '10' for Windows 10, '14.0' for
+    macOS Sonoma).
+
+- name: ua_browser
+  type: STRING
+  description: Browser name parsed from the user agent string (e.g., 'Firefox',
+    'Firefox iOS').
+
+- name: ua_version
+  type: STRING
+  description: Browser or client version parsed from the user agent string (e.g., '120',
+    '121').


### PR DESCRIPTION
Add additional definitions for  jsonPayload, labels, resource, and FxA-specific field descriptions

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-11307

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
