### PR TITLE
chore(DENG-11021): initiate tier 2 backfills

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_churn_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_churn_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_statistics_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_statistics_v1/backfill.yaml
@@ -1,3 +1,15 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
+
 2026-06-08:
   start_date: 2026-06-03
   end_date: 2026-06-08

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_churn_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_churn_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/backfill.yaml
@@ -1,0 +1,11 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
@@ -1,0 +1,11 @@
+2026-07-06:
+  start_date: 2025-01-01
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
This PR initiates Tier 2 backfills for DENG-11021 (adds `install_source` to the cohort retention tables downstream of the roots). Second backfill PR, after the Tier 1 roots backfills.

Adds an Initiate entry to the Tier 2 tables in both families (batched — each reads from the Tier 1 roots, not
  from one another):
- `telemetry_derived.cohort_daily_churn_v1` / `glean_telemetry_derived.cohort_daily_churn_v1`
- `telemetry_derived.cohort_daily_statistics_v2` / `glean_telemetry_derived.cohort_daily_statistics_v1`
- `telemetry_derived.cohort_weekly_cfs_staging_v1` / `glean_telemetry_derived.cohort_weekly_cfs_staging_v1`

Params: window `2025-01-01 → 2026-07-06`; `shredder_mitigation: false` (not set in `metadata.yaml`); `override_retention_limit: false` (within the 775-day limit — these tables have `expiration_days: null`, so the 768-day retention noted in their descriptions does not tighten it).

At Tier 2 `install_source` enters the grain — this is the fan-out the roots deferred. Depends on the Tier 1 roots being backfilled first. Will validate in staging before the complete PR.

## Related Tickets & Documents
* DENG-11021
* https://github.com/mozilla/bigquery-etl/pull/9656
* https://github.com/mozilla/bigquery-etl/pull/9687

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
