### PR TITLE
Deng-11281 cascade dataset descriptions to tables

### DIFF
--- a/bigquery_etl/schema/firefox_accounts_derived.yaml
+++ b/bigquery_etl/schema/firefox_accounts_derived.yaml
@@ -68,28 +68,27 @@ fields:
     type: FLOAT
     description: Application-level numeric log severity from the FxA service payload,
       using syslog-style levels (6=informational, 2=critical). Distinct from the
-      top-level Cloud Logging `severity` STRING field. Null in some tables.
+      top-level Cloud Logging `severity` STRING field.
   - name: type
     type: STRING
-    description: Log entry type classifier (e.g., 'amplitudeEvent'). Up to 15 distinct
-      values observed across tables.
+    description: Log entry type classifier (e.g., 'amplitudeEvent').
   - name: msg
     type: STRING
     description: Log message string from the FxA service payload.
   - name: message
     type: STRING
-    description: Structured log message from the FxA service payload. Null in most tables.
+    description: Structured log message from the FxA service payload.
   - name: name
     type: STRING
     description: Name field from the log payload, identifying the process or subsystem
-      (e.g., 'customs-server', 'configure-sentry'). Null in many tables.
+      (e.g., 'customs-server', 'configure-sentry').
   - name: statuscode
     type: STRING
-    description: HTTP or application status code from the log payload. Null in most tables.
+    description: HTTP or application status code from the log payload.
   - name: level
     type: STRING
     description: Log severity level. Numeric Bunyan-style in some tables (30=info,
-      50=error); string level name in others. Null in most tables.
+      50=error); string level name in others.
   - name: useragent
     type: STRING
     description: User agent string from the log payload.
@@ -110,7 +109,7 @@ fields:
     description: Log type classification for the FxA service event.
   - name: op
     type: STRING
-    description: Operation type from the log payload. Null in most tables.
+    description: Operation type from the log payload.
   - name: referrer
     type: STRING
     description: HTTP referrer URL from the log payload.
@@ -119,8 +118,7 @@ fields:
     description: Remote IP address of the client making the request.
   - name: remote_user
     type: STRING
-    description: Authenticated remote user identifier from the log payload. Null in most
-      tables.
+    description: Authenticated remote user identifier from the log payload.
   - name: request
     type: STRING
     description: Full HTTP request line (method, path, protocol) from the log payload.
@@ -182,7 +180,7 @@ fields:
       description: Stack trace string. Populated on error events.
     - name: time
       type: FLOAT
-      description: Event time as a Unix epoch milliseconds float. Null in some tables.
+      description: Event time as a Unix epoch milliseconds float.
     - name: user_properties
       type: STRING
       description: Structured user properties for the amplitude event, as a JSON string.
@@ -208,10 +206,10 @@ fields:
         millisecond timestamp.
     - name: status
       type: FLOAT
-      description: HTTP or application status code for the event. Null in some tables.
+      description: HTTP or application status code for the event.
     - name: t
       type: FLOAT
-      description: Elapsed time in milliseconds for the operation. Null in some tables.
+      description: Elapsed time in milliseconds for the operation.
     - name: device_model
       type: STRING
       description: Device model associated with the event (e.g., 'iPhone14,3', 'Pixel 6').
@@ -239,14 +237,13 @@ fields:
         tables. Not a raw email address.
     - name: uid
       type: STRING
-      description: Raw FxA user identifier. Null in most tables; use `user_id` for the
-        hashed version.
+      description: Raw FxA user identifier. Use `user_id` for the hashed version.
     - name: clientid
       type: STRING
       description: Client identifier associated with the event.
     - name: config
       type: STRING
-      description: Configuration metadata associated with the event. Null in most tables.
+      description: Configuration metadata associated with the event.
     - name: country
       type: STRING
       description: Country associated with the event, as a full country name
@@ -270,11 +267,10 @@ fields:
       description: Original transaction identifier for subscription or payment events.
     - name: originaltransactionids
       type: STRING
-      description: Stringified list of original transaction identifiers. Null in most
-        records.
+      description: Stringified list of original transaction identifiers.
     - name: payload
       type: STRING
-      description: Raw payload string from the event. Null in most tables.
+      description: Raw payload string from the event.
     - name: poolstats
       type: STRING
       description: Database connection pool statistics as a JSON string, including pool
@@ -291,7 +287,7 @@ fields:
         (e.g., 'verifyEmail', 'newDeviceLogin').
     - name: id
       type: STRING
-      description: Unique identifier for the event record. Null in some tables.
+      description: Unique identifier for the event record.
     - name: locale
       type: STRING
       description: BCP 47 locale string (e.g., 'en-US', 'fr-FR').
@@ -300,7 +296,7 @@ fields:
       description: Reason associated with the event (e.g., 'disconnect', 'unverified').
     - name: request
       type: STRING
-      description: Request metadata associated with the event. Null in most tables.
+      description: Request metadata associated with the event.
     - name: service
       type: STRING
       description: Service or relying party identifier associated with the event.
@@ -309,34 +305,34 @@ fields:
       description: Subscription identifier for subscription-related events.
     - name: to
       type: STRING
-      description: Destination or recipient field. Null in most tables.
+      description: Destination or recipient field.
     - name: action
       type: STRING
-      description: Action type associated with the event. Null in most tables.
+      description: Action type associated with the event.
     - name: body
       type: STRING
-      description: Request or response body. Null in most tables.
+      description: Request or response body.
     - name: name
       type: STRING
-      description: Name field from the event payload. Null in most tables.
+      description: Name field from the event payload.
     - name: profilechangedat
       type: FLOAT
       description: Unix epoch timestamp of the last profile change for the user.
     - name: response
       type: STRING
-      description: Response data associated with the event. Null in most tables.
+      description: Response data associated with the event.
     - name: result
       type: STRING
-      description: Result or outcome of the operation. Null in most tables.
+      description: Result or outcome of the operation.
     - name: statuscode
       type: FLOAT
       description: HTTP or application status code from the event payload.
     - name: url
       type: STRING
-      description: URL associated with the event. Null in most tables.
+      description: URL associated with the event.
     - name: bundle
       type: STRING
-      description: Bundle identifier. Reserved field; null in most observed records.
+      description: Bundle identifier. Reserved field.
     - name: client_id
       type: STRING
       description: Client identifier for the relying party application that initiated
@@ -347,8 +343,7 @@ fields:
       description: Client IP address as logged by the FxA service.
     - name: closed
       type: BOOLEAN
-      description: Boolean flag indicating a closed connection or session. Null in most
-        tables.
+      description: Boolean flag indicating a closed connection or session.
     - name: contentlength
       type: FLOAT
       description: HTTP Content-Length header value in bytes.
@@ -362,7 +357,7 @@ fields:
         (e.g., 'US', 'DE').
     - name: errorcode
       type: STRING
-      description: Application-level error code. Null in most tables.
+      description: Application-level error code.
     - name: joierrors
       type: STRING
       description: Joi schema validation error messages, populated when request
@@ -372,17 +367,17 @@ fields:
       description: HTTP referer URL from the event payload.
     - name: userid
       type: STRING
-      description: User identifier from the event payload. Null in most tables; use
-        top-level `user_id` for the hashed identifier.
+      description: User identifier from the event payload. Use top-level `user_id`
+        for the hashed identifier.
     - name: cause
       type: STRING
-      description: Cause or underlying reason for an error event. Null in most tables.
+      description: Cause or underlying reason for an error event.
     - name: data
       type: STRING
-      description: Generic data field from the event payload. Null in most tables.
+      description: Generic data field from the event payload.
     - name: directory
       type: STRING
-      description: Directory path from the event payload. Null in most tables.
+      description: Directory path from the event payload.
     - name: domain
       type: STRING
       description: Domain string associated with the event (e.g., an email domain).
@@ -393,14 +388,13 @@ fields:
     - name: flow_time
       type: FLOAT
       description: Elapsed time in milliseconds within the current authentication flow.
-        Null in most tables.
+
     - name: flowbegintime
       type: FLOAT
-      description: Unix epoch timestamp of when the authentication flow began. Null in
-        most tables.
+      description: Unix epoch timestamp of when the authentication flow began.
     - name: flowid
       type: STRING
-      description: Flow identifier. Null in most tables; see top-level `flow_id`.
+      description: Flow identifier. See top-level `flow_id`.
     - name: invoiceid
       type: STRING
       description: Invoice identifier for subscription billing events.
@@ -410,16 +404,16 @@ fields:
         for the primary language field.
     - name: param
       type: STRING
-      description: Parameter field from the event payload. Null in most tables.
+      description: Parameter field from the event payload.
     - name: params
       type: STRING
-      description: Request parameters from the event. Null in most tables.
+      description: Request parameters from the event.
     - name: success
       type: BOOLEAN
       description: Boolean indicating whether the operation succeeded.
     - name: templateversion
       type: FLOAT
-      description: Email template version number. Null in most tables.
+      description: Email template version number.
     - name: type
       type: STRING
       description: Event type classifier within the fields payload.
@@ -429,7 +423,7 @@ fields:
         server logs.
     - name: version
       type: STRING
-      description: Version string from the event payload. Null in most tables.
+      description: Version string from the event payload.
 
 - name: labels
   type: RECORD
@@ -476,7 +470,7 @@ fields:
       non-batch workloads.
   - name: k8s_pod_controller_uid
     type: STRING
-    description: Kubernetes pod controller UID. Null in most records.
+    description: Kubernetes pod controller UID.
   - name: k8s_pod_env_code
     type: STRING
     description: Kubernetes pod environment code label (e.g., 'prod').
@@ -485,7 +479,7 @@ fields:
     description: Kubernetes pod job name. Populated only for scheduled job pods.
   - name: k8s_pod_redis
     type: STRING
-    description: Kubernetes pod label for Redis workloads. Null in most records.
+    description: Kubernetes pod label for Redis workloads.
   - name: logging_gke_io_top_level_controller_name
     type: STRING
     description: GKE top-level controller name (e.g., the Deployment name) managing
@@ -496,12 +490,11 @@ fields:
       'CronJob').
   - name: stack
     type: STRING
-    description: Stack label from the log metadata (e.g., 'default'). Present in some
-      tables; null in others.
+    description: Stack label from the log metadata (e.g., 'default').
   - name: type
     type: STRING
     description: Type label from the log metadata indicating the log source category
-      (e.g., 'admin_panel'). Present in some tables; null in others.
+      (e.g., 'admin_panel').
 
 - name: httpRequest
   type: RECORD
@@ -672,42 +665,39 @@ fields:
     fields:
     - name: container
       type: STRING
-      description: App Hub application container. Null in most observed FxA records.
+      description: App Hub application container.
     - name: id
       type: STRING
-      description: App Hub application identifier. Null in most observed FxA records.
+      description: App Hub application identifier.
     - name: location
       type: STRING
-      description: App Hub application location. Null in most observed FxA records.
+      description: App Hub application location.
   - name: service
     type: RECORD
     description: App Hub service context.
     fields:
     - name: criticalityType
       type: STRING
-      description: App Hub service criticality classification. Null in all observed FxA
-        records.
+      description: App Hub service criticality classification.
     - name: environmentType
       type: STRING
-      description: App Hub service environment type (e.g., 'PRODUCTION'). Null in all
-        observed FxA records.
+      description: App Hub service environment type (e.g., 'PRODUCTION').
     - name: id
       type: STRING
-      description: App Hub service identifier. Null in most observed FxA records.
+      description: App Hub service identifier.
   - name: workload
     type: RECORD
     description: App Hub workload context.
     fields:
     - name: criticalityType
       type: STRING
-      description: App Hub workload criticality classification. Null in all observed FxA
-        records.
+      description: App Hub workload criticality classification.
     - name: environmentType
       type: STRING
-      description: App Hub workload environment type. Null in most observed FxA records.
+      description: App Hub workload environment type.
     - name: id
       type: STRING
-      description: App Hub workload identifier. Null in most observed FxA records.
+      description: App Hub workload identifier.
 
 - name: apphubDestination
   type: RECORD
@@ -719,48 +709,39 @@ fields:
     fields:
     - name: container
       type: STRING
-      description: App Hub destination application container. Null in all observed FxA
-        records.
+      description: App Hub destination application container.
     - name: id
       type: STRING
-      description: App Hub destination application identifier. Null in all observed FxA
-        records.
+      description: App Hub destination application identifier.
     - name: location
       type: STRING
-      description: App Hub destination application location. Null in all observed FxA
-        records.
+      description: App Hub destination application location.
   - name: service
     type: RECORD
     description: App Hub destination service context.
     fields:
     - name: criticalityType
       type: STRING
-      description: App Hub destination service criticality classification. Null in all
-        observed FxA records.
+      description: App Hub destination service criticality classification.
     - name: environmentType
       type: STRING
-      description: App Hub destination service environment type. Null in all observed FxA
-        records.
+      description: App Hub destination service environment type.
     - name: id
       type: STRING
-      description: App Hub destination service identifier. Null in all observed FxA
-        records.
+      description: App Hub destination service identifier.
   - name: workload
     type: RECORD
     description: App Hub destination workload context.
     fields:
     - name: criticalityType
       type: STRING
-      description: App Hub destination workload criticality classification. Null in all
-        observed FxA records.
+      description: App Hub destination workload criticality classification.
     - name: environmentType
       type: STRING
-      description: App Hub destination workload environment type. Null in all observed FxA
-        records.
+      description: App Hub destination workload environment type.
     - name: id
       type: STRING
-      description: App Hub destination workload identifier. Null in all observed FxA
-        records.
+      description: App Hub destination workload identifier.
 
 - name: apphubSource
   type: RECORD
@@ -772,44 +753,41 @@ fields:
     fields:
     - name: container
       type: STRING
-      description: App Hub source application container. Null in most observed FxA records.
+      description: App Hub source application container.
     - name: id
       type: STRING
-      description: App Hub source application identifier. Null in most observed FxA records.
+      description: App Hub source application identifier.
     - name: location
       type: STRING
-      description: App Hub source application location. Null in most observed FxA records.
+      description: App Hub source application location.
   - name: service
     type: RECORD
     description: App Hub source service context.
     fields:
     - name: criticalityType
       type: STRING
-      description: App Hub source service criticality classification. Null in all observed
-        FxA records.
+      description: App Hub source service criticality classification.
     - name: environmentType
       type: STRING
-      description: App Hub source service environment type. Null in all observed FxA
-        records.
+      description: App Hub source service environment type.
     - name: id
       type: STRING
-      description: App Hub source service identifier. Null in most observed FxA records.
+      description: App Hub source service identifier.
   - name: workload
     type: RECORD
     description: App Hub source workload context.
     fields:
     - name: criticalityType
       type: STRING
-      description: App Hub source workload criticality classification. Null in all observed
-        FxA records.
+      description: App Hub source workload criticality classification.
     - name: environmentType
       type: STRING
-      description: App Hub source workload environment type. Null in all observed FxA
-        records.
+      description: App Hub source workload environment type.
     - name: id
       type: STRING
-      description: App Hub source workload identifier. Null in most observed FxA records.
+      description: App Hub source workload identifier.
 
+# FxA-derived fields shared across firefox_accounts_derived tables
 
 - name: user_id
   type: STRING
@@ -819,7 +797,6 @@ fields:
 - name: submission_date
   type: DATE
   description: Date the record was ingested into the pipeline, used as the partition key.
-    Derived from the event timestamp.
 
 - name: flow_id
   type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v1/schema.yaml
@@ -24,16 +24,28 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -50,21 +62,39 @@ fields:
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: usergroupheader
       type: STRING
@@ -75,51 +105,96 @@ fields:
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: auto_completed
       type: BOOLEAN
       mode: NULLABLE
     - name: email
       type: BYTES
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user
       type: BYTES
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: success
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.success
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -239,18 +314,33 @@ fields:
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_admin_server_sanitized_v2/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,166 +80,325 @@ fields:
   - name: log_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.log_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request_time
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request_time
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_for
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_for
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.bytes_sent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: user_agent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.user_agent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_proto
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: trace
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.trace
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_user
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_user
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_addr
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_addr
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: referrer
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.referrer
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: status
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.status
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: code
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: result
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: api
       type: FLOAT
       mode: NULLABLE
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: source
       type: STRING
       mode: NULLABLE
@@ -240,18 +420,33 @@ fields:
     - name: url
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.url
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: directory
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.directory
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: signal
       type: STRING
       mode: NULLABLE
@@ -273,6 +468,9 @@ fields:
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: header
       type: STRING
       mode: NULLABLE
@@ -285,9 +483,15 @@ fields:
     - name: user
       type: BYTES
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: email
       type: BYTES
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: search_type
       type: STRING
       mode: NULLABLE
@@ -297,6 +501,9 @@ fields:
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_agent
       type: STRING
       mode: NULLABLE
@@ -318,9 +525,15 @@ fields:
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: duration
       type: FLOAT
       mode: NULLABLE
@@ -333,24 +546,42 @@ fields:
     - name: cause
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.cause
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: success
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.success
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: sample
       type: STRING
       mode: NULLABLE
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: closed
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.closed
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _res
       type: STRING
       mode: NULLABLE
@@ -360,18 +591,27 @@ fields:
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locator
       type: STRING
       mode: NULLABLE
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: twofactorauthentication
       type: BOOLEAN
       mode: NULLABLE
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: atleast18atreg
       type: STRING
       mode: NULLABLE
@@ -384,21 +624,36 @@ fields:
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _
       type: STRING
       mode: NULLABLE
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bundle
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.bundle
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: userid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.userid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errorcode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errorcode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: subscriptionsbyclientid
       type: STRING
       mode: NULLABLE
@@ -420,21 +675,36 @@ fields:
     - name: body
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.body
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: phonenumber
       type: STRING
       mode: NULLABLE
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: to
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.to
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: action
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.action
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: timestamp
       type: STRING
       mode: NULLABLE
@@ -444,12 +714,21 @@ fields:
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: jse_cause
     type: RECORD
     mode: NULLABLE
@@ -463,15 +742,24 @@ fields:
   - name: message
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.message
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: jse_info
     type: RECORD
     mode: NULLABLE
@@ -491,6 +779,9 @@ fields:
   - name: statuscode
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.statuscode
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: retrydelay
     type: FLOAT
     mode: NULLABLE
@@ -503,6 +794,9 @@ fields:
   - name: msg
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.msg
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: scheme
     type: STRING
     mode: NULLABLE
@@ -512,6 +806,9 @@ fields:
   - name: useragent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.useragent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: responseheaders
     type: RECORD
     mode: REPEATED
@@ -624,6 +921,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -743,48 +1043,90 @@ fields:
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_redis
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_redis
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_run
     type: STRING
     mode: NULLABLE
   - name: logging_gke_io_top_level_controller_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logging_gke_io_top_level_controller_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE
@@ -900,129 +1242,243 @@ fields:
 - name: apphub
   type: RECORD
   mode: NULLABLE
+  description: !include-field-description
+    field: apphub
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
   fields:
   - name: application
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: container
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.container
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: service
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.service
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: workload
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.workload
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: apphubDestination
   type: RECORD
   mode: NULLABLE
+  description: !include-field-description
+    field: apphubDestination
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
   fields:
   - name: application
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphubDestination.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: container
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.application.container
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.application.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.application.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: service
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphubDestination.service
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.service.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.service.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.service.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: workload
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphubDestination.workload
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.workload.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.workload.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubDestination.workload.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: apphubSource
   type: RECORD
   mode: NULLABLE
+  description: !include-field-description
+    field: apphubSource
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
   fields:
   - name: application
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphubSource.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: container
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.application.container
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.application.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.application.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: service
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphubSource.service
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.service.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.service.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.service.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: workload
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphubSource.workload
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.workload.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphubSource.workload.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v1/schema.yaml
@@ -24,16 +24,28 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -50,21 +62,39 @@ fields:
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: msg
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.msg
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: op
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.op
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: ip
     type: BYTES
     mode: NULLABLE
@@ -74,9 +104,15 @@ fields:
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: statuscode
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.statuscode
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: filename
     type: STRING
     mode: NULLABLE
@@ -140,6 +176,9 @@ fields:
   - name: timestamp
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: reason
     type: STRING
     mode: NULLABLE
@@ -149,6 +188,9 @@ fields:
   - name: message
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.message
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: host
     type: STRING
     mode: NULLABLE
@@ -484,6 +526,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -603,18 +648,33 @@ fields:
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/docker_fxa_customs_sanitized_v2/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,52 +80,91 @@ fields:
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: traceid
       type: STRING
       mode: NULLABLE
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: keys
       type: BOOLEAN
       mode: NULLABLE
     - name: status
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: domain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.domain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: processingtimemillis
       type: FLOAT
       mode: NULLABLE
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templatename
       type: STRING
       mode: NULLABLE
@@ -114,33 +174,63 @@ fields:
     - name: flowid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowbegintime
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowbegintime
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templateversion
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.templateversion
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lang
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.lang
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bouncesubtype
       type: STRING
       mode: NULLABLE
@@ -150,6 +240,9 @@ fields:
     - name: action
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.action
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bounce
       type: BOOLEAN
       mode: NULLABLE
@@ -159,33 +252,63 @@ fields:
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bounced
       type: BOOLEAN
       mode: NULLABLE
@@ -195,30 +318,54 @@ fields:
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: granttype
       type: STRING
       mode: NULLABLE
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: command
       type: STRING
       mode: NULLABLE
@@ -252,6 +399,9 @@ fields:
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: dbpath
       type: STRING
       mode: NULLABLE
@@ -261,18 +411,33 @@ fields:
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowcompletesignal
       type: STRING
       mode: NULLABLE
@@ -348,6 +513,9 @@ fields:
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: disabledat
       type: STRING
       mode: NULLABLE
@@ -375,18 +543,33 @@ fields:
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: utm_medium
       type: STRING
       mode: NULLABLE
@@ -402,6 +585,9 @@ fields:
     - name: body
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.body
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bodysize
       type: FLOAT
       mode: NULLABLE
@@ -426,6 +612,9 @@ fields:
     - name: id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isverified
       type: BOOLEAN
       mode: NULLABLE
@@ -465,9 +654,15 @@ fields:
     - name: code
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: subscriptionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.subscriptionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: entrypoint_variation
       type: STRING
       mode: NULLABLE
@@ -477,15 +672,27 @@ fields:
     - name: to
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.to
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: params
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.params
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
@@ -495,24 +702,42 @@ fields:
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isaxioserror
       type: BOOLEAN
       mode: NULLABLE
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: data
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.data
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchase
       type: STRING
       mode: NULLABLE
@@ -537,9 +762,15 @@ fields:
     - name: param
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.param
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: postalcode
       type: STRING
       mode: NULLABLE
@@ -555,6 +786,9 @@ fields:
     - name: invoiceid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.invoiceid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isserver
       type: BOOLEAN
       mode: NULLABLE
@@ -576,42 +810,78 @@ fields:
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: regex
     type: STRING
     mode: NULLABLE
   - name: msg
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.msg
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: op
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.op
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: useragent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.useragent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: event
     type: STRING
     mode: NULLABLE
@@ -980,6 +1250,9 @@ fields:
   - name: statuscode
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.statuscode
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: rtime
     type: STRING
     mode: NULLABLE
@@ -1019,6 +1292,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -1138,24 +1414,45 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_export_v1/schema.yaml
@@ -5,6 +5,9 @@ fields:
 - mode: NULLABLE
   name: user_id
   type: STRING
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - mode: NULLABLE
   name: insert_id
   type: STRING
@@ -14,9 +17,15 @@ fields:
 - mode: NULLABLE
   name: country
   type: STRING
+  description: !include-field-description
+    field: country
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - mode: NULLABLE
   name: language
   type: STRING
+  description: !include-field-description
+    field: language
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - mode: REPEATED
   name: services
   type: STRING
@@ -51,9 +60,15 @@ fields:
 - mode: NULLABLE
   name: ua_version
   type: STRING
+  description: !include-field-description
+    field: ua_version
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - mode: NULLABLE
   name: ua_browser
   type: STRING
+  description: !include-field-description
+    field: ua_browser
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - mode: NULLABLE
   name: app_version
   type: FLOAT

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_amplitude_user_ids_v1/schema.yaml
@@ -2,3 +2,6 @@ fields:
 - mode: NULLABLE
   name: user_id
   type: STRING
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_bounce_events_v1/schema.yaml
@@ -21,16 +21,28 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -47,85 +59,154 @@ fields:
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: domain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.domain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templateversion
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.templateversion
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: processingtimemillis
       type: FLOAT
       mode: NULLABLE
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templatename
       type: STRING
       mode: NULLABLE
     - name: flowbegintime
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowbegintime
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: currenttime
       type: FLOAT
       mode: NULLABLE
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bounced
       type: BOOLEAN
       mode: NULLABLE
     - name: action
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.action
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bouncetype
       type: STRING
       mode: NULLABLE
@@ -135,21 +216,33 @@ fields:
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bouncesubtype
       type: STRING
       mode: NULLABLE
     - name: lang
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.lang
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: diagnosticcode
       type: STRING
       mode: NULLABLE
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: complaint
       type: BOOLEAN
       mode: NULLABLE
@@ -162,45 +255,84 @@ fields:
     - name: url
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.url
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: amplitudeevent
       type: STRING
       mode: NULLABLE
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -320,18 +452,33 @@ fields:
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pro
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_auth_events_v1/schema.yaml
@@ -21,16 +21,28 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -47,115 +59,214 @@ fields:
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lang
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.lang
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: keys
       type: BOOLEAN
       mode: NULLABLE
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: missingflowid
       type: BOOLEAN
       mode: NULLABLE
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: granttype
       type: STRING
       mode: NULLABLE
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowtype
       type: STRING
       mode: NULLABLE
     - name: flow_time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowbegintime
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowbegintime
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: entrypoint
       type: STRING
       mode: NULLABLE
@@ -165,6 +276,9 @@ fields:
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: recency
       type: STRING
       mode: NULLABLE
@@ -174,6 +288,9 @@ fields:
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: sendertype
       type: STRING
       mode: NULLABLE
@@ -210,6 +327,9 @@ fields:
     - name: flowid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uaos
       type: STRING
       mode: NULLABLE
@@ -219,18 +339,33 @@ fields:
     - name: templateversion
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.templateversion
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: domain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.domain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: utm_content
       type: STRING
       mode: NULLABLE
@@ -240,6 +375,9 @@ fields:
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: senderos
       type: STRING
       mode: NULLABLE
@@ -249,9 +387,15 @@ fields:
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: emailcode
       type: STRING
       mode: NULLABLE
@@ -279,9 +423,15 @@ fields:
     - name: body
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.body
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: productid
       type: STRING
       mode: NULLABLE
@@ -294,6 +444,9 @@ fields:
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: ipnmessage
       type: STRING
       mode: NULLABLE
@@ -303,12 +456,21 @@ fields:
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: to
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.to
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: code
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: token
       type: STRING
       mode: NULLABLE
@@ -336,6 +498,9 @@ fields:
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: verifiersetat
       type: FLOAT
       mode: NULLABLE
@@ -360,9 +525,15 @@ fields:
     - name: subscriptionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.subscriptionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: redirectto
       type: STRING
       mode: NULLABLE
@@ -375,6 +546,9 @@ fields:
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: dbpath
       type: STRING
       mode: NULLABLE
@@ -384,15 +558,24 @@ fields:
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: data
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.data
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: unblockcode
       type: STRING
       mode: NULLABLE
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remaining
       type: FLOAT
       mode: NULLABLE
@@ -402,9 +585,15 @@ fields:
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: params
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.params
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: entrypoint_variation
       type: STRING
       mode: NULLABLE
@@ -414,6 +603,9 @@ fields:
     - name: invoiceid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.invoiceid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: traceid
       type: STRING
       mode: NULLABLE
@@ -435,21 +627,36 @@ fields:
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchase
       type: STRING
       mode: NULLABLE
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bodysize
       type: FLOAT
       mode: NULLABLE
@@ -468,6 +675,9 @@ fields:
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uabrowserversion
       type: STRING
       mode: NULLABLE
@@ -498,6 +708,9 @@ fields:
     - name: param
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.param
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: rawtype
       type: STRING
       mode: NULLABLE
@@ -513,9 +726,15 @@ fields:
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: value
       type: STRING
       mode: NULLABLE
@@ -525,12 +744,18 @@ fields:
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: deviceid
       type: STRING
       mode: NULLABLE
     - name: result
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: eventid
       type: FLOAT
       mode: NULLABLE
@@ -585,6 +810,9 @@ fields:
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: product
       type: STRING
       mode: NULLABLE
@@ -633,6 +861,9 @@ fields:
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: hasid
       type: BOOLEAN
       mode: NULLABLE
@@ -648,12 +879,18 @@ fields:
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: options
       type: STRING
       mode: NULLABLE
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: scope
       type: STRING
       mode: NULLABLE
@@ -672,6 +909,9 @@ fields:
     - name: user
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: val
       type: STRING
       mode: NULLABLE
@@ -705,12 +945,21 @@ fields:
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -830,18 +1079,33 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pro
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_content_events_v1/schema.yaml
@@ -21,16 +21,28 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -47,21 +59,39 @@ fields:
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
@@ -69,78 +99,150 @@ fields:
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: violated
       type: STRING
       mode: NULLABLE
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: source
       type: STRING
       mode: NULLABLE
@@ -162,30 +264,57 @@ fields:
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: tags
       type: STRING
       mode: NULLABLE
@@ -204,6 +333,9 @@ fields:
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: exception
       type: STRING
       mode: NULLABLE
@@ -225,12 +357,18 @@ fields:
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: value
       type: STRING
       mode: NULLABLE
     - name: param
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.param
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: amplitudeevent
       type: STRING
       mode: NULLABLE
@@ -240,6 +378,9 @@ fields:
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: flow_id
     type: STRING
     mode: NULLABLE
@@ -249,6 +390,9 @@ fields:
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: country
     type: STRING
     mode: NULLABLE
@@ -261,9 +405,15 @@ fields:
   - name: useragent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.useragent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: op
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.op
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: locale
     type: STRING
     mode: NULLABLE
@@ -384,6 +534,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -503,18 +656,33 @@ fields:
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fxa________
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_delete_events_v1/schema.yaml
@@ -5,6 +5,9 @@ fields:
 - name: user_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: hmac_user_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_gcp_stderr_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_gcp_stderr_events_v1/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,52 +80,91 @@ fields:
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: traceid
       type: STRING
       mode: NULLABLE
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: keys
       type: BOOLEAN
       mode: NULLABLE
     - name: status
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: domain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.domain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: processingtimemillis
       type: FLOAT
       mode: NULLABLE
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templatename
       type: STRING
       mode: NULLABLE
@@ -114,33 +174,63 @@ fields:
     - name: flowid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowbegintime
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowbegintime
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templateversion
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.templateversion
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lang
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.lang
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bouncesubtype
       type: STRING
       mode: NULLABLE
@@ -150,6 +240,9 @@ fields:
     - name: action
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.action
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bounce
       type: BOOLEAN
       mode: NULLABLE
@@ -159,33 +252,63 @@ fields:
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bounced
       type: BOOLEAN
       mode: NULLABLE
@@ -195,30 +318,54 @@ fields:
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: granttype
       type: STRING
       mode: NULLABLE
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: command
       type: STRING
       mode: NULLABLE
@@ -252,6 +399,9 @@ fields:
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: dbpath
       type: STRING
       mode: NULLABLE
@@ -261,18 +411,33 @@ fields:
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowcompletesignal
       type: STRING
       mode: NULLABLE
@@ -348,6 +513,9 @@ fields:
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: disabledat
       type: STRING
       mode: NULLABLE
@@ -375,18 +543,33 @@ fields:
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: utm_medium
       type: STRING
       mode: NULLABLE
@@ -402,6 +585,9 @@ fields:
     - name: body
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.body
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bodysize
       type: FLOAT
       mode: NULLABLE
@@ -426,6 +612,9 @@ fields:
     - name: id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isverified
       type: BOOLEAN
       mode: NULLABLE
@@ -465,9 +654,15 @@ fields:
     - name: code
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: subscriptionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.subscriptionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: entrypoint_variation
       type: STRING
       mode: NULLABLE
@@ -477,15 +672,27 @@ fields:
     - name: to
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.to
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: params
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.params
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
@@ -495,24 +702,42 @@ fields:
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isaxioserror
       type: BOOLEAN
       mode: NULLABLE
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: data
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.data
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchase
       type: STRING
       mode: NULLABLE
@@ -537,9 +762,15 @@ fields:
     - name: param
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.param
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: postalcode
       type: STRING
       mode: NULLABLE
@@ -555,6 +786,9 @@ fields:
     - name: invoiceid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.invoiceid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isserver
       type: BOOLEAN
       mode: NULLABLE
@@ -675,9 +909,15 @@ fields:
     - name: result
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: closed
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.closed
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: promotioncode
       type: STRING
       mode: NULLABLE
@@ -696,12 +936,18 @@ fields:
     - name: userid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.userid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: provider
       type: STRING
       mode: NULLABLE
     - name: version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: packagename
       type: STRING
       mode: NULLABLE
@@ -771,9 +1017,15 @@ fields:
     - name: cause
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.cause
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: url
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.url
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: enddate
       type: STRING
       mode: NULLABLE
@@ -831,6 +1083,9 @@ fields:
     - name: bundle
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.bundle
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: sid
       type: STRING
       mode: NULLABLE
@@ -849,6 +1104,9 @@ fields:
     - name: errorcode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errorcode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: segmentscount
       type: FLOAT
       mode: NULLABLE
@@ -864,42 +1122,78 @@ fields:
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: regex
     type: STRING
     mode: NULLABLE
   - name: msg
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.msg
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: op
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.op
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: useragent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.useragent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: event
     type: STRING
     mode: NULLABLE
@@ -1683,6 +1977,9 @@ fields:
   - name: statuscode
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.statuscode
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: rtime
     type: STRING
     mode: NULLABLE
@@ -1725,9 +2022,15 @@ fields:
   - name: message
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.message
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -1847,48 +2150,90 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_redis
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_redis
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_component
     type: STRING
     mode: NULLABLE
   - name: logging_gke_io_top_level_controller_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logging_gke_io_top_level_controller_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE
@@ -2004,43 +2349,79 @@ fields:
 - name: apphub
   type: RECORD
   mode: NULLABLE
+  description: !include-field-description
+    field: apphub
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
   fields:
   - name: application
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: container
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.container
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: service
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.service
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: workload
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.workload
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_gcp_stdout_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_gcp_stdout_events_v1/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,166 +80,325 @@ fields:
   - name: log_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.log_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request_time
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request_time
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_for
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_for
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.bytes_sent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: user_agent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.user_agent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_proto
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: trace
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.trace
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_user
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_user
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_addr
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_addr
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: referrer
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.referrer
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: status
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.status
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: code
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: result
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: api
       type: FLOAT
       mode: NULLABLE
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: source
       type: STRING
       mode: NULLABLE
@@ -240,18 +420,33 @@ fields:
     - name: url
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.url
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: directory
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.directory
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: signal
       type: STRING
       mode: NULLABLE
@@ -273,6 +468,9 @@ fields:
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: header
       type: STRING
       mode: NULLABLE
@@ -285,9 +483,15 @@ fields:
     - name: user
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: search_type
       type: STRING
       mode: NULLABLE
@@ -297,6 +501,9 @@ fields:
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_agent
       type: STRING
       mode: NULLABLE
@@ -318,9 +525,15 @@ fields:
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: duration
       type: FLOAT
       mode: NULLABLE
@@ -333,24 +546,42 @@ fields:
     - name: cause
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.cause
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: success
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.success
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: sample
       type: STRING
       mode: NULLABLE
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: closed
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.closed
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _res
       type: STRING
       mode: NULLABLE
@@ -360,18 +591,27 @@ fields:
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locator
       type: STRING
       mode: NULLABLE
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: twofactorauthentication
       type: BOOLEAN
       mode: NULLABLE
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: atleast18atreg
       type: STRING
       mode: NULLABLE
@@ -384,30 +624,54 @@ fields:
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _
       type: STRING
       mode: NULLABLE
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bundle
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.bundle
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: userid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.userid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errorcode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errorcode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: jse_cause
     type: RECORD
     mode: NULLABLE
@@ -421,15 +685,24 @@ fields:
   - name: message
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.message
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: jse_info
     type: RECORD
     mode: NULLABLE
@@ -446,6 +719,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -565,48 +841,90 @@ fields:
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_redis
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_redis
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_run
     type: STRING
     mode: NULLABLE
   - name: logging_gke_io_top_level_controller_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logging_gke_io_top_level_controller_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE
@@ -722,43 +1040,79 @@ fields:
 - name: apphub
   type: RECORD
   mode: NULLABLE
+  description: !include-field-description
+    field: apphub
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
   fields:
   - name: application
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: container
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.container
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: service
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.service
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: workload
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.workload
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v1/schema.yaml
@@ -2,12 +2,18 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: type
   type: STRING
   mode: NULLABLE
 - name: user_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: index
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_log_device_command_events_v2/schema.yaml
@@ -2,12 +2,18 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: type
   type: STRING
   mode: NULLABLE
 - name: user_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: index
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_oauth_events_v1/schema.yaml
@@ -21,16 +21,28 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -47,43 +59,76 @@ fields:
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: scope
       type: STRING
       mode: NULLABLE
     - name: user
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: auth
       type: STRING
       mode: NULLABLE
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: code
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: created_at
       type: STRING
       mode: NULLABLE
@@ -96,18 +141,33 @@ fields:
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: val
       type: STRING
       mode: NULLABLE
@@ -123,69 +183,126 @@ fields:
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: profile_changed_at
       type: FLOAT
       mode: NULLABLE
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: client
       type: STRING
       mode: NULLABLE
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: params
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.params
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: warning
       type: STRING
       mode: NULLABLE
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -305,18 +422,33 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fxa_
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_stdout_events_v1/schema.yaml
@@ -21,25 +21,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -56,166 +77,322 @@ fields:
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_proto
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request_time
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request_time
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: trace
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.trace
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: status
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.status
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_for
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_for
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: user_agent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.user_agent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: referrer
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.referrer
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_addr
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_addr
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: proxy_host
     type: STRING
     mode: NULLABLE
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.bytes_sent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_user
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_user
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: directory
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.directory
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country_code
       type: STRING
       mode: NULLABLE
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: log_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.log_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: amplituderesponse
     type: RECORD
     mode: NULLABLE
@@ -241,12 +418,21 @@ fields:
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: inputcount
     type: FLOAT
     mode: NULLABLE
@@ -256,6 +442,9 @@ fields:
   - name: msg
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.msg
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: error
     type: RECORD
     mode: NULLABLE
@@ -275,6 +464,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -397,12 +589,21 @@ fields:
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_part_of
     type: STRING
     mode: NULLABLE
@@ -412,9 +613,15 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_jenkins_build_id
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_first_seen_v1/schema.yaml
@@ -2,6 +2,9 @@ fields:
 - name: user_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: first_seen_date
   type: DATE
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_daily_v1/schema.yaml
@@ -2,27 +2,48 @@ fields:
 - name: submission_date
   type: DATE
   mode: NULLABLE
+  description: !include-field-description
+    field: submission_date
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: user_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: service
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: service
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: country
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: country
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: language
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: language
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: app_version
   type: STRING
   mode: NULLABLE
 - name: os_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: os_name
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: os_version
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: os_version
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: seen_in_tier1_country
   type: BOOLEAN
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/fxa_users_services_last_seen_v1/schema.yaml
@@ -20,21 +20,36 @@ fields:
 - name: user_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: user_id
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: service
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: service
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: country
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: country
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: language
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: language
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: app_version
   type: STRING
   mode: NULLABLE
 - name: os_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    field: os_name
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: os_version
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_auth_events_v1/schema.yaml
@@ -21,16 +21,28 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -47,85 +59,157 @@ fields:
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: keys
       type: BOOLEAN
       mode: NULLABLE
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lang
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.lang
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowbegintime
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowbegintime
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowtype
       type: STRING
       mode: NULLABLE
     - name: flow_time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowcompletesignal
       type: STRING
       mode: NULLABLE
     - name: flow_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: emailcode
       type: STRING
       mode: NULLABLE
@@ -141,36 +225,66 @@ fields:
     - name: type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: missingflowid
       type: BOOLEAN
       mode: NULLABLE
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: data
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.data
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: success
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.success
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isserver
       type: BOOLEAN
       mode: NULLABLE
@@ -189,39 +303,69 @@ fields:
     - name: params
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.params
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: scope
       type: STRING
       mode: NULLABLE
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: headers
       type: STRING
       mode: NULLABLE
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: domain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.domain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templateversion
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.templateversion
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: to
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.to
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lastaccesstimeenabled
       type: BOOLEAN
       mode: NULLABLE
@@ -234,6 +378,9 @@ fields:
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: verifiersetat
       type: FLOAT
       mode: NULLABLE
@@ -288,6 +435,9 @@ fields:
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: verifyhash
       type: STRING
       mode: NULLABLE
@@ -306,6 +456,9 @@ fields:
     - name: flowid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: recency
       type: STRING
       mode: NULLABLE
@@ -324,6 +477,9 @@ fields:
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: hasid
       type: BOOLEAN
       mode: NULLABLE
@@ -333,12 +489,21 @@ fields:
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uaos
       type: STRING
       mode: NULLABLE
@@ -375,6 +540,9 @@ fields:
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bundleid
       type: STRING
       mode: NULLABLE
@@ -390,18 +558,30 @@ fields:
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: body
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.body
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: plan
       type: STRING
       mode: NULLABLE
     - name: subscriptionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.subscriptionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: numsessions
       type: FLOAT
       mode: NULLABLE
@@ -417,6 +597,9 @@ fields:
     - name: code
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: entrypoint
       type: STRING
       mode: NULLABLE
@@ -426,9 +609,15 @@ fields:
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: ipnmessage
       type: STRING
       mode: NULLABLE
@@ -441,6 +630,9 @@ fields:
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: traceid
       type: STRING
       mode: NULLABLE
@@ -453,6 +645,9 @@ fields:
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lastaccesstime
       type: FLOAT
       mode: NULLABLE
@@ -498,6 +693,9 @@ fields:
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: refresh_token
       type: STRING
       mode: NULLABLE
@@ -543,21 +741,36 @@ fields:
     - name: param
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.param
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bodysize
       type: FLOAT
       mode: NULLABLE
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: provider
       type: STRING
       mode: NULLABLE
@@ -576,6 +789,9 @@ fields:
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: customerid
       type: STRING
       mode: NULLABLE
@@ -591,9 +807,15 @@ fields:
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: value
       type: STRING
       mode: NULLABLE
@@ -603,18 +825,33 @@ fields:
     - name: invoiceid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.invoiceid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -734,18 +971,33 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_content_events_v1/schema.yaml
@@ -21,31 +21,58 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: zone
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.zone
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: instance_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.instance_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -62,100 +89,196 @@ fields:
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referrer
       type: STRING
       mode: NULLABLE
@@ -180,42 +303,75 @@ fields:
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientcapabilities
       type: STRING
       mode: NULLABLE
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: messageid
       type: STRING
       mode: NULLABLE
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: webhooks
       type: STRING
       mode: NULLABLE
@@ -228,24 +384,42 @@ fields:
     - name: directory
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.directory
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: op
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.op
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: flow_id
     type: STRING
     mode: NULLABLE
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: useragent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.useragent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: flow_time
     type: FLOAT
     mode: NULLABLE
@@ -255,6 +429,9 @@ fields:
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: event
     type: STRING
     mode: NULLABLE
@@ -288,45 +465,84 @@ fields:
   - name: trace
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.trace
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_addr
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_addr
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.bytes_sent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: log_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.log_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: user_agent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.user_agent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: status
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.status
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_for
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_for
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request_time
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request_time
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_user
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_user
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_proto
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: referrer
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.referrer
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: proxy_host
     type: STRING
     mode: NULLABLE
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -446,36 +662,63 @@ fields:
   - name: application
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.stack
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: env
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.env
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_managed_by
     type: STRING
     mode: NULLABLE
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_version
     type: STRING
     mode: NULLABLE
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_part_of
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_gcp_stderr_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_gcp_stderr_events_v1/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,24 +80,45 @@ fields:
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: traceid
       type: STRING
@@ -87,30 +129,57 @@ fields:
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: auth
       type: STRING
       mode: NULLABLE
@@ -126,93 +195,171 @@ fields:
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: params
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.params
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: missingflowid
       type: BOOLEAN
       mode: NULLABLE
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: scope
       type: STRING
       mode: NULLABLE
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lang
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.lang
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: skew
       type: FLOAT
       mode: NULLABLE
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: is_placeholder
       type: BOOLEAN
       mode: NULLABLE
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templateversion
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.templateversion
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: domain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.domain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: data
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.data
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: events
       type: FLOAT
       mode: NULLABLE
@@ -222,24 +369,39 @@ fields:
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: verifyhash
       type: STRING
       mode: NULLABLE
     - name: to
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.to
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowtype
       type: STRING
       mode: NULLABLE
     - name: flow_time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowbegintime
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowbegintime
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowcompletesignal
       type: STRING
       mode: NULLABLE
@@ -249,6 +411,9 @@ fields:
     - name: success
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.success
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lastaccesstimeenabled
       type: BOOLEAN
       mode: NULLABLE
@@ -264,21 +429,36 @@ fields:
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: registered
       type: STRING
       mode: NULLABLE
     - name: param
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.param
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: granttype
       type: STRING
       mode: NULLABLE
@@ -291,9 +471,15 @@ fields:
     - name: body
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.body
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: deviceid
       type: STRING
       mode: NULLABLE
@@ -342,6 +528,9 @@ fields:
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: verifiersetat
       type: FLOAT
       mode: NULLABLE
@@ -420,12 +609,21 @@ fields:
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: action
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.action
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: renewalinfo
       type: STRING
       mode: NULLABLE
@@ -438,6 +636,9 @@ fields:
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: entrypoint
       type: STRING
       mode: NULLABLE
@@ -465,6 +666,9 @@ fields:
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: currenttime
       type: FLOAT
       mode: NULLABLE
@@ -486,15 +690,24 @@ fields:
     - name: code
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: redirectto
       type: STRING
       mode: NULLABLE
     - name: subscriptionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.subscriptionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: plan_id
       type: STRING
       mode: NULLABLE
@@ -519,12 +732,18 @@ fields:
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: utm_content
       type: STRING
       mode: NULLABLE
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: notificationsubtype
       type: STRING
       mode: NULLABLE
@@ -540,15 +759,24 @@ fields:
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: dbpath
       type: STRING
       mode: NULLABLE
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: target
       type: STRING
       mode: NULLABLE
@@ -600,9 +828,15 @@ fields:
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: zip
       type: STRING
       mode: NULLABLE
@@ -633,15 +867,24 @@ fields:
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reminders
       type: STRING
       mode: NULLABLE
     - name: invoiceid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.invoiceid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: provider
       type: STRING
       mode: NULLABLE
@@ -693,6 +936,9 @@ fields:
     - name: closed
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.closed
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _unblockcodesdeleted
       type: FLOAT
       mode: NULLABLE
@@ -714,6 +960,9 @@ fields:
     - name: result
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: deletions
       type: FLOAT
       mode: NULLABLE
@@ -732,9 +981,15 @@ fields:
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _
       type: STRING
       mode: NULLABLE
@@ -750,6 +1005,9 @@ fields:
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: client
       type: STRING
       mode: NULLABLE
@@ -786,36 +1044,60 @@ fields:
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: ip
     type: STRING
     mode: NULLABLE
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: op
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.op
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: err
     type: STRING
     mode: NULLABLE
   - name: level
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: msg
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.msg
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: rtime
     type: STRING
     mode: NULLABLE
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: filename
     type: STRING
     mode: NULLABLE
@@ -855,6 +1137,9 @@ fields:
   - name: useragent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.useragent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: region
     type: STRING
     mode: NULLABLE
@@ -888,6 +1173,9 @@ fields:
   - name: message
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.message
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: config
     type: RECORD
     mode: NULLABLE
@@ -1216,6 +1504,9 @@ fields:
   - name: statuscode
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.statuscode
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: blockreason
     type: STRING
     mode: NULLABLE
@@ -1234,6 +1525,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -1353,30 +1647,57 @@ fields:
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_gcp_stdout_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_gcp_stdout_events_v1/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,94 +80,184 @@ fields:
   - name: referrer
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.referrer
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: trace
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.trace
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: user_agent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.user_agent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_for
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_for
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: status
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.status
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_user
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_user
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request_time
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request_time
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_addr
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_addr
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: log_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.log_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.bytes_sent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_proto
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: code
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: violated
       type: STRING
       mode: NULLABLE
@@ -168,87 +279,162 @@ fields:
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: sample
       type: STRING
       mode: NULLABLE
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: result
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: api
       type: FLOAT
       mode: NULLABLE
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: url
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.url
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: signal
       type: STRING
       mode: NULLABLE
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: directory
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.directory
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: header
       type: STRING
       mode: NULLABLE
@@ -264,24 +450,39 @@ fields:
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cause
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.cause
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: info
       type: STRING
       mode: NULLABLE
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: detail
       type: STRING
       mode: NULLABLE
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: auto_completed
       type: BOOLEAN
       mode: NULLABLE
@@ -291,12 +492,21 @@ fields:
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: closed
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.closed
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reqtime
       type: FLOAT
       mode: NULLABLE
@@ -327,6 +537,9 @@ fields:
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: document_namespace
       type: STRING
       mode: NULLABLE
@@ -336,30 +549,57 @@ fields:
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -479,27 +719,51 @@ fields:
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/nonprod_fxa_stdout_events_v1/schema.yaml
@@ -21,25 +21,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -56,145 +77,277 @@ fields:
   - name: x_forwarded_for
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_for
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: status
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.status
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request_time
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request_time
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.bytes_sent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_user
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_user
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: referrer
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.referrer
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: trace
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.trace
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_proto
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: user_agent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.user_agent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_addr
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_addr
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: proxy_host
     type: STRING
     mode: NULLABLE
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: messageid
       type: STRING
       mode: NULLABLE
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientcapabilities
       type: STRING
       mode: NULLABLE
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: context
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.context
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: directory
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.directory
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: changed
       type: STRING
       mode: NULLABLE
@@ -207,12 +360,21 @@ fields:
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country_code
       type: STRING
       mode: NULLABLE
@@ -222,24 +384,45 @@ fields:
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: log_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.log_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -365,9 +548,15 @@ fields:
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_version
     type: STRING
     mode: NULLABLE
@@ -377,15 +566,24 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_jenkins_build_id
     type: STRING
     mode: NULLABLE
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_generation
     type: STRING
     mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stderr_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stderr_events_v1/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,52 +80,91 @@ fields:
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: traceid
       type: STRING
       mode: NULLABLE
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: keys
       type: BOOLEAN
       mode: NULLABLE
     - name: status
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: domain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.domain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: template
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.template
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: processingtimemillis
       type: FLOAT
       mode: NULLABLE
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templatename
       type: STRING
       mode: NULLABLE
@@ -114,33 +174,63 @@ fields:
     - name: flowid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowbegintime
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flowbegintime
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: templateversion
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.templateversion
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flow_time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.flow_time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: lang
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.lang
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bouncesubtype
       type: STRING
       mode: NULLABLE
@@ -150,6 +240,9 @@ fields:
     - name: action
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.action
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bounce
       type: BOOLEAN
       mode: NULLABLE
@@ -159,33 +252,63 @@ fields:
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bounced
       type: BOOLEAN
       mode: NULLABLE
@@ -195,30 +318,54 @@ fields:
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: granttype
       type: STRING
       mode: NULLABLE
     - name: clientid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: command
       type: STRING
       mode: NULLABLE
@@ -252,6 +399,9 @@ fields:
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: dbpath
       type: STRING
       mode: NULLABLE
@@ -261,18 +411,33 @@ fields:
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: flowcompletesignal
       type: STRING
       mode: NULLABLE
@@ -348,6 +513,9 @@ fields:
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: disabledat
       type: STRING
       mode: NULLABLE
@@ -375,18 +543,33 @@ fields:
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: utm_medium
       type: STRING
       mode: NULLABLE
@@ -402,6 +585,9 @@ fields:
     - name: body
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.body
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bodysize
       type: FLOAT
       mode: NULLABLE
@@ -426,6 +612,9 @@ fields:
     - name: id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isverified
       type: BOOLEAN
       mode: NULLABLE
@@ -465,9 +654,15 @@ fields:
     - name: code
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: subscriptionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.subscriptionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: entrypoint_variation
       type: STRING
       mode: NULLABLE
@@ -477,15 +672,27 @@ fields:
     - name: to
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.to
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: query
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.query
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: params
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.params
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
@@ -495,24 +702,42 @@ fields:
     - name: statuscode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.statuscode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: response
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.response
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isaxioserror
       type: BOOLEAN
       mode: NULLABLE
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: data
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.data
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: purchase
       type: STRING
       mode: NULLABLE
@@ -537,9 +762,15 @@ fields:
     - name: param
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.param
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: countrycode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.countrycode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: postalcode
       type: STRING
       mode: NULLABLE
@@ -555,6 +786,9 @@ fields:
     - name: invoiceid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.invoiceid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: isserver
       type: BOOLEAN
       mode: NULLABLE
@@ -675,9 +909,15 @@ fields:
     - name: result
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: closed
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.closed
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: promotioncode
       type: STRING
       mode: NULLABLE
@@ -696,12 +936,18 @@ fields:
     - name: userid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.userid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: provider
       type: STRING
       mode: NULLABLE
     - name: version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: packagename
       type: STRING
       mode: NULLABLE
@@ -771,9 +1017,15 @@ fields:
     - name: cause
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.cause
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: url
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.url
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: enddate
       type: STRING
       mode: NULLABLE
@@ -831,6 +1083,9 @@ fields:
     - name: bundle
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.bundle
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: sid
       type: STRING
       mode: NULLABLE
@@ -849,6 +1104,9 @@ fields:
     - name: errorcode
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errorcode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: segmentscount
       type: FLOAT
       mode: NULLABLE
@@ -864,42 +1122,78 @@ fields:
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: regex
     type: STRING
     mode: NULLABLE
   - name: msg
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.msg
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: op
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.op
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: hostname
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.hostname
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: v
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.v
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: useragent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.useragent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: event
     type: STRING
     mode: NULLABLE
@@ -1683,6 +1977,9 @@ fields:
   - name: statuscode
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.statuscode
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: rtime
     type: STRING
     mode: NULLABLE
@@ -1725,9 +2022,15 @@ fields:
   - name: message
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.message
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -1847,48 +2150,90 @@ fields:
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_redis
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_redis
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_component
     type: STRING
     mode: NULLABLE
   - name: logging_gke_io_top_level_controller_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logging_gke_io_top_level_controller_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE
@@ -2004,43 +2349,79 @@ fields:
 - name: apphub
   type: RECORD
   mode: NULLABLE
+  description: !include-field-description
+    field: apphub
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
   fields:
   - name: application
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: container
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.container
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: service
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.service
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: workload
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.workload
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stdout_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_accounts_derived/recent_fxa_gcp_stdout_events_v1/schema.yaml
@@ -24,25 +24,46 @@ fields:
   - name: labels
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: resource.labels
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: project_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.project_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: pod_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.pod_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: container_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.container_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: cluster_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.cluster_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: namespace_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.namespace_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: resource.labels.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: textPayload
   type: STRING
   mode: NULLABLE
@@ -59,166 +80,325 @@ fields:
   - name: log_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.log_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: request_time
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.request_time
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_for
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_for
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: bytes_sent
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.bytes_sent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: user_agent
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.user_agent
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: x_forwarded_proto
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.x_forwarded_proto
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: trace
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.trace
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_user
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_user
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: remote_addr
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.remote_addr
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: referrer
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.referrer
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: status
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.status
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logger
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.logger
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: pid
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.pid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: timestamp
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.timestamp
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: fields
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.fields
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: remoteaddresschain
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.remoteaddresschain
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: t
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.t
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: method
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.method
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: status
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.status
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: useragent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.useragent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: contentlength
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.contentlength
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: clientaddress
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.clientaddress
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: path
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.path
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errno
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errno
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: code
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.code
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: agent
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.agent
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: client_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.client_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: uid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.uid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: referer
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.referer
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: message
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.message
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: time
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.time
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_type
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_type
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: region
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.region
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: country
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.country
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: session_id
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.session_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: language
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.language
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: app_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.app_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: event_properties
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.event_properties
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: op
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.op
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: os_name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: err
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.err
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: joierrors
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.joierrors
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: stack
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.stack
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: reason
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.reason
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: result
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.result
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: api
       type: FLOAT
       mode: NULLABLE
     - name: os_version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.os_version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user_id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: msg
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.msg
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: error
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.error
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: source
       type: STRING
       mode: NULLABLE
@@ -240,18 +420,33 @@ fields:
     - name: url
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.url
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: version
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.version
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: directory
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.directory
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: port
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.port
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: poolstats
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.poolstats
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: signal
       type: STRING
       mode: NULLABLE
@@ -273,6 +468,9 @@ fields:
     - name: host
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.host
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: header
       type: STRING
       mode: NULLABLE
@@ -285,9 +483,15 @@ fields:
     - name: user
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.user
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: email
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.email
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: search_type
       type: STRING
       mode: NULLABLE
@@ -297,6 +501,9 @@ fields:
     - name: payload
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.payload
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: user_agent
       type: STRING
       mode: NULLABLE
@@ -318,9 +525,15 @@ fields:
     - name: originaltransactionid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: config
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.config
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: duration
       type: FLOAT
       mode: NULLABLE
@@ -333,24 +546,42 @@ fields:
     - name: cause
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.cause
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: success
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.success
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: device_model
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.device_model
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: sample
       type: STRING
       mode: NULLABLE
     - name: request
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.request
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: name
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.name
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: closed
       type: BOOLEAN
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.closed
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _res
       type: STRING
       mode: NULLABLE
@@ -360,18 +591,27 @@ fields:
     - name: service
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.service
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: locator
       type: STRING
       mode: NULLABLE
     - name: locale
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.locale
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: twofactorauthentication
       type: BOOLEAN
       mode: NULLABLE
     - name: profilechangedat
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.profilechangedat
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: atleast18atreg
       type: STRING
       mode: NULLABLE
@@ -384,30 +624,54 @@ fields:
     - name: purchasetoken
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.purchasetoken
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: _
       type: STRING
       mode: NULLABLE
     - name: originaltransactionids
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.originaltransactionids
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: bundle
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.bundle
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: userid
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.userid
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: errorcode
       type: FLOAT
       mode: NULLABLE
+      description: !include-field-description
+        field: jsonPayload.fields.errorcode
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: envversion
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.envversion
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: severity
     type: FLOAT
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.severity
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: jse_cause
     type: RECORD
     mode: NULLABLE
@@ -421,15 +685,24 @@ fields:
   - name: message
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.message
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: level
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.level
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: stack
     type: STRING
     mode: NULLABLE
   - name: name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: jsonPayload.name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: jse_info
     type: RECORD
     mode: NULLABLE
@@ -446,6 +719,9 @@ fields:
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
+  description: !include-field-description
+    field: timestamp
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: receiveTimestamp
   type: TIMESTAMP
   mode: NULLABLE
@@ -565,48 +841,90 @@ fields:
   - name: k8s_pod_app_kubernetes_io_component
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_component
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_deployment
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_deployment
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: compute_googleapis_com_resource_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.compute_googleapis_com_resource_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_env_code
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_env_code
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_pod_template_hash
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_pod_template_hash
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_redis
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_redis
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_controller_uid
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_controller_uid
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_batch_kubernetes_io_job_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_batch_kubernetes_io_job_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_run
     type: STRING
     mode: NULLABLE
   - name: logging_gke_io_top_level_controller_type
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_type
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: logging_gke_io_top_level_controller_name
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.logging_gke_io_top_level_controller_name
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: k8s_pod_app_kubernetes_io_instance
     type: STRING
     mode: NULLABLE
+    description: !include-field-description
+      field: labels.k8s_pod_app_kubernetes_io_instance
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
 - name: operation
   type: RECORD
   mode: NULLABLE
@@ -722,43 +1040,79 @@ fields:
 - name: apphub
   type: RECORD
   mode: NULLABLE
+  description: !include-field-description
+    field: apphub
+    file: bigquery_etl/schema/firefox_accounts_derived.yaml
   fields:
   - name: application
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.application
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: container
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.container
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: location
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.location
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.application.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: service
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.service
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.service.criticalityType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
   - name: workload
     type: RECORD
     mode: NULLABLE
+    description: !include-field-description
+      field: apphub.workload
+      file: bigquery_etl/schema/firefox_accounts_derived.yaml
     fields:
     - name: id
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.id
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: environmentType
       type: STRING
       mode: NULLABLE
+      description: !include-field-description
+        field: apphub.workload.environmentType
+        file: bigquery_etl/schema/firefox_accounts_derived.yaml
     - name: criticalityType
       type: STRING
       mode: NULLABLE


### PR DESCRIPTION
Cascade dataset.yaml definitions updated in [PR-9630](https://github.com/mozilla/bigquery-etl/pull/9630) to relevant tables. Minor fixes to remove null callouts for null descriptions in the dataset.yaml file. 

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-11281

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
