### PR TITLE
feat(bugzilla_metrics.users): Add backstage to dataViewers

### DIFF
--- a/sql/moz-fx-data-shared-prod/bugzilla_metrics/users/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/bugzilla_metrics/users/metadata.yaml
@@ -3,3 +3,4 @@ workgroup_access:
   - role: roles/bigquery.dataViewer
     members:
       - workgroup:platform/access-events
+      - workgroup:platform/backstage-gke


### PR DESCRIPTION
## Description
Follow up to the private-bqetl pr. Adds backstage-gke to the upstream view 

## Related Tickets & Documents
* MZCLD-3366

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
