### PR TITLE
Bug 2053422 - Switch to v2 table for subsequent shredder column removal runs

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -334,6 +334,7 @@ def delete_from_partition(
     clustering_fields: Optional[Iterable[str]] = None,
     reservation_override: Optional[str] = None,
     column_removal_backfill: Optional[bool] = None,
+    dest_partition_nonempty: bool = False,
     **wait_for_job_kwargs,
 ):
     """Return callable to handle deletion requests for partitions of a target table."""
@@ -375,6 +376,13 @@ def delete_from_partition(
             use_dml = False
         job_config.destination = destination_table
         job_config.write_disposition = bigquery.WriteDisposition.WRITE_TRUNCATE
+
+    # For column removal backfills, the destination is v2. The first time a partition
+    # is written, we seed it from v1 (dropping columns). Later runs read from v2 instead.
+    v1_table_id = sql_table_id(target)
+    v2_table_id = re.sub("_v1$", "_v2", v1_table_id)
+    seed_from_v1 = not (column_removal_backfill and dest_partition_nonempty)
+    read_table_id = v1_table_id if seed_from_v1 else v2_table_id
 
     def create_job(client) -> bigquery.QueryJob:
         def normalized_expr(expr: str) -> str:
@@ -455,11 +463,14 @@ def delete_from_partition(
                 partition_condition = partition.condition
 
             if column_removal_backfill:
-                select_expression = generate_compatible_select_expression(
-                    client,
-                    sql_table_id(target),
-                    re.sub("_v1$", "_v2", sql_table_id(target)),
-                )
+                if seed_from_v1:
+                    select_expression = generate_compatible_select_expression(
+                        client,
+                        v1_table_id,
+                        v2_table_id,
+                    )
+                else:
+                    select_expression = "_target.*"
             elif event_id_backfill:
                 select_expression = """
                     _target.* REPLACE (
@@ -477,7 +488,7 @@ def delete_from_partition(
                 SELECT
                   {select_expression},
                 FROM
-                  `{sql_table_id(target)}` AS _target
+                  `{read_table_id}` AS _target
                 {field_joins}
                 WHERE
                   {f"({field_conditions}) AND " if field_conditions else ""}
@@ -506,6 +517,7 @@ def delete_from_partition_with_sampling(
     temp_dataset: str,
     reservation_override: str,
     column_removal_backfill: bool,
+    dest_partition_nonempty: bool = False,
     **wait_for_job_kwargs,
 ):
     """Return callable to delete from a partition of a target table per sample id."""
@@ -513,11 +525,24 @@ def delete_from_partition_with_sampling(
         write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
         create_disposition=bigquery.CreateDisposition.CREATE_IF_NEEDED,
     )
-    target_table = f"{sql_table_id(target)}${partition.id}"
+    # For column removal backfills, the destination is v2. The first time a partition
+    # is written, we seed it from v1 (dropping columns). Later runs read from v2 instead.
+    v1_table_id = sql_table_id(target)
+    v2_table_id = re.sub("_v1$", "_v2", v1_table_id)
+    destination_table_id = v2_table_id if column_removal_backfill else v1_table_id
+    read_table_id = (
+        v2_table_id
+        if column_removal_backfill and dest_partition_nonempty
+        else v1_table_id
+    )
+    target_table = f"{destination_table_id}${partition.id}"
 
     def delete_by_sample(client) -> Union[bigquery.CopyJob, bigquery.QueryJob]:
+        # Match the intermediate tables' clustering to the destination table. For
+        # column removal the destination partition may not exist yet on the first
+        # (seed) run, so read clustering from the base destination table.
         intermediate_clustering_fields = client.get_table(
-            target_table
+            destination_table_id if column_removal_backfill else target_table
         ).clustering_fields
 
         tasks = [
@@ -535,6 +560,7 @@ def delete_from_partition_with_sampling(
                 check_table_existence=True,
                 reservation_override=reservation_override,
                 column_removal_backfill=column_removal_backfill,
+                dest_partition_nonempty=dest_partition_nonempty,
                 **{
                     **wait_for_job_kwargs,
                     # override task id with sample id suffix
@@ -576,7 +602,7 @@ def delete_from_partition_with_sampling(
         else:
             # copy job doesn't have dry runs so dry run base partition for byte estimate
             return client.query(
-                f"SELECT * FROM `{sql_table_id(target)}` WHERE {partition.condition}",
+                f"SELECT * FROM `{read_table_id}` WHERE {partition.condition}",
                 job_config=bigquery.QueryJobConfig(dry_run=True),
             )
 
@@ -663,6 +689,30 @@ def list_partitions(
     return partitions
 
 
+def get_populated_partitions(client, table_id):
+    """Return the set of partition ids that already contain rows in table_id.
+
+    Used by the column removal backfill to tell which v2 partitions have already been written.
+    """
+    project, dataset, table = table_id.split(".")
+    try:
+        rows = client.query(
+            dedent(f"""
+                SELECT
+                  partition_id
+                FROM
+                  `{project}.{dataset}.INFORMATION_SCHEMA.PARTITIONS`
+                WHERE
+                  table_name = '{table}'
+                  AND partition_id IS NOT NULL
+                  AND total_rows > 0
+                """).strip(),
+        ).result()
+    except NotFound:
+        return set()
+    return {row["partition_id"] for row in rows}
+
+
 @dataclass
 class Task:
     """Return type for delete_from_table."""
@@ -714,6 +764,13 @@ def delete_from_table(
         logging.warning(f"Skipping {sql_table_id(target)} due to NotFound exception")
         return ()  # type: ignore
     partition_expr = get_partition_expr(table)
+    # For column-removal backfills, once a partition has data in v2, we read from v2 instead of
+    # v1 so deletions aren't undone if the deletion request rolls out of the lookback window
+    nonempty_partitions = (
+        get_populated_partitions(client, re.sub("_v1$", "_v2", sql_table_id(target)))
+        if column_removal_backfill
+        else set()
+    )
     for partition in list_partitions(
         client,
         table,
@@ -752,6 +809,7 @@ def delete_from_table(
                 temp_dataset=temp_dataset,
                 reservation_override=reservation_override,
                 column_removal_backfill=column_removal_backfill,
+                dest_partition_nonempty=partition.id in nonempty_partitions,
                 **kwargs,
             ),
         )

--- a/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_rows_deleted_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/monitoring_derived/shredder_rows_deleted_v1/query.py
@@ -96,6 +96,13 @@ def add_job_metadata(client: bigquery.Client, job: dict) -> Optional[dict]:
 
     if job["deleted_row_count"] is None:
         table = f'{job["project_id"]}.{job["dataset_id"]}.{job["table_id"]}'
+        job_id = job["job_id"]
+        start_time = datetime.datetime.fromtimestamp(
+            job["start_time_millis"] / 1000, tz=datetime.timezone.utc
+        ).isoformat()
+        end_time = datetime.datetime.fromtimestamp(
+            job["end_time_millis"] / 1000, tz=datetime.timezone.utc
+        ).isoformat()
         try:
             is_glean_v2 = (
                 re.fullmatch(r"[a-z0-9_]+_v2\$[0-9]{8}", job["table_id"])
@@ -115,12 +122,27 @@ def add_job_metadata(client: bigquery.Client, job: dict) -> Optional[dict]:
             after = client.get_table(f'{table}@{job["end_time_millis"]}').num_rows
         except exceptions.NotFound:
             print(
-                f"Could not get table {table}, table may have been deleted since the job ran."
+                f"Could not get a snapshot of table {table} for shredder job {job_id}, "
+                f"table may have been deleted since the job ran. "
+                f"Snapshot timestamps: start={start_time}, end={end_time}."
             )
             return None
+        except Exception as e:
+            print(
+                f"Error computing deleted_row_count for table {table} "
+                f"(shredder job {job_id}): {type(e).__name__}: {e}"
+            )
+            raise
         job["deleted_row_count"] = count = before - after
         if count < 0:
-            raise ValueError(f"deleted_row_count must be >= 0, but got: {count}")
+            raise ValueError(
+                f"deleted_row_count must be >= 0, but got {count} for table {table} "
+                f"(shredder job {job_id}, is_glean_v2={bool(is_glean_v2)}): "
+                f"before={before} rows at start_time {start_time}, "
+                f"after={after} rows at end_time {end_time}. "
+                f"This usually means rows were added to the partition between the "
+                f"snapshot timestamps rather than deleted."
+            )
     # Use v1 table name in the output table for continuity
     if is_glean_v2:
         job["table_id"] = job["table_id"].replace("_v2$", "_v1$")

--- a/tests/shredder/test_delete.py
+++ b/tests/shredder/test_delete.py
@@ -136,6 +136,7 @@ def test_delete_from_partition_with_sampling(mock_delete_from_partition):
             clustering_fields=ANY,
             check_table_existence=True,
             sample_id_range=(i, i),
+            dest_partition_nonempty=False,
             task_id=f"{base_task_id}__sample_{i}_{i}",
         )
 
@@ -174,8 +175,73 @@ def test_delete_from_partition_with_sampling_batch_size(mock_delete_from_partiti
             clustering_fields=ANY,
             check_table_existence=True,
             sample_id_range=(i, i + batch_size - 1),
+            dest_partition_nonempty=False,
             task_id=f"{base_task_id}__sample_{i}_{i + batch_size - 1}",
         )
+
+
+@patch("bigquery_etl.shredder.delete.delete_from_partition")
+def test_delete_from_partition_with_sampling_column_removal(mock_delete_from_partition):
+    """
+    With column_removal_backfill, sampling should copy the intermediate tables into the
+    v2 partition and match their clustering to the v2 table, mirroring the non-column
+    removal path (which copies into and clusters by the same table it reads).
+    """
+    base_task_id = "proj.dataset.table_v1"
+
+    # each per-sample delete_from_partition returns a task producing an intermediate table
+    def make_task(**kwargs):
+        return lambda client: Mock(
+            destination=f"proj.tmp.intermediate_{kwargs['sample_id_range'][0]}",
+            total_bytes_processed=1,
+        )
+
+    mock_delete_from_partition.side_effect = make_task
+
+    args = {**COMMON_DELETE_ARGS, "dry_run": False, "column_removal_backfill": True}
+
+    wait_for_job = shredder_delete.delete_from_partition_with_sampling(
+        **args,
+        partition=shredder_delete.Partition(
+            id="20240101", condition="", is_special=False
+        ),
+        sampling_parallelism=10,
+        sampling_batch_size=1,
+        dest_partition_nonempty=True,
+        task_id=base_task_id,
+    )
+
+    mock_client = Mock()
+
+    job_function = wait_for_job.keywords["create_job"]
+    job_function(mock_client)
+
+    # per-sample queries read/write with column removal enabled
+    for i in range(100):
+        mock_delete_from_partition.assert_any_call(
+            **args,
+            partition=shredder_delete.Partition(
+                id="20240101", condition="", is_special=False
+            ),
+            clustering_fields=ANY,
+            check_table_existence=True,
+            sample_id_range=(i, i),
+            dest_partition_nonempty=True,
+            task_id=f"{base_task_id}__sample_{i}_{i}",
+        )
+
+    v2_table_id = shredder_delete.sql_table_id(COMMON_DELETE_ARGS["target"]).replace(
+        "_v1", "_v2"
+    )
+
+    # clustering is read from the base v2 table (its partition may not exist yet)
+    mock_client.get_table.assert_called_once_with(v2_table_id)
+
+    # intermediates are copied into the v2 partition, not v1
+    assert (
+        mock_client.copy_table.call_args.kwargs["destination"]
+        == f"{v2_table_id}$20240101"
+    )
 
 
 @patch("bigquery_etl.shredder.delete.list_partitions")
@@ -458,6 +524,57 @@ def test_delete_from_partition_with_column_removal_true():
     """)
 
     assert mock_client.query.call_args.args[0].startswith(reformat(expected_query))
+    assert (
+        str(mock_client.query.call_args.kwargs["job_config"].destination)
+        == "test_project.firefox.metrics_v2$20260101"
+    )
+
+
+def test_delete_from_partition_column_removal_reads_v2_when_nonempty():
+    """
+    When the v2 partition is already populated, column_removal_backfill should read
+    from v2 with SELECT _target.* instead of reseeding from v1. This keeps deletions
+    from earlier runs from coming back once the requests age out of the source window.
+    """
+    mock_client = Mock()
+
+    delete_func = delete_from_partition(
+        dry_run=True,
+        partition=Partition(condition="", id="20260101"),
+        priority="INTERACTIVE",
+        source_condition="",
+        sources=[
+            DeleteSource(
+                project="test_project",
+                field="client_id",
+                table="firefox.deletion_request_v1",
+            )
+        ],
+        target=DeleteTarget(
+            project="test_project", field="client_id", table="firefox.metrics_v1"
+        ),
+        use_dml=True,
+        column_removal_backfill=True,
+        dest_partition_nonempty=True,
+        task_id="test",
+        states={},
+        state_table=None,
+        start_date=None,
+        end_date=None,
+    )
+
+    delete_func(mock_client)
+
+    assert mock_client.query.call_count == 1
+    # reading from an already-populated v2 partition needs no schema lookup
+    mock_client.get_table.assert_not_called()
+
+    query = mock_client.query.call_args.args[0]
+    assert query.startswith(reformat("""
+            SELECT
+              _target.*,
+            FROM `test_project.firefox.metrics_v2` AS _target
+            """))
     assert (
         str(mock_client.query.call_args.kwargs["job_config"].destination)
         == "test_project.firefox.metrics_v2$20260101"


### PR DESCRIPTION
## Description

Column-removal reads from v1 and writes to v2, which means that when a deletion request rolls out of the 9 week lookback window shredder uses, the rows will be undeleted. The change here is to make it only read from v1 if the v2 partition is empty.

This also fixes a bug with column-removal not working with per-sample id shredding and adds more context to `shredder_rows_deleted` logs, which was how this was discovered.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=2053422

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
