### PR TITLE
chore(schema): add field descriptions for subscription_platform_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/active_subscriptions_v1/schema.yaml
@@ -5,42 +5,78 @@ fields:
 - name: plan_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - name: country
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - name: country_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_country_name
 - name: provider
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - name: plan_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_amount
 - name: plan_currency
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_currency
 - name: plan_interval
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval
 - name: plan_interval_count
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - name: product_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - name: product_name
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_product_name
 - name: pricing_plan
   type: STRING
   mode: NULLABLE
 - name: promotion_codes
   type: STRING
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes
 - name: promotion_discounts_amount
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_discounts_amount
 - name: count
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_changelog_v1/schema.yaml
@@ -2,28 +2,33 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_service_id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the associated Firestore record change occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: firestore_export_event_id
   type: STRING
   mode: NULLABLE
-  description: |-
-    The associated Firestore export event ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: firestore_export_event_id
 - name: firestore_export_operation
   type: STRING
   mode: NULLABLE
-  description: |-
-    The associated Firestore export operation ("IMPORT", "CREATE", "UPDATE", or "DELETE").
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: firestore_export_operation
 - name: subscription
   type: RECORD
   mode: NULLABLE
-  description: |-
-    The Apple subscription as it ostensibly was after the change occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription
   fields:
   - name: environment
     type: STRING

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_history_v1/schema.yaml
@@ -2,19 +2,21 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    History record ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_service_id
 - name: valid_from
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    Start of the time range this history record is considered valid for (inclusive).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_from
 - name: valid_to
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    End of the time range this history record is considered valid for (non-inclusive).
-    Open-ended history records will have this set to the max timestamp value (9999-12-31 23:59:59.999999).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_to
 - name: apple_subscriptions_revised_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_revised_changelog_v1/schema.yaml
@@ -2,13 +2,15 @@ fields: !flatten-lists
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Revised changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_service_id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the change ostensibly occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: created_at
   type: TIMESTAMP
   mode: NULLABLE
@@ -17,11 +19,9 @@ fields: !flatten-lists
 - name: type
   type: STRING
   mode: NULLABLE
-  description: |-
-    Type of revised changelog.
-
-    * "original" indicates the changelog wasn't altered from what SubPlat recorded.
-    * "synthetic_..." indicates the changelog was synthesized based on other available data.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_type
 - name: apple_subscriptions_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/apple_subscriptions_v1/schema.yaml
@@ -2,66 +2,132 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: original_subscription_id
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: status
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_status
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: event_timestamp
 - mode: NULLABLE
   name: subscription_start_date
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_start_date
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: cancel_at_period_end
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: cancel_at_period_end
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_at
 - mode: NULLABLE
   name: ended_reason
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_reason
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: in_billing_grace_period
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_grace_period
 - mode: REPEATED
   name: promotion_codes
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/exchange_rates_v1/schema.yaml
@@ -2,6 +2,9 @@ fields:
 - name: date
   type: DATE
   mode: REQUIRED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: date
 - name: base_currency
   type: STRING
   mode: REQUIRED
@@ -14,3 +17,6 @@ fields:
 - name: price
   type: NUMERIC
   mode: REQUIRED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_price

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_history_v1/schema.yaml
@@ -2,19 +2,21 @@ fields:
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    History record ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_service_id
 - name: valid_from
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    Start of the time range this history record is considered valid for (inclusive).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_from
 - name: valid_to
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    End of the time range this history record is considered valid for (non-inclusive).
-    Open-ended history records will have this set to the max timestamp value (9999-12-31 23:59:59.999999).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_to
 - name: google_subscriptions_revised_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_revised_changelog_v1/schema.yaml
@@ -2,13 +2,15 @@ fields: !flatten-lists
 - name: id
   type: STRING
   mode: NULLABLE
-  description: |-
-    Revised changelog ID.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_service_id
 - name: timestamp
   type: TIMESTAMP
   mode: NULLABLE
-  description: |-
-    When the change ostensibly occurred.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: timestamp
 - name: created_at
   type: TIMESTAMP
   mode: NULLABLE
@@ -17,12 +19,9 @@ fields: !flatten-lists
 - name: type
   type: STRING
   mode: NULLABLE
-  description: |-
-    Type of revised changelog.
-
-    * "original" indicates the changelog wasn't altered from what SubPlat recorded.
-    * "adjusted_..." indicates a minor adjustment was made, like altering when the change was considered to have occurred.
-    * "synthetic_..." indicates the changelog was synthesized based on other available data.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_type
 - name: google_subscriptions_changelog_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/google_subscriptions_v1/schema.yaml
@@ -2,66 +2,132 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: original_subscription_id
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: event_timestamp
 - mode: NULLABLE
   name: subscription_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_start
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: canceled_for_customer_at
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: canceled_for_customer_at
 - mode: NULLABLE
   name: subscription_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_end
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: country
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_provider
 - mode: NULLABLE
   name: plan_amount
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_amount
 - mode: NULLABLE
   name: plan_currency
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_currency
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_last_transaction_product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: in_billing_grace_period
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_grace_period

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/logical_subscriptions_history_v1/schema.yaml
@@ -43,25 +43,9 @@ fields: !include-fields
     - name: provider_subscription_updated_at
       type: TIMESTAMP
       mode: NULLABLE
-      description: |-
-        When the provider subscription was last updated.
-    - !include-fields
-      file: /sql/moz-fx-data-shared-prod/subscription_platform_derived/provider_logical_subscriptions_history_v1_schema.yaml
-      parent_field: subscription
-      field_names:
-      - provider_customer_id
-      - mozilla_account_id
-      - mozilla_account_id_sha256
-      field_replacements:
-      - !include-field
-        file: /sql/moz-fx-data-shared-prod/subscription_platform_derived/provider_logical_subscriptions_history_v1_schema.yaml
-        field: subscription.provider_customer_id
-        append_description: |-
-          This will be null for Google and Apple subscriptions.
-      - !include-field
-        table: moz-fx-data-shared-prod.subscription_platform_derived.stripe_logical_subscriptions_history_v1
-        field: subscription.mozilla_account_id
-    - name: customer_subscription_number
+      description: !include-field-description
+        file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+        field: subscription_provider_subscription_updated_at
       type: INTEGER
       mode: NULLABLE
       description: |-

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_apple_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_apple_subscriptions_v1/schema.yaml
@@ -2,34 +2,39 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
-  description: The Firefox Accounts user ID (SHA-256 hashed) of the subscriber, used as the customer identifier
-    in this non-production Apple IAP dataset.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: subscription_id
   type: STRING
-  description: The unique identifier for this Apple App Store subscription period. For a subscription with
-    multiple active date ranges, a suffix (e.g. '-1') is appended to the original transaction ID to form
-    subsequent period IDs.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
-  description: The Apple original transaction ID that this subscription period is derived from. Null for
-    the first (or only) active period; populated for renewal periods that follow a gap in coverage.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: original_subscription_id
 - mode: NULLABLE
   name: plan_id
   type: STRING
-  description: The Apple App Store product identifier (e.g. 'org.mozilla.ios.FirefoxVPN.product.1_month_subscription')
-    representing the subscription plan purchased.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: status
   type: STRING
-  description: The current lifecycle status of the Apple subscription, derived from the Apple status code.
-    Possible values include 'active' (subscription is currently valid) and 'expired' (subscription has ended).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_status
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
-  description: The timestamp of the most recent Apple App Store notification event that was used to populate
-    this subscription record.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: event_timestamp
 - mode: NULLABLE
   name: subscription_start_date
   type: TIMESTAMP
@@ -69,9 +74,9 @@ fields:
 - mode: NULLABLE
   name: ended_reason
   type: STRING
-  description: The reason the subscription ended, mapped from Apple's expiration_intent and revocation_reason
-    codes. Values include 'Cancelled by Customer', 'Payment Failed', 'Price Change Not Approved by Customer',
-    'Product Unavailable at Renewal', and 'Refund'. Null if the subscription has not yet ended.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_ended_reason
 - mode: NULLABLE
   name: fxa_uid
   type: STRING

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_apple_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_apple_subscriptions_v1/schema.yaml
@@ -2,66 +2,127 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: The Firefox Accounts user ID (SHA-256 hashed) of the subscriber, used as the customer identifier
+    in this non-production Apple IAP dataset.
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: The unique identifier for this Apple App Store subscription period. For a subscription with
+    multiple active date ranges, a suffix (e.g. '-1') is appended to the original transaction ID to form
+    subsequent period IDs.
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
+  description: The Apple original transaction ID that this subscription period is derived from. Null for
+    the first (or only) active period; populated for renewal periods that follow a gap in coverage.
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: The Apple App Store product identifier (e.g. 'org.mozilla.ios.FirefoxVPN.product.1_month_subscription')
+    representing the subscription plan purchased.
 - mode: NULLABLE
   name: status
   type: STRING
+  description: The current lifecycle status of the Apple subscription, derived from the Apple status code.
+    Possible values include 'active' (subscription is currently valid) and 'expired' (subscription has ended).
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: The timestamp of the most recent Apple App Store notification event that was used to populate
+    this subscription record.
 - mode: NULLABLE
   name: subscription_start_date
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_start_date
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: cancel_at_period_end
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: cancel_at_period_end
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: ended_at
 - mode: NULLABLE
   name: ended_reason
   type: STRING
+  description: The reason the subscription ended, mapped from Apple's expiration_intent and revocation_reason
+    codes. Values include 'Cancelled by Customer', 'Payment Failed', 'Price Change Not Approved by Customer',
+    'Product Unavailable at Renewal', and 'Refund'. Null if the subscription has not yet ended.
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: provider
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: in_billing_grace_period
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_grace_period
 - mode: REPEATED
   name: promotion_codes
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_google_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_google_subscriptions_v1/schema.yaml
@@ -2,33 +2,39 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
-  description: The Firefox Accounts user ID (SHA-256 hashed) of the subscriber, used as the customer identifier
-    in this non-production Google Play IAP dataset.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: subscription_id
   type: STRING
-  description: The unique identifier for this Google Play subscription period. For a subscription with multiple
-    active date ranges, a suffix (e.g. '-1') is appended to the original document ID to form subsequent
-    period IDs.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
-  description: The original Google Play Firestore document ID for this subscription. Null for the first
-    (or only) active period; populated for subsequent renewal periods that follow a coverage gap.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: original_subscription_id
 - mode: NULLABLE
   name: plan_id
   type: STRING
-  description: The Google Play SKU identifier for the subscription plan (e.g. 'org.mozilla.gps.mozillavpn.product.1_month_subscription').
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
-  description: The timestamp of the Google Play IAP event that produced the most recent state of this subscription
-    record.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: event_timestamp
 - mode: NULLABLE
   name: subscription_start
   type: TIMESTAMP
-  description: The timestamp when the paid subscription period began, after any free trial. Null if the
-    subscription period fell entirely within a trial.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_start
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
@@ -56,8 +62,9 @@ fields:
 - mode: NULLABLE
   name: subscription_end
   type: TIMESTAMP
-  description: The timestamp when this subscription period ends or ended (the Google Play expiry time for
-    this active date range).
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_end
 - mode: NULLABLE
   name: fxa_uid
   type: STRING

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_google_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_google_subscriptions_v1/schema.yaml
@@ -2,66 +2,125 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: The Firefox Accounts user ID (SHA-256 hashed) of the subscriber, used as the customer identifier
+    in this non-production Google Play IAP dataset.
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: The unique identifier for this Google Play subscription period. For a subscription with multiple
+    active date ranges, a suffix (e.g. '-1') is appended to the original document ID to form subsequent
+    period IDs.
 - mode: NULLABLE
   name: original_subscription_id
   type: STRING
+  description: The original Google Play Firestore document ID for this subscription. Null for the first
+    (or only) active period; populated for subsequent renewal periods that follow a coverage gap.
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: The Google Play SKU identifier for the subscription plan (e.g. 'org.mozilla.gps.mozillavpn.product.1_month_subscription').
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: The timestamp of the Google Play IAP event that produced the most recent state of this subscription
+    record.
 - mode: NULLABLE
   name: subscription_start
   type: TIMESTAMP
+  description: The timestamp when the paid subscription period began, after any free trial. Null if the
+    subscription period fell entirely within a trial.
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: canceled_for_customer_at
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: canceled_for_customer_at
 - mode: NULLABLE
   name: subscription_end
   type: TIMESTAMP
+  description: The timestamp when this subscription period ends or ended (the Google Play expiry time for
+    this active date range).
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: country
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: provider
 - mode: NULLABLE
   name: plan_amount
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_amount
 - mode: NULLABLE
   name: plan_currency
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_currency
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_id
 - mode: NULLABLE
   name: in_billing_grace_period
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: in_billing_grace_period
 - mode: NULLABLE
   name: billing_grace_period
   type: INTERVAL
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_grace_period

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/schema.yaml
@@ -2,105 +2,208 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: subscription_item_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_item_id
 - mode: NULLABLE
   name: synced_at
   type: TIMESTAMP
+  description: The timestamp when this record was last synced from Stripe via Fivetran (_fivetran_synced),
+    representing the most recent sync time for this row.
 - mode: NULLABLE
   name: valid_from
   type: TIMESTAMP
+  description: The start of the validity window for this history record, derived from the Fivetran _fivetran_start
+    field. Together with valid_to, this defines the period during which this snapshot was the current state
+    of the subscription.
 - mode: NULLABLE
   name: valid_to
   type: TIMESTAMP
+  description: The end of the validity window for this history record. Null for the most recent (current)
+    snapshot of a subscription; otherwise the valid_from of the next history record.
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: subscription_start_date
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_start_date
 - mode: NULLABLE
   name: cancel_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: cancel_at
 - mode: NULLABLE
   name: cancel_at_period_end
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: cancel_at_period_end
 - mode: NULLABLE
   name: canceled_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: canceled_at
 - mode: NULLABLE
   name: canceled_for_customer_at
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: canceled_for_customer_at
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: ended_at
 - mode: NULLABLE
   name: status
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: status
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_id
 - mode: NULLABLE
   name: product_name
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_name
 - mode: REPEATED
   name: product_capabilities
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_capabilities
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: plan_started_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_started_at
 - mode: NULLABLE
   name: plan_ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_ended_at
 - mode: NULLABLE
   name: plan_name
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_name
 - mode: REPEATED
   name: plan_capabilities
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_capabilities
 - mode: NULLABLE
   name: plan_amount
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_amount
 - mode: NULLABLE
   name: billing_scheme
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_scheme
 - mode: NULLABLE
   name: plan_currency
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_currency
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: provider
 - mode: NULLABLE
   name: country
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - mode: REPEATED
   name: promotion_codes
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes
 - mode: NULLABLE
   name: promotion_discounts_amount
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_discounts_amount

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_history_v1/schema.yaml
@@ -31,14 +31,15 @@ fields:
 - mode: NULLABLE
   name: valid_from
   type: TIMESTAMP
-  description: The start of the validity window for this history record, derived from the Fivetran _fivetran_start
-    field. Together with valid_to, this defines the period during which this snapshot was the current state
-    of the subscription.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_from
 - mode: NULLABLE
   name: valid_to
   type: TIMESTAMP
-  description: The end of the validity window for this history record. Null for the most recent (current)
-    snapshot of a subscription; otherwise the valid_from of the next history record.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: valid_to
 - mode: NULLABLE
   name: created
   type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_v1/schema.yaml
@@ -26,8 +26,9 @@ fields:
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
-  description: The Fivetran sync timestamp (synced_at) of the underlying history record used to populate
-    this current-state view.
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: event_timestamp
 - mode: NULLABLE
   name: created
   type: TIMESTAMP

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/nonprod_stripe_subscriptions_v1/schema.yaml
@@ -2,99 +2,197 @@ fields:
 - mode: NULLABLE
   name: customer_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: customer_id
 - mode: NULLABLE
   name: fxa_uid
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: fxa_uid
 - mode: NULLABLE
   name: subscription_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_id
 - mode: NULLABLE
   name: subscription_item_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_item_id
 - mode: NULLABLE
   name: event_timestamp
   type: TIMESTAMP
+  description: The Fivetran sync timestamp (synced_at) of the underlying history record used to populate
+    this current-state view.
 - mode: NULLABLE
   name: created
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: created
 - mode: NULLABLE
   name: trial_start
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_start
 - mode: NULLABLE
   name: trial_end
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: trial_end
 - mode: NULLABLE
   name: subscription_start_date
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: subscription_start_date
 - mode: NULLABLE
   name: cancel_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: cancel_at
 - mode: NULLABLE
   name: cancel_at_period_end
   type: BOOLEAN
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: cancel_at_period_end
 - mode: NULLABLE
   name: canceled_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: canceled_at
 - mode: NULLABLE
   name: canceled_for_customer_at
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: canceled_for_customer_at
 - mode: NULLABLE
   name: ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: ended_at
 - mode: NULLABLE
   name: status
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: status
 - mode: NULLABLE
   name: product_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_id
 - mode: NULLABLE
   name: product_name
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_name
 - mode: REPEATED
   name: product_capabilities
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: product_capabilities
 - mode: NULLABLE
   name: plan_id
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_id
 - mode: NULLABLE
   name: plan_started_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_started_at
 - mode: NULLABLE
   name: plan_ended_at
   type: TIMESTAMP
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_ended_at
 - mode: NULLABLE
   name: plan_name
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_name
 - mode: REPEATED
   name: plan_capabilities
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_capabilities
 - mode: NULLABLE
   name: plan_amount
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_amount
 - mode: NULLABLE
   name: billing_scheme
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: billing_scheme
 - mode: NULLABLE
   name: plan_currency
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_currency
 - mode: NULLABLE
   name: plan_interval
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval
 - mode: NULLABLE
   name: plan_interval_count
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_count
 - mode: NULLABLE
   name: plan_interval_timezone
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: plan_interval_timezone
 - mode: NULLABLE
   name: provider
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: provider
 - mode: NULLABLE
   name: country
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: country
 - mode: REPEATED
   name: promotion_codes
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_codes
 - mode: NULLABLE
   name: promotion_discounts_amount
   type: INTEGER
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+    field: promotion_discounts_amount

--- a/sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
+++ b/sql/moz-fx-data-shared-prod/subscription_platform_derived/subscription_platform_derived.yaml
@@ -1430,3 +1430,32 @@ fields:
   description: Indicates whether the subscription was in an active state at the start of the day. True means the subscription was active at day-start;
     false means it was not yet active or had already ended before the day began.
   type: BOOLEAN
+- name: customer_subscription_number
+  description: Ordinal position of this subscription within the customer's overall history of logical
+    subscriptions. A value of 1 means it is the customer's first subscription, 2 their second, and so
+    on.
+- name: first_touch_attribution
+  description: First-touch attribution for the subscription, capturing the earliest marketing impression
+    that influenced the subscription. Null for Stripe subscriptions created by SubPlat 3 (launched June
+    2025) and later, and null for Google and Apple subscriptions.
+- name: last_touch_attribution
+  description: Last-touch attribution for the subscription, capturing the most recent marketing impression
+    prior to subscription. For SubPlat 3 subscriptions (launched June 2025) this reflects values stored
+    by SubPlat; for earlier subscriptions this is the most recent impression found in SubPlat/FxA logs.
+    Null for Google and Apple subscriptions.
+- name: services
+  description: Array of services provided by this subscription. Each element identifies a Mozilla service
+    (e.g. VPN, Relay, Monitor) that the subscriber has access to under this subscription.
+- name: services_id
+  description: Short identifier for the service within the services array (e.g. "VPN", "Relay", "Monitor",
+    "FPN", "MDN", "Hubs").
+- name: services_name
+  description: Human-readable name of the service within the services array (e.g. "Mozilla VPN", "Relay
+    Premium", "Mozilla Monitor Plus").
+- name: services_tier
+  description: Tier or plan level for the service within the services array, when applicable (e.g. "Email
+    Masking", "Email & Phone Masking", "Plus 5"). Null when no tier information is available for the service.
+- name: subscription
+  type: RECORD
+  description: The Apple logical subscription as it ostensibly was during the time range this history
+    record is considered valid for, normalized into the cross-provider logical subscription schema.


### PR DESCRIPTION
## Schema Update: `moz-fx-data-shared-prod.subscription_platform_derived`

> Generated by the metadata agent pipeline on 2026-07-03.

### Summary

| | |
|---|---|
| Tables updated | 14 |
| Fields described | 448 |
| Probe-matched | 0 / 448 |
| Contradictions flagged | 0 |

### Fields Updated by Table

| Table | Fields Described | Probe Matches |
|---|---|---|
| `active_subscriptions_v1` | 15 | 0/15 |
| `apple_subscriptions_changelog_v1` | 41 | 0/41 |
| `apple_subscriptions_history_v1` | 38 | 0/38 |
| `apple_subscriptions_revised_changelog_v1` | 40 | 0/40 |
| `apple_subscriptions_v1` | 22 | 0/22 |
| `exchange_rates_v1` | 5 | 0/5 |
| `google_subscriptions_history_v1` | 40 | 0/40 |
| `google_subscriptions_revised_changelog_v1` | 42 | 0/42 |
| `google_subscriptions_v1` | 22 | 0/22 |
| `logical_subscriptions_history_v1` | 71 | 0/71 |
| `nonprod_apple_subscriptions_v1` | 22 | 0/22 |
| `nonprod_google_subscriptions_v1` | 22 | 0/22 |
| `nonprod_stripe_subscriptions_history_v1` | 35 | 0/35 |
| `nonprod_stripe_subscriptions_v1` | 33 | 0/33 |

### Contradictions Found

_None_

### Checklist

- [ ] Descriptions reviewed for accuracy
- [ ] Contradictions investigated before merging
