### PR TITLE
chore(DENG-11021): initiate tier 1 backfills for rolling_cohorts

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
+
 2026-06-08:
   start_date: 2026-06-03
   end_date: 2026-06-08
@@ -9,4 +21,5 @@
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false
+  override_depends_on_past_null_partition: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
@@ -21,5 +21,4 @@
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false
-  override_depends_on_past_null_partition: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
@@ -1,3 +1,15 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
+
 2026-06-08:
   start_date: 2026-06-03
   end_date: 2026-06-08
@@ -9,4 +21,5 @@
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false
+  override_depends_on_past_null_partition: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
@@ -21,5 +21,4 @@
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false
-  override_depends_on_past_null_partition: false
   ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

This PR initiates Tier 1 backfills for DENG-11021 (adds `install_source` to fenix cohort retention roots). First backfill PR after code PR #9656.

Adds an Initiate entry to both roots (batched — neither depends on the other):
- `telemetry_derived.rolling_cohorts_v2`
- `glean_telemetry_derived.rolling_cohorts_v1`

 Params: window `2025-01-01 → 2026-07-06`; `shredder_mitigation: false` (not set in `metadata.yaml`); `override_retention_limit: false` (within the 775-day limit).

At the roots `install_source` is attribute-only — no grain change (fan-out is Tier 2/3). Will validate in staging before the complete PR.

## Related Tickets & Documents
* DENG-11021
* https://github.com/mozilla/bigquery-etl/pull/9656

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
