### PR TITLE
feat: mark backfill entry 2026-06-30 for addons_derived/firefox_desktop_stats_installs_combined_v1 as complete

### DIFF
--- a/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/addons_derived/firefox_desktop_stats_installs_combined_v1/backfill.yaml
@@ -6,4 +6,4 @@
   watchers:
   - kik@mozilla.com
   - lgreco@mozilla.com
-  status: Initiate
+  status: Complete


### PR DESCRIPTION
# feat: mark backfill entry 2026-06-30 for addons_derived/firefox_desktop_stats_installs_combined_v1 as complete