### PR TITLE
fix(mdn): add session_sample_rate to ping_info in UNION ALL views

### DIFF
--- a/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_action/view.sql
@@ -162,7 +162,8 @@ CREATE OR REPLACE VIEW
             STRUCT<
               event_threshold INT64,
               metrics_enabled ARRAY<STRUCT<key STRING, value BOOLEAN>>,
-              pings_enabled ARRAY<STRUCT<key STRING, value BOOLEAN>>
+              pings_enabled ARRAY<STRUCT<key STRING, value BOOLEAN>>,
+              session_sample_rate FLOAT64
             >
         ) AS server_knobs_config,
         ping_info.parsed_start_time AS parsed_start_time,

--- a/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
+++ b/sql/moz-fx-data-shared-prod/mdn/legacy_page/view.sql
@@ -133,7 +133,8 @@ CREATE OR REPLACE VIEW
             STRUCT<
               event_threshold INT64,
               metrics_enabled ARRAY<STRUCT<key STRING, value BOOLEAN>>,
-              pings_enabled ARRAY<STRUCT<key STRING, value BOOLEAN>>
+              pings_enabled ARRAY<STRUCT<key STRING, value BOOLEAN>>,
+              session_sample_rate FLOAT64
             >
         ) AS server_knobs_config,
         ping_info.parsed_start_time AS parsed_start_time,


### PR DESCRIPTION
## Description

Fixes the `UNION ALL` struct-type incompatibility in the `mdn.legacy_action` and `mdn.legacy_page` views.

The Glean `ping_info.server_knobs_config` struct gained a `session_sample_rate FLOAT64` field. Both views build `ping_info` explicitly to align the `mdn_fred.events_stream` branch with the `mdn_yari.action` / `mdn_yari.page` branch, so the `UNION ALL` failed with `Column 12 in UNION ALL has incompatible types` until the field was added (as a typed `NULL`, in the live schema's field order). Validated via dry run of both views' inner `SELECT`.

## Debugging notes

- The column number maps to the Nth top-level `SELECT` column (12 = `ping_info`); the error truncates structs with `...`, so the real diff is often a deep field, not the visible one.
- Get the live struct (no committed schema exists for Glean stable tables): `bq show --schema --format=prettyjson moz-fx-data-shared-prod:mdn_yari.action`, then diff field-by-field — `UNION ALL` matches by name, type, and order.
- Recurs whenever Glean adds a `ping_info` field (cf. #8880).

## Related Tickets & Documents

* Fixes #9652

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**