### PR TITLE
Fix ambiguous table name matching for backfills

### DIFF
--- a/bigquery_etl/cli/backfill.py
+++ b/bigquery_etl/cli/backfill.py
@@ -1092,7 +1092,7 @@ def _initiate_backfill(
     try:
         ctx.invoke(
             query_backfill,
-            name=f"{dataset}.{table}",
+            name=f"{project}.{dataset}.{table}",
             project_id=project,
             # convert date objects to datetime
             start_date=datetime.combine(entry.start_date, time.min),

--- a/tests/cli/test_cli_query.py
+++ b/tests/cli/test_cli_query.py
@@ -414,7 +414,17 @@ class TestQuery:
             ) as f:
                 f.write("SELECT 1")
 
-            assert len(paths_matching_name_pattern("*", "sql/", None)) == 4
+            # Same table name in a dataset whose name is a suffix of another dataset
+            # (telemetry_derived vs glean_telemetry_derived). The "*{pattern}" suffix
+            # match means a bare "telemetry_derived.query_v1" over-matches this one.
+            os.makedirs("sql/moz-fx-data-shared-prod/glean_telemetry_derived/query_v1")
+            with open(
+                "sql/moz-fx-data-shared-prod/glean_telemetry_derived/query_v1/query.sql",
+                "w",
+            ) as f:
+                f.write("SELECT 1")
+
+            assert len(paths_matching_name_pattern("*", "sql/", None)) == 5
             assert (
                 len(
                     paths_matching_name_pattern(
@@ -447,7 +457,31 @@ class TestQuery:
                 )
                 == 1
             )
-            assert len(paths_matching_name_pattern("*query*", "sql/", None)) == 4
+            assert len(paths_matching_name_pattern("*query*", "sql/", None)) == 5
+
+            # Known issue: A bare "dataset.table" over-matches glean_telemetry_derived
+            # because the "*{pattern}" suffix matches
+            assert (
+                len(
+                    paths_matching_name_pattern(
+                        "telemetry_derived.query_v1",
+                        "sql/",
+                        "moz-fx-data-shared-prod",
+                    )
+                )
+                == 2
+            )
+            # Fully qualifying with the project disambiguates the table name
+            assert (
+                len(
+                    paths_matching_name_pattern(
+                        "moz-fx-data-shared-prod.telemetry_derived.query_v1",
+                        "sql/",
+                        "moz-fx-data-shared-prod",
+                    )
+                )
+                == 1
+            )
             assert (
                 len(
                     paths_matching_name_pattern(


### PR DESCRIPTION
## Description

The backfill globs `*{dataset}.{table}` so if that's the suffix of another backfilled table, it's ambiguous:
```
Found multiple query source files to backfill: [PosixPath('sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_churn_v1/query.sql'), PosixPath('sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_churn_v1/query.sql')] 
```
([error](https://workflow.telemetry.mozilla.org/dags/bqetl_backfill_initiate/grid?dag_run_id=scheduled__2026-07-09T21%3A00%3A00%2B00%3A00&task_id=initiate_backfill.process_backfill&base_date=2026-07-09T21%3A00%3A00%2B0000&tab=mapped_tasks&map_index=2))

Fix here is to add project to the glob

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
