### PR TITLE
feat: add backfill entry 2026-06-30 for addons_derived/firefox_desktop_stats_installs_combined_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/backfill.yaml
@@ -1,0 +1,9 @@
+2026-06-30:
+  start_date: 2026-03-01
+  end_date: 2026-06-20
+  reason: |-
+    Backfilling as a follow up to PR#9603.
+  watchers:
+  - kik@mozilla.com
+  - lgreco@mozilla.com
+  status: Initiate


### PR DESCRIPTION
# feat: add backfill entry 2026-06-30 for addons_derived/firefox_desktop_stats_installs_combined_v1

To ensure changes introduced via #9603 apply for at least the lat 3 months.