### PR TITLE
Add use counters for when MIDI access is granted

### DIFF
--- a/sql_generators/use_counters/templates/templating.yaml
+++ b/sql_generators/use_counters/templates/templating.yaml
@@ -1827,6 +1827,7 @@ use_counters:
 - name: use_counter_doc_mediadevices_enumeratedevices
 - name: use_counter_doc_mediadevices_getdisplaymedia
 - name: use_counter_doc_mediadevices_getusermedia
+- name: use_counter_doc_midiaccess_granted
 - name: use_counter_doc_mixed_content_not_upgraded_audio_failure
 - name: use_counter_doc_mixed_content_not_upgraded_audio_success
 - name: use_counter_doc_mixed_content_not_upgraded_image_failure
@@ -2340,6 +2341,7 @@ use_counters:
 - name: use_counter_page_mediadevices_enumeratedevices
 - name: use_counter_page_mediadevices_getdisplaymedia
 - name: use_counter_page_mediadevices_getusermedia
+- name: use_counter_page_midiaccess_granted
 - name: use_counter_page_mixed_content_not_upgraded_audio_failure
 - name: use_counter_page_mixed_content_not_upgraded_audio_success
 - name: use_counter_page_mixed_content_not_upgraded_image_failure


### PR DESCRIPTION

## Description

This PR adds use counters for when access to MIDI devices is actually granted.

## Related Tickets & Documents

These were added in Firefox in [bug 2015187](https://bugzilla.mozilla.org/show_bug.cgi?id=2015187).

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
