### PR TITLE
feat(DENG-11321): Add fct_suggest_impressions_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/metadata.yaml
@@ -1,0 +1,40 @@
+---
+friendly_name: Fact Suggest Impressions Daily
+
+owners:
+  - cbeck@mozilla.com
+
+description: |-
+  Row-level Firefox Suggest impression events, deduplicated at the
+  session/advertiser level (keeping the deepest typed partial per
+  session, by sequence_no).
+
+  Rows with no session_id or empty query (i.e. impressions that did not
+  match a Merino log entry) are excluded.
+
+  The experiments column is a repeated struct of (slug, branch)
+  representing active experiment enrollments at impression time.
+  To filter by experiment, UNNEST the array:
+    WHERE EXISTS (SELECT 1 FROM UNNEST(experiments) e WHERE e.slug = 'my-experiment' AND e.branch = 'treatment')
+
+labels:
+  incremental: true
+
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: 180
+  clustering:
+    fields:
+      - country
+      - form_factor
+
+scheduling:
+  dag_name: bqetl_search_terms_daily
+
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:search-terms/aggregated

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/metadata.yaml
@@ -15,7 +15,15 @@ description: |-
   The experiments column is a repeated struct of (slug, branch)
   representing active experiment enrollments at impression time.
   To filter by experiment, UNNEST the array:
-    WHERE EXISTS (SELECT 1 FROM UNNEST(experiments) e WHERE e.slug = 'my-experiment' AND e.branch = 'treatment')
+    SELECT
+      * EXCEPT (experiments) -- or select columns without experiments
+    FROM
+      `moz-fx-data-shared-prod.search_terms_derived.fct_suggest_impressions_daily_v1`
+    CROSS JOIN UNNEST(experiments) AS experiments
+    WHERE
+      experiments.slug
+        = 'slug-name'
+      AND experiments.branch = 'control'
 
 labels:
   incremental: true

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/metadata.yaml
@@ -25,6 +25,11 @@ description: |-
         = 'slug-name'
       AND experiments.branch = 'control'
 
+  The match_type column indicates whether a position-0 result is an
+  explicit top pick ("best-match") or a standard suggestion
+  ("firefox-suggest"). Only populated for Glean impressions; NULL
+  for legacy impressions.
+
 labels:
   incremental: true
 

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/query.sql
@@ -1,0 +1,18 @@
+SELECT
+  DATE(submission_timestamp) AS submission_date,
+  country,
+  form_factor,
+  advertiser,
+  LOWER(TRIM(query)) AS partial,
+  position,
+  experiments,
+  is_clicked,
+FROM
+  `moz-fx-data-shared-prod.search_terms_derived.suggest_impression_sanitized_v3`
+WHERE
+  DATE(submission_timestamp) = @submission_date
+  AND session_id IS NOT NULL
+  AND query IS NOT NULL
+  AND LENGTH(TRIM(query)) > 0
+QUALIFY
+  ROW_NUMBER() OVER (PARTITION BY session_id, advertiser ORDER BY sequence_no DESC) = 1

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/query.sql
@@ -5,6 +5,7 @@ SELECT
   advertiser,
   LOWER(TRIM(query)) AS partial,
   position,
+  match_type,
   experiments,
   is_clicked,
 FROM

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/query.sql
@@ -15,4 +15,4 @@ WHERE
   AND query IS NOT NULL
   AND LENGTH(TRIM(query)) > 0
 QUALIFY
-  ROW_NUMBER() OVER (PARTITION BY session_id, advertiser ORDER BY sequence_no DESC) = 1
+  ROW_NUMBER() OVER (PARTITION BY session_id, advertiser ORDER BY sequence_no DESC, request_id) = 1

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/schema.yaml
@@ -1,0 +1,48 @@
+fields:
+- mode: NULLABLE
+  name: submission_date
+  type: DATE
+  description: Date of the impression event.
+- mode: NULLABLE
+  name: country
+  type: STRING
+  description: Two-letter ISO country code.
+- mode: NULLABLE
+  name: form_factor
+  type: STRING
+  description: >-
+    Form factor of the client device (e.g. "desktop", "phone").
+    Sourced from Merino logs.
+- mode: NULLABLE
+  name: advertiser
+  type: STRING
+  description: Advertiser name associated with the suggest result.
+- mode: NULLABLE
+  name: partial
+  type: STRING
+  description: >-
+    Normalized search query partial typed by the user at the time of the
+    impression, lowercased and trimmed. Sourced from Merino logs; rows
+    without a Merino match are excluded.
+- mode: NULLABLE
+  name: position
+  type: INTEGER
+  description: Position of the suggest result in the Firefox address bar dropdown.
+- fields:
+  - mode: NULLABLE
+    name: slug
+    type: STRING
+    description: Experiment slug identifier.
+  - mode: NULLABLE
+    name: branch
+    type: STRING
+    description: Experiment branch the client was enrolled in.
+  mode: REPEATED
+  name: experiments
+  type: RECORD
+  description: >-
+    Active experiments the client was enrolled in at the time of the impression.
+- mode: NULLABLE
+  name: is_clicked
+  type: BOOLEAN
+  description: Whether the suggest result was clicked by the user.

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/fct_suggest_impressions_daily_v1/schema.yaml
@@ -28,6 +28,13 @@ fields:
   name: position
   type: INTEGER
   description: Position of the suggest result in the Firefox address bar dropdown.
+- mode: NULLABLE
+  name: match_type
+  type: STRING
+  description: >-
+    Whether the suggest result was a best/top match or not. Either
+    "best-match" or "firefox-suggest". Only populated for Glean
+    impressions; NULL for legacy impressions.
 - fields:
   - mode: NULLABLE
     name: slug

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/query.sql
@@ -30,6 +30,7 @@ WITH legacy_impressions AS (
     scenario,
     -- Truncate to just Firefox major version
     SPLIT(version, '.')[SAFE_OFFSET(0)] AS version,
+    CAST(NULL AS STRING) AS match_type,
     ARRAY_AGG(
       STRUCT(experiment.key AS slug, experiment.value.branch AS branch) IGNORE NULLS
     ) AS experiments,
@@ -63,6 +64,7 @@ glean_impressions AS (
     CAST(NULL AS STRING) AS scenario,
     -- Truncate to just Firefox major version
     SPLIT(client_info.app_display_version, '.')[SAFE_OFFSET(0)] AS version,
+    metrics.string.quick_suggest_match_type AS match_type,
     ARRAY_AGG(
       STRUCT(experiment.key AS slug, experiment.value.branch AS branch) IGNORE NULLS
     ) AS experiments,

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/schema.yaml
@@ -77,6 +77,13 @@ fields:
 - mode: NULLABLE
   name: sequence_no
   type: INTEGER
+- mode: NULLABLE
+  name: match_type
+  type: STRING
+  description: >-
+    Whether the suggest result was a best/top match or not. Either
+    "best-match" or "firefox-suggest". Only populated for Glean
+    impressions; NULL for legacy impressions.
 - fields:
   - mode: NULLABLE
     name: slug

--- a/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/test_single_day/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/test_single_day/expect.yaml
@@ -21,6 +21,7 @@
   scenario: online
   submission_timestamp: 2021-01-01T12:00:00+00:00
   version: "94"
+
   experiments:
     - slug: suggest-exp
       branch: control
@@ -46,6 +47,7 @@
   scenario: online
   submission_timestamp: 2021-01-01T12:07:00+00:00
   version: "94"
+
   experiments:
     - slug: suggest-exp
       branch: control
@@ -71,6 +73,7 @@
   submission_timestamp: "2021-01-01T13:01:00+00:00"
   timestamp: "2021-01-01T13:01:00+00:00"
   version: "134"
+  match_type: "firefox-suggest"
   experiments:
     - slug: glean-exp
       branch: treatment
@@ -96,6 +99,7 @@
   submission_timestamp: "2021-01-01T13:02:00+00:00"
   timestamp: "2021-01-01T13:02:00+00:00"
   version: "134"
+  match_type: "best-match"
   experiments:
     - slug: glean-exp
       branch: treatment
@@ -123,6 +127,7 @@
   submission_timestamp: "2021-01-01T13:06:00+00:00"
   timestamp: "2021-01-01T12:05:00+00:00"
   version: "94"
+
   experiments:
     - slug: overlap-exp
       branch: legacy-wins
@@ -140,6 +145,7 @@
   reporting_url: https://example.com/duff-beer
   submission_timestamp: "2021-01-01T13:03:00+00:00"
   version: "134"
+  match_type: "firefox-suggest"
   experiments:
     - slug: glean-exp
       branch: treatment
@@ -166,6 +172,7 @@
   submission_timestamp: "2021-01-01T13:20:30+00:00"
   timestamp: "2021-01-01T13:21:00+00:00"
   version: "94"
+
   experiments:
     - slug: suggest-exp
       branch: control
@@ -192,6 +199,7 @@
   submission_timestamp: "2021-01-01T13:31:00+00:00"
   timestamp: "2021-01-01T13:33:00+00:00"
   version: "134"
+  match_type: "best-match"
   experiments:
     - slug: glean-dup-exp
       branch: wins
@@ -219,6 +227,7 @@
   telemetry_query: "best shoes"
   timestamp: "2021-01-01T13:40:00+00:00"
   version: "94"
+
   experiments:
     - slug: suggest-exp
       branch: control

--- a/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/test_single_day/moz-fx-data-shared-prod.firefox_desktop_stable.quick_suggest_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v3/test_single_day/moz-fx-data-shared-prod.firefox_desktop_stable.quick_suggest_v1.yaml
@@ -14,6 +14,7 @@
     string:
       quick_suggest_advertiser: acme corp
       quick_suggest_block_id: 201
+      quick_suggest_match_type: "firefox-suggest"
       quick_suggest_ping_type: "quicksuggest-impression"
       quick_suggest_request_id: rid11
     url2:
@@ -45,6 +46,7 @@
     string:
       quick_suggest_advertiser: dunder mifflin
       quick_suggest_block_id: 202
+      quick_suggest_match_type: "best-match"
       quick_suggest_ping_type: "quicksuggest-impression"
       quick_suggest_request_id: rid12
     url2:
@@ -76,6 +78,7 @@
     string:
       quick_suggest_advertiser: duff beer
       quick_suggest_block_id: 203
+      quick_suggest_match_type: "firefox-suggest"
       quick_suggest_ping_type: "quicksuggest-impression"
       quick_suggest_request_id: null
     url2:
@@ -107,6 +110,7 @@
     string:
       quick_suggest_advertiser: glean store
       quick_suggest_block_id: 205
+      quick_suggest_match_type: "firefox-suggest"
       quick_suggest_ping_type: "quicksuggest-impression"
       quick_suggest_request_id: rid_overlap
     url2:
@@ -139,6 +143,7 @@
     string:
       quick_suggest_advertiser: umbrella corp
       quick_suggest_block_id: 204
+      quick_suggest_match_type: "firefox-suggest"
       quick_suggest_ping_type: "quicksuggest-click"
       quick_suggest_request_id: rid14
     url2:
@@ -171,6 +176,7 @@
     string:
       quick_suggest_advertiser: widget co
       quick_suggest_block_id: 130
+      quick_suggest_match_type: "firefox-suggest"
       quick_suggest_ping_type: "quicksuggest-impression"
       quick_suggest_request_id: rid_glean_dup
     url2:
@@ -203,6 +209,7 @@
     string:
       quick_suggest_advertiser: widget co 2
       quick_suggest_block_id: 131
+      quick_suggest_match_type: "best-match"
       quick_suggest_ping_type: "quicksuggest-impression"
       quick_suggest_request_id: rid_glean_dup
     url2:


### PR DESCRIPTION
## Description

Adds table `fct_suggest_impressions_daily_v1` -> low-level Firefox Suggest impressions with position and experiments, deduplicated at the session/advertiser level. Provides granular impression data for experiment-level analysis.

Also adds `match_type` column to `suggest_impression_sanitized_v3` as suggested in ticket comment - so that we can pull it in to this table

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-11321

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
