### PR TITLE
chore(schema): add field descriptions for subscription_platform_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
@@ -5,42 +5,78 @@ fields:
 - name: plan_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - name: country
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - name: country_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country_name
 - name: provider
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - name: plan_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_amount
 - name: plan_currency
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_currency
 - name: plan_interval
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - name: plan_interval_count
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - name: product_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - name: product_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_product_name
 - name: pricing_plan
   type: STRING
   mode: NULLABLE
 - name: promotion_codes
   type: STRING
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes
 - name: promotion_discounts_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_discounts_amount
 - name: count
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/schema.yaml
@@ -2,28 +2,33 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the associated Firestore record change occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: firestore_export_event_id
   type: STRING
   mode: NULLABLE
-  description: |-
-    The associated Firestore export event ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: firestore_export_event_id
 - name: firestore_export_operation
   type: STRING
   mode: NULLABLE
-  description: |-
-    The associated Firestore export operation ("IMPORT", "CREATE", "UPDATE", or "DELETE").
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: firestore_export_operation
 - name: subscription
   type: RECORD
   mode: NULLABLE
-  description: |-
-    The Apple subscription as it ostensibly was after the change occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription
   fields:
   - name: environment
     type: STRING

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/schema.yaml
@@ -2,19 +2,21 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    History record ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - name: valid_from
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    Start of the time range this history record is considered valid for (inclusive).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_from
 - name: valid_to
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    End of the time range this history record is considered valid for (non-inclusive).
-    Open-ended history records will have this set to the max timestamp value (9999-12-31 23:59:59.999999).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_to
 - name: apple_subscriptions_revised_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/schema.yaml
@@ -2,13 +2,15 @@ fields: !flatten-lists
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Revised changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the change ostensibly occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: created_at
   type: TIMESTAMP
   mode: NULLABLE
@@ -17,11 +19,9 @@ fields: !flatten-lists
 - name: type
   type: STRING
   mode: NULLABLE
-  description: |-
-    Type of revised changelog.
-
-    * "original" indicates the changelog wasn't altered from what SubPlat recorded.
-    * "synthetic_..." indicates the changelog was synthesized based on other available data.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_type
 - name: apple_subscriptions_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
@@ -11,9 +11,15 @@ fields:
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: status
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: status
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
@@ -35,27 +41,45 @@ fields:
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_at
 - mode: NULLABLE
   name: ended_reason
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_reason
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
@@ -65,3 +89,6 @@ fields:
 - mode: REPEATED
   name: promotion_codes
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/encrypted_keys_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/encrypted_keys_v1/schema.yaml
@@ -1,0 +1,9 @@
+fields:
+- name: key_id
+  type: STRING
+  mode: NULLABLE
+  description: ''
+- name: ciphertext
+  type: BYTES
+  mode: NULLABLE
+  description: ''

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/encrypted_keys_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/encrypted_keys_v1/schema.yaml
@@ -2,8 +2,10 @@ fields:
 - name: key_id
   type: STRING
   mode: NULLABLE
-  description: ''
+  description: Identifier for the encryption key set used to encrypt the ciphertext. This references the
+    namespace or key ring under which the key was created (e.g. 'subplat_namespaces_prod').
 - name: ciphertext
   type: BYTES
   mode: NULLABLE
-  description: ''
+  description: Encrypted binary payload produced using the key identified by `key_id`. This contains sensitive
+    data encrypted at rest via the subscription platform's key management system.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
@@ -21,5 +21,6 @@ fields:
 - name: price
   type: NUMERIC
   mode: REQUIRED
-  description: The exchange rate from `base_currency` to `quote_currency` on the given `date`, rounded to
-    9 decimal places. Multiply a price in `base_currency` by this value to convert it to `quote_currency`.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_price

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
@@ -2,15 +2,24 @@ fields:
 - name: date
   type: DATE
   mode: REQUIRED
+  description: The calendar date for which the exchange rate applies, used as the table's partition key.
 - name: base_currency
   type: STRING
   mode: REQUIRED
+  description: ISO 4217 currency code of the source currency being converted from (e.g. 'EUR', 'GBP'). The
+    rate expresses how many units of `quote_currency` one unit of this currency buys.
 - name: quote_currency
   type: STRING
   mode: REQUIRED
+  description: ISO 4217 currency code of the target currency being converted to (e.g. 'USD'). All rows in
+    this table use USD as the quote currency.
 - name: price_type
   type: STRING
   mode: REQUIRED
+  description: The type of exchange rate quote sourced from the OANDA API. Currently always 'mid', representing
+    the midpoint between the bid and ask prices.
 - name: price
   type: NUMERIC
   mode: REQUIRED
+  description: The exchange rate from `base_currency` to `quote_currency` on the given `date`, rounded to
+    9 decimal places. Multiply a price in `base_currency` by this value to convert it to `quote_currency`.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
@@ -1430,3 +1430,7 @@ fields:
   description: Indicates whether the subscription was in an active state at the start of the day. True means the subscription was active at day-start;
     false means it was not yet active or had already ended before the day began.
   type: BOOLEAN
+- name: subscription
+  type: RECORD
+  description: The Apple logical subscription as it ostensibly was during the time range this history
+    record is considered valid for, normalized into the cross-provider logical subscription schema.


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.subscription_platform_derived`

> Generated by the metadata agent pipeline on 2026-07-03.

### Summary

| | |
|---|---|
| Tables updated | 7 |
| Fields described | 163 |
| Probe-matched | 0 / 163 |
| Contradictions flagged | 0 |

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `active_subscriptions_v1` | 15 | 0/15 |
| `apple_subscriptions_changelog_v1` | 41 | 0/41 |
| `apple_subscriptions_history_v1` | 38 | 0/38 |
| `apple_subscriptions_revised_changelog_v1` | 40 | 0/40 |
| `apple_subscriptions_v1` | 22 | 0/22 |
| `encrypted_keys_v1` | 2 | 0/2 |
| `exchange_rates_v1` | 5 | 0/5 |

### Contradictions Found

_None_

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Contradictions investigated before merging
