### PR TITLE
chore(DENG-11021): complete tier 1 backfills

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/rolling_cohorts_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/rolling_cohorts_v2/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

`Complete`s Tier 1 `rolling_cohorts` backfills:

- `telemetry_derived.rolling_cohorts_v2`
- `glean_telemetry_derived.rolling_cohorts_v1`

Staging tables validated: `install_source` is conserved (no fan-out, expected `NULL` tail, cross-family identity) and the small count gap vs prod is benign shredder drift. Safe to promote.

## Related Tickets & Documents
* DENG-11021
* https://github.com/mozilla/bigquery-etl/pull/9680

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
