### PR TITLE
[DENG-4193] Use GSM restricted secrets

### DIFF
--- a/bigquery_etl/query_scheduling/task.py
+++ b/bigquery_etl/query_scheduling/task.py
@@ -233,7 +233,7 @@ class Secret:
     deploy_target: str
     key: str
     deploy_type: str = attr.ib("env")
-    secret: str = attr.ib("airflow-gke-secrets")
+    secret: str = attr.ib("airflow-gke-restricted-secrets")
 
     @deploy_type.validator
     def validate_deploy_type(self, attribute, value):

--- a/tests/data/dags/test_dag_with_secrets
+++ b/tests/data/dags/test_dag_with_secrets
@@ -33,7 +33,7 @@ test__incremental_query__v1_some_secret_stored = Secret(
 test__incremental_query__v1_some_secret_stored_2 = Secret(
     deploy_type="env",
     deploy_target="SECRET2",
-    secret="airflow-gke-secrets",
+    secret="airflow-gke-restricted-secrets",
     key="some_secret_stored_2",
 )
 


### PR DESCRIPTION
## Description

This uses the new restricted GSM secrets in all Airflow DAGs, based on https://docs.google.com/document/d/18iktgFGfn2ElVlhkwVOoTaJtjS6Qc9u1swox8yj0Fdo/edit?tab=t.0

All secrets have been created and set in GSM. This has been tested in the Looker DAG.

## Related Tickets & Documents
* [DENG-4193](https://mozilla-hub.atlassian.net/browse/DENG-4193)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-4193]: https://mozilla-hub.atlassian.net/browse/DENG-4193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ