### PR TITLE
DENG-11281: expand firefox_accounts_derived.yaml

### DIFF
--- a/bigquery_etl/schema/firefox_accounts_derived.yaml
+++ b/bigquery_etl/schema/firefox_accounts_derived.yaml
@@ -569,8 +569,9 @@ fields:
       description: Database path or connection string identifier.
     - name: utm_term
       type: STRING
-      description: UTM term parameter from the originating URL, used for tracking paid
-        keyword campaigns.
+      description: In FxA, repurposed from the standard paid-search UTM term to track
+        A/B test cohort assignments (e.g., 'my-experiment-var-a'). Not a paid search
+        keyword.
     - name: utm_source
       type: STRING
       description: UTM source parameter from the originating URL.

--- a/bigquery_etl/schema/firefox_accounts_derived.yaml
+++ b/bigquery_etl/schema/firefox_accounts_derived.yaml
@@ -63,7 +63,8 @@ fields:
   - name: logger
     type: STRING
     description: Name of the logger or component that emitted the log entry
-      (e.g., 'fxa-auth-server', 'fxa-content-server').
+      (e.g., 'fxa-auth-server', 'fxa-content-server', 'fxa-oauth-server'). Used
+      to derive the top-level `fxa_server` field.
   - name: severity
     type: FLOAT
     description: Application-level numeric log severity from the FxA service payload,
@@ -138,7 +139,117 @@ fields:
   - name: x_forwarded_proto
     type: STRING
     description: X-Forwarded-Proto header value indicating the originating protocol
-      (e.g., 'https').
+      ('http' or 'https').
+  - name: locale
+    type: STRING
+    description: BCP 47 locale string (e.g., 'en-US', 'fr', 'de') from the FxA content
+      server log payload.
+  - name: event
+    type: STRING
+    description: FxA content server event name (e.g., 'flow.signin.view',
+      'flow.signin.submit'). Excludes Amplitude-captured event types.
+  - name: flow_id
+    type: STRING
+    description: UUID flow identifier from the FxA content server log payload, linking all
+      events in a single authentication session.
+  - name: flow_time
+    type: FLOAT
+    description: Milliseconds elapsed since the authentication flow began, as reported by
+      the FxA content server. Pair with `flow_id` to measure funnel completion latency.
+  - name: utm_source
+    type: STRING
+    description: UTM source parameter identifying the traffic origin (e.g., 'google',
+      'email'). Present when the user arrived at FxA via a tracked marketing URL.
+  - name: utm_campaign
+    type: STRING
+    description: UTM campaign parameter identifying the marketing campaign that drove the
+      user to FxA.
+  - name: utm_content
+    type: STRING
+    description: UTM content parameter used to distinguish links within the same campaign
+      (for A/B testing creative).
+  - name: utm_medium
+    type: STRING
+    description: UTM medium parameter identifying the marketing channel (e.g., 'cpc',
+      'email', 'social').
+  - name: entrypoint
+    type: STRING
+    description: FxA entry point where the user started the flow, set by Firefox UI
+      callsites (e.g., 'menupanel', 'preferences', 'synced-tabs'). Not a fixed enum.
+  - name: context
+    type: STRING
+    description: OAuth context string identifying the FxA flow type (e.g., 'oauth',
+      'fx_desktop_v3'). Set when the flow originates from a relying party OAuth integration.
+  - name: region
+    type: STRING
+    description: Geographic region associated with the event.
+  - name: country
+    type: STRING
+    description: Country associated with the event, as a full country name.
+  - name: service
+    type: STRING
+    description: The Mozilla service or relying party associated with the event.
+  - name: err
+    type: STRING
+    description: Error details from the top-level log payload.
+  - name: error
+    type: STRING
+    description: Error message from the top-level log payload.
+  - name: port
+    type: FLOAT
+    description: Network port from the top-level log payload.
+  - name: host
+    type: STRING
+    description: Hostname from the top-level log payload.
+  - name: ip
+    type: STRING
+    description: Client IP address from the customs server log payload.
+  - name: rtime
+    type: FLOAT
+    description: Request processing time from the customs server log payload, in seconds.
+  - name: action
+    type: STRING
+    description: Action type from the customs server log payload.
+  - name: email
+    type: STRING
+    description: Hashed or redacted email identifier. Not a raw email address.
+  - name: unblock
+    type: BOOLEAN
+    description: Whether the request was unblocked by the customs server.
+  - name: suspect
+    type: BOOLEAN
+    description: Whether the IP or account was flagged as suspect by the customs server.
+  - name: block
+    type: BOOLEAN
+    description: Whether the request was blocked by the customs server.
+  - name: blockreason
+    type: STRING
+    description: Reason the request was blocked by the customs server.
+  - name: regex
+    type: STRING
+    description: Regular expression pattern used in user-agent blocklist matching
+      (e.g., matching browser or device strings to identify blocked clients).
+  - name: loadedin
+    type: FLOAT
+    description: Time in milliseconds for the page or resource to load.
+  - name: filename
+    type: STRING
+    description: Name of an IP blocklist data file associated with the log event.
+  - name: filesize
+    type: FLOAT
+    description: File size in bytes associated with the log event.
+  - name: errno
+    type: FLOAT
+    description: FxA error number from the customs server payload.
+  - name: foundin
+    type: STRING
+    description: IP blocklist name in which the client address was found.
+  - name: listhits
+    type: STRING
+    description: JSON-encoded list of IP blocklist names that matched the request.
+  - name: listhitcount
+    type: FLOAT
+    description: Number of IP blocklists that matched the request.
   - name: fields
     type: RECORD
     description: Application-level structured event data from the FxA service.
@@ -158,20 +269,22 @@ fields:
     - name: app_version
       type: STRING
       description: Firefox Accounts application version at the time of the event
-        (e.g., '152.1', '195.0').
+        (e.g., '333.6').
     - name: error
       type: STRING
       description: Error message or details associated with the event.
     - name: event
       type: STRING
-      description: Amplitude event name.
+      description: Event name from the FxA service payload. In Amplitude-connected tables
+        this is an Amplitude event name; in admin and log tables it is a service-level
+        action name.
     - name: event_properties
       type: STRING
       description: Structured event properties for the amplitude event, as a JSON string.
     - name: event_type
       type: STRING
       description: Event type string identifying the category of event
-        (e.g., 'fxa_email - bounced', 'fxa_login - complete').
+        (e.g., 'fxa_login - complete', 'fxa_email - sent').
     - name: op
       type: STRING
       description: Operation or action type associated with the event.
@@ -193,10 +306,10 @@ fields:
       description: Log message from the event payload.
     - name: method
       type: STRING
-      description: HTTP method associated with the request (e.g., 'GET', 'POST').
+      description: HTTP method associated with the request.
     - name: path
       type: STRING
-      description: URL path of the request (e.g., '/v1/account/login').
+      description: URL path of the request.
     - name: remoteaddresschain
       type: STRING
       description: Forwarding chain of client IP addresses from X-Forwarded-For headers.
@@ -212,7 +325,7 @@ fields:
       description: Elapsed time in milliseconds for the operation.
     - name: device_model
       type: STRING
-      description: Device model associated with the event (e.g., 'iPhone14,3', 'Pixel 6').
+      description: Device model associated with the event (e.g., 'iPhone', 'iPad').
     - name: os_name
       type: STRING
       description: Operating system name from the event payload (e.g., 'Windows', 'iOS',
@@ -257,8 +370,7 @@ fields:
         error code).
     - name: errno
       type: FLOAT
-      description: FxA error number. See FxA errno documentation for values
-        (e.g., 102 for unknown account, 110 for invalid auth token).
+      description: FxA error number. See FxA errno documentation for values.
     - name: host
       type: STRING
       description: Hostname of the server handling the request.
@@ -283,17 +395,16 @@ fields:
       description: URL query parameters associated with the request.
     - name: template
       type: STRING
-      description: Email or notification template identifier
-        (e.g., 'verifyEmail', 'newDeviceLogin').
+      description: Email or notification template identifier.
     - name: id
       type: STRING
       description: Unique identifier for the event record.
     - name: locale
       type: STRING
-      description: BCP 47 locale string (e.g., 'en-US', 'fr-FR').
+      description: BCP 47 locale string.
     - name: reason
       type: STRING
-      description: Reason associated with the event (e.g., 'disconnect', 'unverified').
+      description: Reason associated with the event.
     - name: request
       type: STRING
       description: Request metadata associated with the event.
@@ -349,12 +460,10 @@ fields:
       description: HTTP Content-Length header value in bytes.
     - name: context
       type: STRING
-      description: Context string for the event (e.g., OAuth flow context such as
-        'fx_desktop_v3').
+      description: Context string for the event (OAuth flow context).
     - name: countrycode
       type: STRING
-      description: Two-letter ISO 3166-1 country code associated with the event
-        (e.g., 'US', 'DE').
+      description: Two-letter ISO 3166-1 country code associated with the event.
     - name: errorcode
       type: STRING
       description: Application-level error code.
@@ -409,8 +518,8 @@ fields:
       type: STRING
       description: Request parameters from the event.
     - name: success
-      type: BOOLEAN
-      description: Boolean indicating whether the operation succeeded.
+      type: FLOAT
+      description: Count of successful operations associated with the event.
     - name: templateversion
       type: FLOAT
       description: Email template version number.
@@ -424,6 +533,317 @@ fields:
     - name: version
       type: STRING
       description: Version string from the event payload.
+    - name: assertion
+      type: STRING
+      description: Assertion string used in device pairing or browser verification flows.
+    - name: line
+      type: FLOAT
+      description: Source code line number associated with the log event.
+    - name: referrer
+      type: STRING
+      description: HTTP referrer URL at the time of the event.
+    - name: violated
+      type: STRING
+      description: CSP directive that was violated, from a content security policy report.
+    - name: source
+      type: STRING
+      description: Source identifier for the event (e.g., originating service or component).
+    - name: blocked
+      type: BOOLEAN
+      description: Whether the action was blocked (e.g., by rate limiting or IP blocklist).
+    - name: sample
+      type: FLOAT
+      description: Sampling rate or sample value associated with the log entry.
+    - name: column
+      type: FLOAT
+      description: Source code column number associated with the log event.
+    - name: tokenverificationid
+      type: STRING
+      description: Identifier for a token verification attempt.
+    - name: targettype
+      type: STRING
+      description: Type of the target resource for the event.
+    - name: dbpath
+      type: STRING
+      description: Database path or connection string identifier.
+    - name: utm_term
+      type: STRING
+      description: UTM term parameter from the originating URL, used for tracking paid
+        keyword campaigns.
+    - name: utm_source
+      type: STRING
+      description: UTM source parameter from the originating URL.
+    - name: remaining
+      type: FLOAT
+      description: Remaining allowed attempts before rate limiting applies.
+    - name: verifiedat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account or email was verified.
+    - name: product_id
+      type: STRING
+      description: Mozilla subscription product identifier.
+    - name: planid
+      type: STRING
+      description: Subscription plan identifier.
+    - name: ecosystemanonid
+      type: STRING
+      description: Anonymized ecosystem user identifier for cross-product analytics,
+        derived without exposing the raw user ID.
+    - name: traceid
+      type: STRING
+      description: Distributed tracing identifier for correlating events across services.
+    - name: entrypoint_experiment
+      type: STRING
+      description: A/B experiment identifier associated with the entrypoint that started
+        the authentication flow.
+    - name: is_placeholder
+      type: BOOLEAN
+      description: Whether this record is a placeholder entry.
+    - name: index
+      type: FLOAT
+      description: Index position within a list or sequence in the event payload.
+    - name: ka
+      type: STRING
+      description: Key agreement value used in FxA account key derivation.
+    - name: isboom
+      type: BOOLEAN
+      description: Whether the error is a Boom HTTP error object.
+    - name: customeruid
+      type: STRING
+      description: Unique identifier for the customer in the subscription billing system.
+    - name: flowtype
+      type: STRING
+      description: Type classification of the authentication flow.
+    - name: keyschangedat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account encryption keys were last
+        changed.
+    - name: templatename
+      type: STRING
+      description: Name of the email or notification template used for the event.
+    - name: disabledat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account was disabled.
+    - name: _original
+      type: STRING
+      description: Original raw value before transformation or normalization.
+    - name: enabled
+      type: BOOLEAN
+      description: Whether the feature or configuration option is enabled.
+    - name: target
+      type: STRING
+      description: Target resource or endpoint associated with the event.
+    - name: wrapwrapkb
+      type: STRING
+      description: Double-wrapped kB key value used in FxA sync key exchange.
+    - name: automatic_tax
+      type: BOOLEAN
+      description: Whether tax was calculated automatically for a subscription event.
+    - name: entrypoint_variation
+      type: STRING
+      description: A/B variation identifier for the entrypoint experiment.
+    - name: lockedat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account was locked.
+    - name: plan_id
+      type: STRING
+      description: Subscription plan identifier. See also planid.
+    - name: primaryemail
+      type: STRING
+      description: Hashed primary email address for the FxA account. Not a raw email
+        address.
+    - name: _intboolfields
+      type: STRING
+      description: Comma-separated list of field names cast from integer to boolean during
+        log normalization.
+    - name: _uuidfields
+      type: STRING
+      description: Comma-separated list of field names containing UUID strings, used for
+        schema normalization metadata.
+    - name: numsessions
+      type: FLOAT
+      description: Number of active sessions for the account.
+    - name: createdat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account or resource was created.
+    - name: granttype
+      type: STRING
+      description: OAuth grant type.
+    - name: productid
+      type: STRING
+      description: Mozilla subscription product identifier. See also product_id.
+    - name: authsalt
+      type: STRING
+      description: Authentication salt value used in account credential derivation.
+    - name: emailverified
+      type: BOOLEAN
+      description: Whether the account's primary email address has been verified.
+    - name: uabrowserversion
+      type: STRING
+      description: Browser version string parsed from the user agent.
+    - name: isserver
+      type: BOOLEAN
+      description: Whether the event originated from a server-side operation rather than
+        a client request.
+    - name: accountrecreated
+      type: BOOLEAN
+      description: Whether the account was recreated (deleted and re-registered with the
+        same email).
+    - name: isprimary
+      type: BOOLEAN
+      description: Whether the associated email address is the account's primary email.
+    - name: sendertype
+      type: STRING
+      description: Type of email sender used for the notification.
+    - name: targetos
+      type: STRING
+      description: Target operating system for the event.
+    - name: entrypoint
+      type: STRING
+      description: Entry point identifier for the authentication or account creation flow.
+    - name: deviceid
+      type: STRING
+      description: FxA device identifier. See also device_id for the hashed version.
+    - name: postalcode
+      type: STRING
+      description: Postal code from the subscription billing address.
+    - name: details
+      type: STRING
+      description: Additional detail string associated with the event.
+    - name: emails
+      type: STRING
+      description: JSON-encoded list of email objects associated with the account.
+    - name: flowcompletesignal
+      type: STRING
+      description: Event name that signalled flow completion.
+    - name: verifiersetat
+      type: FLOAT
+      description: Unix epoch timestamp of when the account verifier (password) was last
+        set.
+    - name: uaos
+      type: STRING
+      description: Operating system name parsed from the user agent string.
+    - name: headers
+      type: STRING
+      description: JSON-encoded HTTP request headers associated with the event.
+    - name: metricsoptoutat
+      type: FLOAT
+      description: Unix epoch timestamp of when the user opted out of metrics collection.
+    - name: utm_medium
+      type: STRING
+      description: UTM medium parameter from the originating URL.
+    - name: events
+      type: STRING
+      description: JSON-encoded list of sub-events or event sequence associated with the
+        log entry.
+    - name: priceid
+      type: STRING
+      description: Stripe price identifier for a subscription plan.
+    - name: purchase
+      type: STRING
+      description: Purchase identifier or metadata for a subscription purchase.
+    - name: uaosversion
+      type: STRING
+      description: Operating system version string parsed from the user agent.
+    - name: output
+      type: STRING
+      description: Output value or result string from the operation.
+    - name: utm_campaign
+      type: STRING
+      description: UTM campaign parameter from the originating URL.
+    - name: uabrowser
+      type: STRING
+      description: Browser name parsed from the user agent string.
+    - name: normalizedemail
+      type: STRING
+      description: Normalized form of the account email address (lowercased, Gmail dots
+        removed).
+    - name: ipaddress
+      type: STRING
+      description: Client IP address associated with the event.
+    - name: utm_content
+      type: STRING
+      description: UTM content parameter from the originating URL, used to differentiate
+        ads or links.
+    - name: verifierversion
+      type: FLOAT
+      description: Version of the account verifier (password hashing algorithm) in use.
+    - name: sender
+      type: STRING
+      description: Sender identifier for email or notification events.
+    - name: missingflowid
+      type: BOOLEAN
+      description: Whether the event was missing a flow_id at logging time.
+    - name: keys
+      type: STRING
+      description: JSON-encoded account key bundle or key metadata.
+    - name: token
+      type: STRING
+      description: Authentication or session token associated with the event.
+    - name: ipnmessage
+      type: STRING
+      description: IPN (Instant Payment Notification) message payload for subscription
+        billing events.
+    - name: syscall
+      type: STRING
+      description: System call name associated with an OS-level error event.
+    - name: emailcode
+      type: STRING
+      description: Verification code sent to the user's email address.
+    - name: recency
+      type: STRING
+      description: Recency classification of the user session.
+    - name: command
+      type: STRING
+      description: Device command name dispatched or received.
+    - name: unblockcode
+      type: STRING
+      description: One-time code sent to the user to unblock their account after rate
+        limiting.
+    - name: location
+      type: STRING
+      description: JSON-encoded location object containing city, country, and region for
+        the request.
+    - name: newsletters
+      type: STRING
+      description: JSON-encoded list of newsletter subscription identifiers the user opted
+        into.
+    - name: bodysize
+      type: FLOAT
+      description: Size of the HTTP request body in bytes.
+    - name: redirectto
+      type: STRING
+      description: URL the user was redirected to after the authentication flow.
+    - name: senderos
+      type: STRING
+      description: Operating system of the sender in a device command event.
+    - name: zip
+      type: STRING
+      description: Postal ZIP code from the subscription billing address.
+    - name: isverified
+      type: BOOLEAN
+      description: Whether the account has been verified.
+    - name: raw
+      type: STRING
+      description: Raw log line or payload before parsing.
+    - name: rawtype
+      type: STRING
+      description: Type classification of the raw log payload.
+    - name: processingtimemillis
+      type: FLOAT
+      description: Time in milliseconds taken to process the event.
+    - name: currenttime
+      type: FLOAT
+      description: Current server time as a Unix epoch milliseconds float.
+    - name: hostname
+      type: STRING
+      description: Hostname of the server that processed the event.
+    - name: requestid
+      type: STRING
+      description: Unique identifier for the HTTP request.
+    - name: plan
+      type: STRING
+      description: Subscription plan name or identifier associated with the event.
 
 - name: labels
   type: RECORD
@@ -456,10 +876,10 @@ fields:
       entry.
   - name: application
     type: STRING
-    description: Application label identifying the FxA application (e.g., 'fxa').
+    description: Application label identifying the FxA application.
   - name: env
     type: STRING
-    description: Deployment environment label (e.g., 'prod', 'stage').
+    description: Deployment environment label.
   - name: k8s_pod_batch_kubernetes_io_controller_uid
     type: STRING
     description: Kubernetes batch controller UID (batch.kubernetes.io/controller-uid).
@@ -490,11 +910,10 @@ fields:
       'CronJob').
   - name: stack
     type: STRING
-    description: Stack label from the log metadata (e.g., 'default').
+    description: Stack label from the log metadata.
   - name: type
     type: STRING
-    description: Type label from the log metadata indicating the log source category
-      (e.g., 'admin_panel').
+    description: Type label from the log metadata indicating the log source category.
 
 - name: httpRequest
   type: RECORD
@@ -589,7 +1008,7 @@ fields:
     - name: cluster_name
       type: STRING
       description: Kubernetes cluster name where the FxA service is running
-        (e.g., 'fxa-prod').
+        (e.g., 'webservices-high-prod').
     - name: container_name
       type: STRING
       description: Container name within the pod that generated the log entry.
@@ -599,17 +1018,16 @@ fields:
     - name: namespace_name
       type: STRING
       description: Kubernetes namespace of the pod that generated the log entry
-        (e.g., 'fxa').
+        (e.g., 'fxa-prod').
     - name: pod_name
       type: STRING
       description: Kubernetes pod name that generated the log entry.
     - name: instance_id
       type: STRING
-      description: Cloud instance identifier of the node that generated the log entry
-        (e.g., 'i-xxxxxxxxxxxxxxxxx').
+      description: Cloud instance identifier of the node that generated the log entry.
     - name: zone
       type: STRING
-      description: Availability zone of the resource (e.g., 'us-west-1').
+      description: Availability zone of the resource.
 
 - name: sourceLocation
   type: RECORD
@@ -681,7 +1099,7 @@ fields:
       description: App Hub service criticality classification.
     - name: environmentType
       type: STRING
-      description: App Hub service environment type (e.g., 'PRODUCTION').
+      description: App Hub service environment type.
     - name: id
       type: STRING
       description: App Hub service identifier.
@@ -800,13 +1218,15 @@ fields:
 
 - name: flow_id
   type: STRING
-  description: Unique identifier tracking a single end-to-end authentication or account
-    creation flow. Used to correlate all events belonging to the same user session.
+  description: 64-character hex string uniquely identifying a single authentication or
+    account creation attempt from start to finish. HMAC-signed by the auth server to
+    prevent forgery. Links all client-side and server-side events for one user session
+    across auth and content servers.
 
 - name: service
   type: STRING
-  description: The Mozilla service or OAuth relying party associated with the event
-    (e.g., 'sync', 'pocket-web', 'fenix', 'amo-web').
+  description: The Mozilla service or relying party associated with the event
+    (e.g., 'sync', 'fenix', 'fx-private-relay', 'amo-web').
 
 - name: country
   type: STRING
@@ -824,8 +1244,7 @@ fields:
 
 - name: os_version
   type: STRING
-  description: Operating system version string (e.g., '10' for Windows 10, '14.0' for
-    macOS Sonoma).
+  description: Operating system version string (e.g., '10', '10.15', '16').
 
 - name: ua_browser
   type: STRING
@@ -834,5 +1253,107 @@ fields:
 
 - name: ua_version
   type: STRING
-  description: Browser or client version parsed from the user agent string (e.g., '120',
-    '121').
+  description: Browser or client version parsed from the user agent string (e.g., '148.0',
+    '149.0').
+
+- name: event
+  type: STRING
+  description: FxA event name from the log payload (e.g., 'account.login',
+    'account.created' in auth tables; 'flow.signin.view', 'flow.signin.submit' in content
+    tables). Sourced from `jsonPayload.fields.event` (auth) or `jsonPayload.event`
+    (content) depending on the table.
+
+- name: device_id
+  type: STRING
+  description: SHA-256 hashed FxA device identifier, hex-encoded. Coalesced from
+    `jsonPayload.fields.device_id` and `jsonPayload.fields.deviceid` across log sources.
+    Use `user_id` for user-level joins; `device_id` is device-scoped.
+
+- name: entrypoint
+  type: STRING
+  description: FxA entry point where the user started the authentication flow, set by
+    Firefox UI callsites (e.g., 'menupanel', 'preferences', 'synced-tabs'). Not a fixed
+    enum. Sourced from `jsonPayload.fields.entrypoint` in auth tables,
+    `jsonPayload.entrypoint` in content tables, or Amplitude `user_properties` in
+    aggregated tables.
+
+- name: useragent
+  type: STRING
+  description: Raw HTTP User-Agent string from the FxA request. Sourced from
+    `jsonPayload.fields.useragent` in auth tables and `jsonPayload.useragent` in content
+    tables. Use `ua_browser` and `ua_version` for structured browser and version
+    extraction.
+
+- name: utm_source
+  type: STRING
+  description: UTM source parameter identifying the traffic origin (e.g., 'google',
+    'newsletter', 'email'). Captured when users arrive at FxA via a marketing campaign URL.
+    Sourced from Amplitude `user_properties` in aggregated tables.
+
+- name: utm_campaign
+  type: STRING
+  description: UTM campaign parameter identifying the specific marketing campaign (e.g.,
+    'spring_sale', 'email-onboarding'). Sourced from Amplitude `user_properties` in
+    aggregated tables.
+
+- name: utm_content
+  type: STRING
+  description: UTM content parameter used to differentiate links within the same campaign,
+    typically for A/B testing creative. Sourced from Amplitude `user_properties` in
+    aggregated tables.
+
+- name: utm_medium
+  type: STRING
+  description: UTM medium parameter identifying the marketing channel (e.g., 'cpc',
+    'email', 'social'). Sourced from Amplitude `user_properties` in aggregated tables.
+
+- name: utm_term
+  type: STRING
+  description: In FxA, repurposed from the standard paid-search UTM term to track A/B
+    test cohort assignments (e.g., 'my-experiment-var-a'). Not a paid search keyword.
+    Sourced from Amplitude `user_properties`.
+
+- name: flow_time
+  type: FLOAT
+  description: Milliseconds elapsed since the authentication flow began, as reported by
+    the FxA content server (`jsonPayload.flow_time`). Present in content server event
+    tables only. Pair with `flow_id` to measure authentication funnel latency.
+
+- name: locale
+  type: STRING
+  description: BCP 47 locale string (e.g., 'en-US', 'fr', 'de') from the FxA content
+    server log payload (`jsonPayload.locale`). Present in content server tables only. See
+    `language` in aggregated tables for the user-preference language field.
+
+- name: region
+  type: STRING
+  description: Geographic subdivision name derived from the user's IP address (e.g.,
+    'California', 'Bavaria'). In aggregated tables, this is the mode-last value across all
+    events on the submission date. Full name format, not ISO code. Pair with `country` for
+    full geo context.
+
+- name: fxa_server
+  type: STRING
+  description: FxA server component that generated the log entry, derived from the logger
+    name by extracting the service token (e.g., auth, content, oauth, profile, customs).
+    Use to filter to a specific FxA service log stream.
+
+- name: days_since_seen
+  type: INTEGER
+  description: Days since the user last appeared in any FxA event, as of
+    `submission_date`. Computed by `mozfun.bits28.days_since_seen()` over a 28-day
+    rolling window. Values 0 (active today) through 27; NULL if not active in the past
+    28 days.
+
+- name: days_since_seen_in_tier1_country
+  type: INTEGER
+  description: Days since the user was last seen from a Tier 1 country (United States,
+    Canada, United Kingdom, France, Germany), as of `submission_date`. Same 28-day window
+    as `days_since_seen`. NULL if not seen from a tier-1 country in the past 28 days.
+
+- name: date
+  type: DATE
+  description: Event date derived from `DATE(timestamp)`, used as the partition key in
+    some log-derived tables. Distinct from `submission_date` (the pipeline ingestion date).
+    Use `submission_date` for incremental processing; use this field when you need the
+    event's occurrence date.

--- a/bigquery_etl/schema/firefox_accounts_derived.yaml
+++ b/bigquery_etl/schema/firefox_accounts_derived.yaml
@@ -519,7 +519,8 @@ fields:
       description: Request parameters from the event.
     - name: success
       type: FLOAT
-      description: Count of successful operations associated with the event.
+      description: Indicates whether the operation succeeded; in some tables a count of
+        successful operations associated with the event.
     - name: templateversion
       type: FLOAT
       description: Email template version number.


### PR DESCRIPTION
Add 11 jsonPayload content server fields (locale, event, flow_id, flow_time, utm_*, entrypoint, context) and 16 top-level FxA-derived fields (event, device_id, entrypoint, useragent, utm_*, flow_time, locale, region, fxa_server, days_since_seen, days_since_seen_in_tier1_country, date).

Descriptions use the 3-pass methodology: Pass 1 (profiling table), Pass 2 (GCP Cloud Logging docs + FxA GitHub source + UTM spec), Pass 3 (reconciliation). 

Also restores examples in three descriptions that were incorrectly shortened in a prior pass (logger, name, x_forwarded_proto).

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-11281

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
