### PR TITLE
chore(glam): Update aggregates views to support static labeled counters

### DIFF
--- a/sql/moz-fx-glam-prod/glam_etl/glam_fenix_beta_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fenix_beta_aggregates/view.sql
@@ -5,7 +5,10 @@ CREATE OR REPLACE VIEW
         * EXCEPT (percentiles, non_norm_percentiles),
         IF(
           percentiles IS NOT NULL
-          OR metric_type IN ("boolean", "labeled_boolean"),
+          OR metric_type IN ("boolean", "labeled_boolean")
+          -- labeled_counter summed_histogram rows are label-keyed (categorical),
+          -- not numeric bins, so casting them for percentiles fails; skip them.
+          OR (metric_type = "labeled_counter" AND client_agg_type = "summed_histogram"),
           NULL,
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fenix_nightly_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fenix_nightly_aggregates/view.sql
@@ -5,7 +5,10 @@ CREATE OR REPLACE VIEW
         * EXCEPT (percentiles, non_norm_percentiles),
         IF(
           percentiles IS NOT NULL
-          OR metric_type IN ("boolean", "labeled_boolean"),
+          OR metric_type IN ("boolean", "labeled_boolean")
+          -- labeled_counter summed_histogram rows are label-keyed (categorical),
+          -- not numeric bins, so casting them for percentiles fails; skip them.
+          OR (metric_type = "labeled_counter" AND client_agg_type = "summed_histogram"),
           NULL,
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fenix_release_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fenix_release_aggregates/view.sql
@@ -5,7 +5,10 @@ CREATE OR REPLACE VIEW
         * EXCEPT (percentiles, non_norm_percentiles),
         IF(
           percentiles IS NOT NULL
-          OR metric_type IN ("boolean", "labeled_boolean"),
+          OR metric_type IN ("boolean", "labeled_boolean")
+          -- labeled_counter summed_histogram rows are label-keyed (categorical),
+          -- not numeric bins, so casting them for percentiles fails; skip them.
+          OR (metric_type = "labeled_counter" AND client_agg_type = "summed_histogram"),
           NULL,
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fog_beta_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fog_beta_aggregates/view.sql
@@ -5,7 +5,10 @@ CREATE OR REPLACE VIEW
         * EXCEPT (percentiles, non_norm_percentiles),
         IF(
           percentiles IS NOT NULL
-          OR metric_type IN ("boolean", "labeled_boolean"),
+          OR metric_type IN ("boolean", "labeled_boolean")
+          -- labeled_counter summed_histogram rows are label-keyed (categorical),
+          -- not numeric bins, so casting them for percentiles fails; skip them.
+          OR (metric_type = "labeled_counter" AND client_agg_type = "summed_histogram"),
           NULL,
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fog_nightly_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fog_nightly_aggregates/view.sql
@@ -5,7 +5,10 @@ CREATE OR REPLACE VIEW
         * EXCEPT (percentiles, non_norm_percentiles),
         IF(
           percentiles IS NOT NULL
-          OR metric_type IN ("boolean", "labeled_boolean"),
+          OR metric_type IN ("boolean", "labeled_boolean")
+          -- labeled_counter summed_histogram rows are label-keyed (categorical),
+          -- not numeric bins, so casting them for percentiles fails; skip them.
+          OR (metric_type = "labeled_counter" AND client_agg_type = "summed_histogram"),
           NULL,
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,

--- a/sql/moz-fx-glam-prod/glam_etl/glam_fog_release_aggregates/view.sql
+++ b/sql/moz-fx-glam-prod/glam_etl/glam_fog_release_aggregates/view.sql
@@ -5,7 +5,10 @@ CREATE OR REPLACE VIEW
         * EXCEPT (percentiles, non_norm_percentiles),
         IF(
           percentiles IS NOT NULL
-          OR metric_type IN ("boolean", "labeled_boolean"),
+          OR metric_type IN ("boolean", "labeled_boolean")
+          -- labeled_counter summed_histogram rows are label-keyed (categorical),
+          -- not numeric bins, so casting them for percentiles fails; skip them.
+          OR (metric_type = "labeled_counter" AND client_agg_type = "summed_histogram"),
           NULL,
           mozfun.glam.histogram_cast_struct(histogram)
         ) AS struct_histogram,


### PR DESCRIPTION
## Description

static `labeled_counters`'s `client_agg_type` is now `summed_histogram` after https://github.com/mozilla/bigquery-etl/pull/9622. This updates the aggregates views to support the new aggregation.

## Related Tickets & Documents
* DENG-7764


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
