### PR TITLE
chore: Add billingetl and atlantis service account wg to bugzilla_met…

### DIFF
--- a/sql/moz-fx-data-shared-prod/bugzilla_metrics/users/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/bugzilla_metrics/users/metadata.yaml
@@ -2,4 +2,6 @@
 workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
+      - workgroup:finops/billingetl-bq-scheduled
       - workgroup:platform/access-events
+      - workgroup:platform/platform-tf


### PR DESCRIPTION
…rics.user table

## Description
Enable billingetl scheduled jobs and atlantis to read these tables. Related to https://github.com/mozilla/private-bigquery-etl/pull/1416

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* [MZCLD-2515](https://mozilla-hub.atlassian.net/browse/MZCLD-2515)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[MZCLD-2515]: https://mozilla-hub.atlassian.net/browse/MZCLD-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ