### PR TITLE
chore(schema): add field descriptions for subscription_platform_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
@@ -5,42 +5,78 @@ fields:
 - name: plan_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - name: country
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - name: country_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country_name
 - name: provider
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - name: plan_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_amount
 - name: plan_currency
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_currency
 - name: plan_interval
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - name: plan_interval_count
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - name: product_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - name: product_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_product_name
 - name: pricing_plan
   type: STRING
   mode: NULLABLE
 - name: promotion_codes
   type: STRING
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes
 - name: promotion_discounts_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_discounts_amount
 - name: count
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/schema.yaml
@@ -2,28 +2,33 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the associated Firestore record change occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: firestore_export_event_id
   type: STRING
   mode: NULLABLE
-  description: |-
-    The associated Firestore export event ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: firestore_export_event_id
 - name: firestore_export_operation
   type: STRING
   mode: NULLABLE
-  description: |-
-    The associated Firestore export operation ("IMPORT", "CREATE", "UPDATE", or "DELETE").
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: firestore_export_operation
 - name: subscription
   type: RECORD
   mode: NULLABLE
-  description: |-
-    The Apple subscription as it ostensibly was after the change occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription
   fields:
   - name: environment
     type: STRING

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/schema.yaml
@@ -2,19 +2,21 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    History record ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: id
 - name: valid_from
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    Start of the time range this history record is considered valid for (inclusive).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_from
 - name: valid_to
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    End of the time range this history record is considered valid for (non-inclusive).
-    Open-ended history records will have this set to the max timestamp value (9999-12-31 23:59:59.999999).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_to
 - name: apple_subscriptions_revised_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/schema.yaml
@@ -2,13 +2,15 @@ fields: !flatten-lists
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Revised changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the change ostensibly occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: created_at
   type: TIMESTAMP
   mode: NULLABLE
@@ -17,11 +19,9 @@ fields: !flatten-lists
 - name: type
   type: STRING
   mode: NULLABLE
-  description: |-
-    Type of revised changelog.
-
-    * "original" indicates the changelog wasn't altered from what SubPlat recorded.
-    * "synthetic_..." indicates the changelog was synthesized based on other available data.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_type
 - name: apple_subscriptions_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
@@ -2,66 +2,126 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: original_subscription_id
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: status
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: status
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: event_timestamp
 - mode: NULLABLE
   name: subscription_start_date
   type: TIMESTAMP
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: cancel_at_period_end
   type: BOOLEAN
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_at
 - mode: NULLABLE
   name: ended_reason
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_reason
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: in_billing_grace_period
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_grace_period
 - mode: REPEATED
   name: promotion_codes
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
@@ -14,3 +14,6 @@ fields:
 - name: price
   type: NUMERIC
   mode: REQUIRED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_price

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/schema.yaml
@@ -2,19 +2,21 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    History record ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: id
 - name: valid_from
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    Start of the time range this history record is considered valid for (inclusive).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_from
 - name: valid_to
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    End of the time range this history record is considered valid for (non-inclusive).
-    Open-ended history records will have this set to the max timestamp value (9999-12-31 23:59:59.999999).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_to
 - name: google_subscriptions_revised_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/schema.yaml
@@ -2,13 +2,15 @@ fields: !flatten-lists
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Revised changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the change ostensibly occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: created_at
   type: TIMESTAMP
   mode: NULLABLE
@@ -17,12 +19,9 @@ fields: !flatten-lists
 - name: type
   type: STRING
   mode: NULLABLE
-  description: |-
-    Type of revised changelog.
-
-    * "original" indicates the changelog wasn't altered from what SubPlat recorded.
-    * "adjusted_..." indicates a minor adjustment was made, like altering when the change was considered to have occurred.
-    * "synthetic_..." indicates the changelog was synthesized based on other available data.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_type
 - name: google_subscriptions_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_v1/schema.yaml
@@ -2,66 +2,107 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: SHA-256 hex-encoded Firefox Accounts (FxA) user ID of the subscriber. Matches `fxa_uid` —
+    both fields carry the same hashed identifier.
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: Unique identifier for this subscription period. For the initial purchase this equals the
+    Google Play purchase token; for subsequent periods (e.g. after an upgrade or downgrade) a numeric suffix
+    is appended to distinguish them.
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
+  description: Google Play purchase token of the original subscription before any plan change. Null when
+    the subscription has never been replaced by a new purchase.
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: Google Play SKU identifier for the subscription plan, e.g. `org.mozilla.gps.mozillavpn.product.12_month_subscription`.
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: Timestamp of the most-recent Google Play IAP event that contributed to this subscription
+    record.
 - mode: NULLABLE
   name: subscription_start
   type: TIMESTAMP
+  description: When the paid subscription period began. Null when the entire active period was a free trial,
+    i.e. the subscription ended before the trial period concluded.
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: Timestamp of the earliest Google Play IAP event observed for this subscription, representing
+    when the subscription was first created.
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: Start of the free-trial period for this subscription. Null when no free trial was associated
+    with this subscription.
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: End of the free-trial period for this subscription. Null when no free trial was associated
+    with this subscription.
 - mode: NULLABLE
   name: canceled_for_customer_at
   type: STRING
+  description: Timestamp string indicating when the customer cancelled the subscription. Null when the subscription
+    has not been cancelled by the user.
 - mode: NULLABLE
   name: subscription_end
   type: TIMESTAMP
+  description: Timestamp when the subscription period ends or ended (i.e. the Google Play expiry time for
+    this period).
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: SHA-256 hex-encoded Firefox Accounts user ID of the subscriber. Null when the subscription
+    event could not be linked to an FxA account.
 - mode: NULLABLE
   name: country
   type: STRING
+  description: ISO 3166-1 alpha-2 country code (lowercased) of the subscriber's Google Play account at the
+    time of the most recent event.
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: Payment provider for this subscription. Always `Google Play` for records in this table.
 - mode: NULLABLE
   name: plan_amount
   type: INTEGER
+  description: Subscription plan price in the minor unit of the plan currency (e.g. cents for USD), derived
+    by dividing `price_amount_micros` by 10,000.
 - mode: NULLABLE
   name: plan_currency
   type: STRING
+  description: ISO 4217 currency code (lowercased) for the subscription plan price, e.g. `usd` or `eur`.
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: Billing interval unit for the subscription plan. One of `month` or `year`.
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: Number of `plan_interval` units per billing cycle. For example, a value of `6` with `plan_interval`
+    = `month` indicates a semi-annual plan.
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: Timezone used for computing plan interval boundaries. Always `Etc/UTC` for Google Play subscriptions.
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: Google Play application package name identifying the product. Always `org.mozilla.firefox.vpn`
+    for Mozilla VPN subscriptions.
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
+  description: True when the subscription is currently in a billing grace period — that is, the most recent
+    payment failed (`payment_state = 0`) but auto-renewal is still enabled. Only the most-recent active
+    period for a given purchase token can be in a billing grace period.
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
+  description: Duration of the billing grace period as a BigQuery INTERVAL. Set to `INTERVAL 1 MONTH` when
+    `in_billing_grace_period` is true, otherwise `INTERVAL 0 DAY`.

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_v1/schema.yaml
@@ -2,28 +2,33 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
-  description: SHA-256 hex-encoded Firefox Accounts (FxA) user ID of the subscriber. Matches `fxa_uid` —
-    both fields carry the same hashed identifier.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: subscription_id
   type: STRING
-  description: Unique identifier for this subscription period. For the initial purchase this equals the
-    Google Play purchase token; for subsequent periods (e.g. after an upgrade or downgrade) a numeric suffix
-    is appended to distinguish them.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
-  description: Google Play purchase token of the original subscription before any plan change. Null when
-    the subscription has never been replaced by a new purchase.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: original_subscription_id
 - mode: NULLABLE
   name: plan_id
   type: STRING
-  description: Google Play SKU identifier for the subscription plan, e.g. `org.mozilla.gps.mozillavpn.product.12_month_subscription`.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
-  description: Timestamp of the most-recent Google Play IAP event that contributed to this subscription
-    record.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: event_timestamp
 - mode: NULLABLE
   name: subscription_start
   type: TIMESTAMP
@@ -32,18 +37,21 @@ fields:
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
-  description: Timestamp of the earliest Google Play IAP event observed for this subscription, representing
-    when the subscription was first created.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
-  description: Start of the free-trial period for this subscription. Null when no free trial was associated
-    with this subscription.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
-  description: End of the free-trial period for this subscription. Null when no free trial was associated
-    with this subscription.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: canceled_for_customer_at
   type: STRING
@@ -57,52 +65,66 @@ fields:
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
-  description: SHA-256 hex-encoded Firefox Accounts user ID of the subscriber. Null when the subscription
-    event could not be linked to an FxA account.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: country
   type: STRING
-  description: ISO 3166-1 alpha-2 country code (lowercased) of the subscriber's Google Play account at the
-    time of the most recent event.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - mode: NULLABLE
   name: provider
   type: STRING
-  description: Payment provider for this subscription. Always `Google Play` for records in this table.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - mode: NULLABLE
   name: plan_amount
   type: INTEGER
-  description: Subscription plan price in the minor unit of the plan currency (e.g. cents for USD), derived
-    by dividing `price_amount_micros` by 10,000.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_amount
 - mode: NULLABLE
   name: plan_currency
   type: STRING
-  description: ISO 4217 currency code (lowercased) for the subscription plan price, e.g. `usd` or `eur`.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_currency
 - mode: NULLABLE
   name: plan_interval
   type: STRING
-  description: Billing interval unit for the subscription plan. One of `month` or `year`.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
-  description: Number of `plan_interval` units per billing cycle. For example, a value of `6` with `plan_interval`
-    = `month` indicates a semi-annual plan.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
-  description: Timezone used for computing plan interval boundaries. Always `Etc/UTC` for Google Play subscriptions.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: product_id
   type: STRING
-  description: Google Play application package name identifying the product. Always `org.mozilla.firefox.vpn`
-    for Mozilla VPN subscriptions.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
-  description: True when the subscription is currently in a billing grace period — that is, the most recent
-    payment failed (`payment_state = 0`) but auto-renewal is still enabled. Only the most-recent active
-    period for a given purchase token can be in a billing grace period.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: in_billing_grace_period
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
-  description: Duration of the billing grace period as a BigQuery INTERVAL. Set to `INTERVAL 1 MONTH` when
-    `in_billing_grace_period` is true, otherwise `INTERVAL 0 DAY`.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_grace_period

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
@@ -1430,3 +1430,7 @@ fields:
   description: Indicates whether the subscription was in an active state at the start of the day. True means the subscription was active at day-start;
     false means it was not yet active or had already ended before the day began.
   type: BOOLEAN
+- name: subscription
+  type: RECORD
+  description: The Apple logical subscription as it ostensibly was during the time range this history
+    record is considered valid for, normalized into the cross-provider logical subscription schema.


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.subscription_platform_derived`

> Generated by the metadata agent pipeline on 2026-07-03.

### Summary

| | |
|---|---|
| Tables updated | 9 |
| Fields described | 265 |
| Probe-matched | 0 / 265 |
| Contradictions flagged | 0 |

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `active_subscriptions_v1` | 15 | 0/15 |
| `apple_subscriptions_changelog_v1` | 41 | 0/41 |
| `apple_subscriptions_history_v1` | 38 | 0/38 |
| `apple_subscriptions_revised_changelog_v1` | 40 | 0/40 |
| `apple_subscriptions_v1` | 22 | 0/22 |
| `exchange_rates_v1` | 5 | 0/5 |
| `google_subscriptions_history_v1` | 40 | 0/40 |
| `google_subscriptions_revised_changelog_v1` | 42 | 0/42 |
| `google_subscriptions_v1` | 22 | 0/22 |

### Contradictions Found

_None_

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Contradictions investigated before merging
