### PR TITLE
chore: Add billingetl and atlantis service account wg to mozcloud dat…

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozcloud/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud/dataset_metadata.yaml
@@ -6,5 +6,7 @@ user_facing: true
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
+  - workgroup:finops/billingetl-bq-scheduled
   - workgroup:mozilla-confidential/data-viewers
   - workgroup:platform/backstage-gke
+  - workgroup:platform/platform-tf

--- a/sql/moz-fx-data-shared-prod/mozcloud_derived/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud_derived/dataset_metadata.yaml
@@ -6,5 +6,7 @@ user_facing: false
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
+  - workgroup:finops/billingetl-bq-scheduled
   - workgroup:mozilla-confidential/data-viewers
   - workgroup:platform/backstage-gke
+  - workgroup:platform/platform-tf

--- a/sql/moz-fx-data-shared-prod/mozcloud_tenants_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud_tenants_syndicate/dataset_metadata.yaml
@@ -11,5 +11,7 @@ syndication:
 workgroup_access:
 - role: roles/bigquery.dataViewer
   members:
+  - workgroup:finops/billingetl-bq-scheduled
   - workgroup:mozilla-confidential/data-viewers
   - workgroup:platform/backstage-gke
+  - workgroup:platform/platform-tf


### PR DESCRIPTION
…aset

## Description
Enable billingetl scheduled jobs and atlantis to read these tables. 

r? 
<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
[MZCLD-2515](https://mozilla-hub.atlassian.net/browse/MZCLD-2515)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[MZCLD-2515]: https://mozilla-hub.atlassian.net/browse/MZCLD-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ