### PR TITLE
Restore fork PR builds under actions/checkout v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,10 @@ jobs:
           filter: blob:none
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+          # Fork code only runs here via workflow_run, after the per-SHA
+          # external-fork approval in fork-gate.yml — that gate is the control,
+          # so opt past checkout v7's pull_request_target protection.
+          allow-unsafe-pr-checkout: true
       # For workflow_run (fork PRs post-gate), the PR event payload isn't
       # available. Resolve the PR's base SHA via the API so changed-files can
       # still compute a real diff instead of conservatively running everything.
@@ -190,6 +194,8 @@ jobs:
           persist-credentials: false
           filter: blob:none
           ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+          # Fork ref gated by the external-fork approval (see checkout-with-history).
+          allow-unsafe-pr-checkout: true
       - &setup-python
         name: Set up Python
         id: setup_python
@@ -365,6 +371,8 @@ jobs:
           persist-credentials: true
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+          # Fork ref gated by the external-fork approval (see checkout-with-history).
+          allow-unsafe-pr-checkout: true
       - *setup-python
       - *restore-venv
       - *auth-gcp-dryrun


### PR DESCRIPTION
GHA [`checkout-v7` blocks checking out fork PR refs by default](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target), which broke `build.yml`'s fork build (it checks out workflow_run.head_sha): https://github.com/mozilla/bigquery-etl/actions/runs/28115305683. Fork code only runs on the `workflow_run` path after the `external-fork` environment approval, so that approval is the control. This PR adds `allow-unsafe-pr-checkout: true` to the three fork-code checkout anchors to opt past the v7 protection.

See https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
