### PR TITLE
chore(schema): add field descriptions for subscription_platform_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
@@ -2,45 +2,87 @@ fields:
 - name: active_date
   type: DATE
   mode: NULLABLE
+  description: The calendar date for which active subscription counts are aggregated. Each row represents
+    a unique combination of dimensions on this date.
 - name: plan_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - name: country
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - name: country_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country_name
 - name: provider
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: provider
 - name: plan_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_amount
 - name: plan_currency
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_currency
 - name: plan_interval
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - name: plan_interval_count
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_count
 - name: product_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_id
 - name: product_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_name
 - name: pricing_plan
   type: STRING
   mode: NULLABLE
+  description: A human-readable label identifying the specific pricing plan, combining interval, currency,
+    and amount (e.g. "1-year-eur-59.88", "1-month-apple").
 - name: promotion_codes
   type: STRING
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes
 - name: promotion_discounts_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_discounts_amount
 - name: count
   type: INTEGER
   mode: NULLABLE
+  description: The number of active subscriptions matching the combination of dimensions on the given `active_date`.
+    Aggregated across mozilla_vpn, relay, and hubs product datasets.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
@@ -2,66 +2,119 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: The SHA-256 hash of the customer's Mozilla Account user ID, used to identify the subscriber
+    without exposing the raw account ID.
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: The unique identifier for this subscription period, derived from the Apple original transaction
+    ID. For multi-period subscriptions, a suffix (e.g. "-1", "-2") is appended to distinguish subsequent
+    periods.
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
+  description: The original Apple transaction ID for the first subscription period. Null when this is the
+    first (or only) subscription period; populated when this is a subsequent resubscription period.
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: status
   type: STRING
+  description: The current status of the Apple subscription. Possible values; "active", "expired", "in billing
+    retry period", "in billing grace period", "revoked".
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: The timestamp of the latest Apple App Store Server API verification event that determined
+    the subscription's current state.
 - mode: NULLABLE
   name: subscription_start_date
   type: TIMESTAMP
+  description: The date and time when the paid subscription period started, after any free trial ended.
+    Null when the subscription started entirely within a trial period.
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: The date and time of the original purchase of the subscription (i.e. the first transaction
+    date for this original transaction ID).
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: The start date and time of the free trial period for this subscription, if one was offered.
+    Null when no trial was associated with this subscription period.
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: The end date and time of the free trial period for this subscription. Null when no trial
+    was associated with this subscription period.
 - mode: NULLABLE
   name: cancel_at_period_end
   type: BOOLEAN
+  description: True when the customer has disabled auto-renewal, meaning the subscription will not renew
+    at the end of the current period. False when auto-renewal is enabled.
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
+  description: The date and time when this subscription period ended or is scheduled to end. For active
+    subscriptions, this reflects the next expiration date.
 - mode: NULLABLE
   name: ended_reason
   type: STRING
+  description: The reason the subscription ended. Possible values; "Cancelled by Customer", "Payment Failed",
+    "Price Change Not Approved by Customer", "Product Unavailable at Renewal", "Refund". Null for active
+    subscriptions.
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: The SHA-256 hash of the customer's Firefox Accounts (Mozilla Account) user ID, used to link
+    this subscription to a Mozilla Account.
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: provider
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: The timezone used when computing billing interval boundaries, always "America/Los_Angeles"
+    for Apple subscriptions.
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
+  description: True when the subscription is currently in a billing grace period (Apple is still attempting
+    to charge the customer but service is not yet interrupted). Null for all records except the most recent
+    period.
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
+  description: The length of the billing grace period as an interval. Populated only when `in_billing_grace_period`
+    is true; otherwise zero-length.
 - mode: REPEATED
   name: promotion_codes
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
@@ -59,14 +59,15 @@ fields:
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
-  description: The date and time when this subscription period ended or is scheduled to end. For active
-    subscriptions, this reflects the next expiration date.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_at
 - mode: NULLABLE
   name: ended_reason
   type: STRING
-  description: The reason the subscription ended. Possible values; "Cancelled by Customer", "Payment Failed",
-    "Price Change Not Approved by Customer", "Product Unavailable at Renewal", "Refund". Null for active
-    subscriptions.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_reason
 - mode: NULLABLE
   name: fxa_uid
   type: STRING


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.subscription_platform_derived`

> Generated by the metadata agent pipeline on 2026-07-02.

### Summary

| | |
|---|---|
| Tables updated | 2 |
| Fields described | 37 |
| Probe-matched | 0 / 37 |
| Contradictions flagged | 0 |

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `active_subscriptions_v1` | 15 | 0/15 |
| `apple_subscriptions_v1` | 22 | 0/22 |

### Contradictions Found

_None_

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Contradictions investigated before merging
