### PR TITLE
chore(ci): unset runner tokens before Claude Code Review step

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,6 +98,15 @@ jobs:
               -f id="$id"
           done
 
+      - name: Unset runner tokens before agent step
+        if: github.event_name == 'pull_request' || steps.fork-check.outputs.is_fork == 'false'
+        # Prevents a prompt injection in this step from using these to touch the Actions
+        # cache/artifacts API or mint an OIDC token.
+        run: |
+          echo "ACTIONS_RUNTIME_TOKEN=" >> "$GITHUB_ENV"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN=" >> "$GITHUB_ENV"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL=" >> "$GITHUB_ENV"
+
       - name: Run Claude Code Review
         if: github.event_name == 'pull_request' || steps.fork-check.outputs.is_fork == 'false'
         # Mozilla org allowlist permits either "anthropics/claude-code-action@v1" (mutable tag)

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Unset runner tokens before agent step
         if: github.event_name == 'pull_request' || steps.fork-check.outputs.is_fork == 'false'
-        # Prevents a prompt injection in this step from using these to touch the Actions
+        # Prevents a prompt injection in the agent step below from using these to touch the Actions
         # cache/artifacts API or mint an OIDC token.
         run: |
           echo "ACTIONS_RUNTIME_TOKEN=" >> "$GITHUB_ENV"


### PR DESCRIPTION
ACTIONS_RUNTIME_TOKEN and ACTIONS_ID_TOKEN_REQUEST_TOKEN/URL are ambient runner credentials. This unsets them before claude-code-action step following SSDLC guide.
