### PR TITLE
DENG-11281: Expand firefox_accounts_derived.yaml with cross-table field descriptions

### DIFF
--- a/bigquery_etl/schema/firefox_accounts_derived.yaml
+++ b/bigquery_etl/schema/firefox_accounts_derived.yaml
@@ -139,6 +139,112 @@ fields:
     type: STRING
     description: X-Forwarded-Proto header value indicating the originating protocol
       (e.g., 'https').
+  - name: locale
+    type: STRING
+    description: BCP 47 locale string from the FxA content server log payload
+      (e.g., 'en-US', 'fr-FR').
+  - name: event
+    type: STRING
+    description: FxA event name from the top-level content server log payload.
+  - name: flow_id
+    type: STRING
+    description: Flow identifier for the authentication session. See top-level flow_id.
+  - name: flow_time
+    type: FLOAT
+    description: Elapsed time in milliseconds since the start of the authentication flow.
+  - name: utm_source
+    type: STRING
+    description: UTM source parameter captured from the originating URL
+      (e.g., 'google', 'email').
+  - name: utm_campaign
+    type: STRING
+    description: UTM campaign parameter captured from the originating URL.
+  - name: utm_content
+    type: STRING
+    description: UTM content parameter captured from the originating URL.
+  - name: utm_medium
+    type: STRING
+    description: UTM medium parameter captured from the originating URL
+      (e.g., 'email', 'cpc').
+  - name: entrypoint
+    type: STRING
+    description: Entry point identifier for the authentication or account creation flow
+      (e.g., 'fxa-email-update', 'menupanel').
+  - name: context
+    type: STRING
+    description: OAuth or flow context string (e.g., 'fx_desktop_v3', 'oauth').
+  - name: region
+    type: STRING
+    description: Geographic region associated with the event (e.g., 'California').
+  - name: country
+    type: STRING
+    description: Country associated with the event, as a full country name
+      (e.g., 'United States', 'Germany').
+  - name: service
+    type: STRING
+    description: The Mozilla service or relying party associated with the event
+      (e.g., 'sync', 'pocket-web').
+  - name: err
+    type: STRING
+    description: Error details from the top-level log payload.
+  - name: error
+    type: STRING
+    description: Error message from the top-level log payload.
+  - name: port
+    type: FLOAT
+    description: Network port from the top-level log payload.
+  - name: host
+    type: STRING
+    description: Hostname from the top-level log payload.
+  - name: ip
+    type: STRING
+    description: Client IP address from the customs server log payload.
+  - name: rtime
+    type: FLOAT
+    description: Request processing time from the customs server log payload, in seconds.
+  - name: action
+    type: STRING
+    description: Action type from the customs server log payload.
+  - name: email
+    type: STRING
+    description: Hashed or redacted email identifier. Not a raw email address.
+  - name: unblock
+    type: BOOLEAN
+    description: Whether the request was unblocked by the customs server.
+  - name: suspect
+    type: BOOLEAN
+    description: Whether the IP or account was flagged as suspect by the customs server.
+  - name: block
+    type: BOOLEAN
+    description: Whether the request was blocked by the customs server.
+  - name: blockreason
+    type: STRING
+    description: Reason the request was blocked by the customs server.
+  - name: regex
+    type: STRING
+    description: Regular expression pattern used in IP blocklist matching.
+  - name: loadedin
+    type: FLOAT
+    description: Time in milliseconds for the page or resource to load.
+  - name: filename
+    type: STRING
+    description: Filename associated with the log event (e.g., from a file upload or
+      error).
+  - name: filesize
+    type: FLOAT
+    description: File size in bytes associated with the log event.
+  - name: errno
+    type: FLOAT
+    description: FxA error number from the customs server payload.
+  - name: foundin
+    type: STRING
+    description: IP blocklist name in which the client address was found.
+  - name: listhits
+    type: STRING
+    description: JSON-encoded list of IP blocklist names that matched the request.
+  - name: listhitcount
+    type: FLOAT
+    description: Number of IP blocklists that matched the request.
   - name: fields
     type: RECORD
     description: Application-level structured event data from the FxA service.
@@ -424,6 +530,320 @@ fields:
     - name: version
       type: STRING
       description: Version string from the event payload.
+    - name: assertion
+      type: STRING
+      description: Assertion string used in device pairing or browser verification flows.
+    - name: line
+      type: FLOAT
+      description: Source code line number associated with the log event.
+    - name: referrer
+      type: STRING
+      description: HTTP referrer URL at the time of the event.
+    - name: violated
+      type: STRING
+      description: CSP directive that was violated, from a content security policy report.
+    - name: source
+      type: STRING
+      description: Source identifier for the event (e.g., originating service or component).
+    - name: blocked
+      type: BOOLEAN
+      description: Whether the action was blocked (e.g., by rate limiting or IP blocklist).
+    - name: sample
+      type: FLOAT
+      description: Sampling rate or sample value associated with the log entry.
+    - name: column
+      type: FLOAT
+      description: Source code column number associated with the log event.
+    - name: tokenverificationid
+      type: STRING
+      description: Identifier for a token verification attempt.
+    - name: targettype
+      type: STRING
+      description: Type of the target resource for the event (e.g., 'account', 'session').
+    - name: dbpath
+      type: STRING
+      description: Database path or connection string identifier.
+    - name: utm_term
+      type: STRING
+      description: UTM term parameter from the originating URL, used for tracking paid
+        keyword campaigns.
+    - name: utm_source
+      type: STRING
+      description: UTM source parameter from the originating URL (e.g., 'google', 'email').
+    - name: remaining
+      type: FLOAT
+      description: Remaining allowed attempts before rate limiting applies.
+    - name: verifiedat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account or email was verified.
+    - name: product_id
+      type: STRING
+      description: Mozilla subscription product identifier.
+    - name: planid
+      type: STRING
+      description: Subscription plan identifier.
+    - name: ecosystemanonid
+      type: STRING
+      description: Anonymized ecosystem user identifier for cross-product analytics,
+        derived without exposing the raw user ID.
+    - name: traceid
+      type: STRING
+      description: Distributed tracing identifier for correlating events across services.
+    - name: entrypoint_experiment
+      type: STRING
+      description: A/B experiment identifier associated with the entrypoint that started
+        the authentication flow.
+    - name: is_placeholder
+      type: BOOLEAN
+      description: Whether this record is a placeholder entry.
+    - name: index
+      type: FLOAT
+      description: Index position within a list or sequence in the event payload.
+    - name: ka
+      type: STRING
+      description: Key agreement value used in FxA account key derivation.
+    - name: isboom
+      type: BOOLEAN
+      description: Whether the error is a Boom HTTP error object.
+    - name: customeruid
+      type: STRING
+      description: Unique identifier for the customer in the subscription billing system.
+    - name: flowtype
+      type: STRING
+      description: Type classification of the authentication flow (e.g., 'login',
+        'registration', 'reset-password').
+    - name: keyschangedat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account encryption keys were last
+        changed.
+    - name: templatename
+      type: STRING
+      description: Name of the email or notification template used for the event.
+    - name: disabledat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account was disabled.
+    - name: _original
+      type: STRING
+      description: Original raw value before transformation or normalization.
+    - name: enabled
+      type: BOOLEAN
+      description: Whether the feature or configuration option is enabled.
+    - name: target
+      type: STRING
+      description: Target resource or endpoint associated with the event.
+    - name: wrapwrapkb
+      type: STRING
+      description: Double-wrapped kB key value used in FxA sync key exchange.
+    - name: automatic_tax
+      type: BOOLEAN
+      description: Whether tax was calculated automatically for a subscription event.
+    - name: entrypoint_variation
+      type: STRING
+      description: A/B variation identifier for the entrypoint experiment.
+    - name: lockedat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account was locked.
+    - name: plan_id
+      type: STRING
+      description: Subscription plan identifier. See also planid.
+    - name: primaryemail
+      type: STRING
+      description: Hashed primary email address for the FxA account. Not a raw email
+        address.
+    - name: _intboolfields
+      type: STRING
+      description: Comma-separated list of field names cast from integer to boolean during
+        log normalization.
+    - name: _uuidfields
+      type: STRING
+      description: Comma-separated list of field names containing UUID strings, used for
+        schema normalization metadata.
+    - name: numsessions
+      type: FLOAT
+      description: Number of active sessions for the account.
+    - name: createdat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account or resource was created.
+    - name: granttype
+      type: STRING
+      description: OAuth grant type (e.g., 'authorization_code', 'refresh_token').
+    - name: productid
+      type: STRING
+      description: Mozilla subscription product identifier. See also product_id.
+    - name: authsalt
+      type: STRING
+      description: Authentication salt value used in account credential derivation.
+    - name: emailverified
+      type: BOOLEAN
+      description: Whether the account's primary email address has been verified.
+    - name: uabrowserversion
+      type: STRING
+      description: Browser version string parsed from the user agent.
+    - name: isserver
+      type: BOOLEAN
+      description: Whether the event originated from a server-side operation rather than
+        a client request.
+    - name: accountrecreated
+      type: BOOLEAN
+      description: Whether the account was recreated (deleted and re-registered with the
+        same email).
+    - name: isprimary
+      type: BOOLEAN
+      description: Whether the associated email address is the account's primary email.
+    - name: sendertype
+      type: STRING
+      description: Type of email sender used for the notification.
+    - name: targetos
+      type: STRING
+      description: Target operating system for the event (e.g., 'Windows', 'iOS').
+    - name: entrypoint
+      type: STRING
+      description: Entry point identifier for the authentication or account creation flow
+        (e.g., 'fxa-email-update', 'menupanel').
+    - name: deviceid
+      type: STRING
+      description: FxA device identifier. See also device_id for the hashed version.
+    - name: postalcode
+      type: STRING
+      description: Postal code from the subscription billing address.
+    - name: details
+      type: STRING
+      description: Additional detail string associated with the event.
+    - name: emails
+      type: STRING
+      description: JSON-encoded list of email objects associated with the account.
+    - name: flowcompletesignal
+      type: STRING
+      description: Event name that signalled flow completion.
+    - name: verifiersetat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account verifier (password) was last
+        set.
+    - name: uaos
+      type: STRING
+      description: Operating system name parsed from the user agent string.
+    - name: headers
+      type: STRING
+      description: JSON-encoded HTTP request headers associated with the event.
+    - name: metricsoptoutat
+      type: FLOAT
+      description: Unix epoch timestamp of when the user opted out of metrics collection.
+    - name: utm_medium
+      type: STRING
+      description: UTM medium parameter from the originating URL (e.g., 'email', 'cpc').
+    - name: events
+      type: STRING
+      description: JSON-encoded list of sub-events or event sequence associated with the
+        log entry.
+    - name: priceid
+      type: STRING
+      description: Stripe price identifier for a subscription plan.
+    - name: purchase
+      type: STRING
+      description: Purchase identifier or metadata for a subscription purchase.
+    - name: uaosversion
+      type: STRING
+      description: Operating system version string parsed from the user agent.
+    - name: output
+      type: STRING
+      description: Output value or result string from the operation.
+    - name: utm_campaign
+      type: STRING
+      description: UTM campaign parameter from the originating URL.
+    - name: uabrowser
+      type: STRING
+      description: Browser name parsed from the user agent string.
+    - name: normalizedemail
+      type: STRING
+      description: Normalized form of the account email address (lowercased, Gmail dots
+        removed).
+    - name: ipaddress
+      type: STRING
+      description: Client IP address associated with the event.
+    - name: utm_content
+      type: STRING
+      description: UTM content parameter from the originating URL, used to differentiate
+        ads or links.
+    - name: verifierversion
+      type: FLOAT
+      description: Version of the account verifier (password hashing algorithm) in use.
+    - name: sender
+      type: STRING
+      description: Sender identifier for email or notification events.
+    - name: missingflowid
+      type: BOOLEAN
+      description: Whether the event was missing a flow_id at logging time.
+    - name: keys
+      type: STRING
+      description: JSON-encoded account key bundle or key metadata.
+    - name: token
+      type: STRING
+      description: Authentication or session token associated with the event.
+    - name: ipnmessage
+      type: STRING
+      description: IPN (Instant Payment Notification) message payload for subscription
+        billing events.
+    - name: syscall
+      type: STRING
+      description: System call name associated with an OS-level error event.
+    - name: emailcode
+      type: STRING
+      description: Verification code sent to the user's email address.
+    - name: recency
+      type: STRING
+      description: Recency classification of the user session (e.g., 'new', 'active',
+        'inactive').
+    - name: command
+      type: STRING
+      description: Device command name dispatched or received (e.g., 'sendTab').
+    - name: unblockcode
+      type: STRING
+      description: One-time code sent to the user to unblock their account after rate
+        limiting.
+    - name: location
+      type: STRING
+      description: JSON-encoded location object containing city, country, and region for
+        the request.
+    - name: newsletters
+      type: STRING
+      description: JSON-encoded list of newsletter subscription identifiers the user opted
+        into.
+    - name: bodysize
+      type: FLOAT
+      description: Size of the HTTP request body in bytes.
+    - name: redirectto
+      type: STRING
+      description: URL the user was redirected to after the authentication flow.
+    - name: senderos
+      type: STRING
+      description: Operating system of the sender in a device command event.
+    - name: zip
+      type: STRING
+      description: Postal ZIP code from the subscription billing address.
+    - name: isverified
+      type: BOOLEAN
+      description: Whether the account has been verified.
+    - name: raw
+      type: STRING
+      description: Raw log line or payload before parsing.
+    - name: rawtype
+      type: STRING
+      description: Type classification of the raw log payload.
+    - name: processingtimemillis
+      type: FLOAT
+      description: Time in milliseconds taken to process the event.
+    - name: currenttime
+      type: FLOAT
+      description: Current server time as a Unix epoch milliseconds float.
+    - name: hostname
+      type: STRING
+      description: Hostname of the server that processed the event.
+    - name: requestid
+      type: STRING
+      description: Unique identifier for the HTTP request.
+    - name: plan
+      type: STRING
+      description: Subscription plan name or identifier associated with the event.
 
 - name: labels
   type: RECORD
@@ -836,3 +1256,76 @@ fields:
   type: STRING
   description: Browser or client version parsed from the user agent string (e.g., '120',
     '121').
+
+- name: event
+  type: STRING
+  description: FxA event name, as aliased from the log payload to a top-level column
+    (e.g., 'account.login', 'account.created').
+
+- name: device_id
+  type: STRING
+  description: SHA-256 hashed FxA device identifier, hex-encoded.
+
+- name: entrypoint
+  type: STRING
+  description: Entry point identifier for the authentication or account creation flow
+    (e.g., 'fxa-email-update', 'menupanel').
+
+- name: useragent
+  type: STRING
+  description: Raw user agent string from the request.
+
+- name: utm_source
+  type: STRING
+  description: UTM source parameter from the originating marketing URL
+    (e.g., 'google', 'email').
+
+- name: utm_campaign
+  type: STRING
+  description: UTM campaign parameter from the originating marketing URL.
+
+- name: utm_content
+  type: STRING
+  description: UTM content parameter from the originating marketing URL, used to
+    differentiate ads or links.
+
+- name: utm_medium
+  type: STRING
+  description: UTM medium parameter from the originating marketing URL
+    (e.g., 'email', 'cpc').
+
+- name: utm_term
+  type: STRING
+  description: UTM term parameter from the originating marketing URL, used for tracking
+    paid keyword campaigns.
+
+- name: flow_time
+  type: FLOAT
+  description: Elapsed time in milliseconds since the start of the authentication flow.
+
+- name: locale
+  type: STRING
+  description: BCP 47 locale string for the user's locale at the time of the event
+    (e.g., 'en-US', 'fr-FR').
+
+- name: region
+  type: STRING
+  description: Geographic region associated with the event (e.g., 'California').
+
+- name: fxa_server
+  type: STRING
+  description: FxA server component that generated the log entry, derived from the logger
+    name (e.g., 'auth', 'content', 'payments').
+
+- name: days_since_seen
+  type: INTEGER
+  description: Number of days since the user was last active, as of the submission date.
+
+- name: days_since_seen_in_tier1_country
+  type: INTEGER
+  description: Number of days since the user was last active from a tier-1 country, as
+    of the submission date.
+
+- name: date
+  type: DATE
+  description: Date partition field used in some log-derived tables.

--- a/bigquery_etl/schema/firefox_accounts_derived.yaml
+++ b/bigquery_etl/schema/firefox_accounts_derived.yaml
@@ -270,7 +270,9 @@ fields:
       description: Error message or details associated with the event.
     - name: event
       type: STRING
-      description: Amplitude event name.
+      description: Event name from the FxA service payload. In Amplitude-connected tables
+        this is an Amplitude event name; in admin and log tables it is a service-level
+        action name (e.g., 'account.login', 'account-search', 'disable-login').
     - name: event_properties
       type: STRING
       description: Structured event properties for the amplitude event, as a JSON string.
@@ -1225,8 +1227,9 @@ fields:
 
 - name: service
   type: STRING
-  description: The Mozilla service or OAuth relying party associated with the event
-    (e.g., 'sync', 'pocket-web', 'fenix', 'amo-web').
+  description: The Mozilla service or OAuth relying party associated with the event.
+    May be a human-readable name (e.g., 'sync', 'pocket-web', 'content-server') or a
+    raw OAuth client ID hex string (e.g., '5882386c6d801776').
 
 - name: country
   type: STRING


### PR DESCRIPTION
## Summary

Expands the `firefox_accounts_derived` dataset-level YAML with 493 lines of new field descriptions, covering three groups:

- **89 `jsonPayload.fields.*` entries** — business-domain fields that appear across 5–6 tables: `entrypoint`, `deviceid`, `utm_*`, `granttype`, `ecosystemanonid`, `emailverified`, flow timestamps, subscription fields (`planid`, `product_id`, `priceid`), and more
- **34 `jsonPayload.*` singleton entries** — top-level log payload fields previously missing descriptions: `locale`, `event`, `flow_id`, `flow_time`, `utm_*`, `context`, `region`, `country`, `service`, customs-server fields (`block`, `suspect`, `unblock`, `listhits`, etc.)
- **16 top-level flat field entries** — needed for the follow-on PR that creates `schema.yaml` files for `fxa_log_auth_events_v1`, `fxa_log_content_events_v1`, and `exact_mau28_v1`: `event`, `device_id`, `entrypoint`, `useragent`, `utm_*`, `flow_time`, `locale`, `region`, `fxa_server`, `days_since_seen`, `days_since_seen_in_tier1_country`, `date`

All 380 entries in the dataset YAML now have descriptions (100% coverage on the source file). YAML validated via `yamllint`.

## Why this is structured as a standalone PR

The follow-on PR (cascade + new `schema.yaml` files) uses `!include-field-description` tags referencing this file. Getting these descriptions reviewed independently means the cascade PR is a straightforward mechanical application with no description content to re-review.

## Test plan

- [ ] `yamllint` passes (confirmed via pre-commit hook)
- [ ] Spot-check a sample of the new entries against FxA service logs / FxA docs to confirm accuracy
- [ ] Verify the follow-on cascade PR picks up the new paths correctly