### PR TITLE
feat(DENG-11344): Aggregate Fenix [marketing] notifications allowed i…

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_daily_v1/backfill.yaml
@@ -9,3 +9,11 @@
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false
+
+2026-07-10:
+  start_date: 2026-04-01
+  end_date: 2026-07-10
+  reason: DENG-11344
+  watchers:
+  - nalexander@mozilla.com
+  status: Initiate

--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_daily_v1/backfill.yaml
@@ -1,3 +1,11 @@
+2026-07-10:
+  start_date: 2026-04-01
+  end_date: 2026-07-10
+  reason: DENG-11344
+  watchers:
+  - nalexander@mozilla.com
+  status: Initiate
+
 2026-05-15:
   start_date: 2026-03-30
   end_date: 2026-05-15
@@ -9,11 +17,3 @@
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false
-
-2026-07-10:
-  start_date: 2026-04-01
-  end_date: 2026-07-10
-  reason: DENG-11344
-  watchers:
-  - nalexander@mozilla.com
-  status: Initiate

--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
@@ -9,3 +9,11 @@
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false
+
+2026-07-10:
+  start_date: 2026-04-01
+  end_date: 2026-07-10
+  reason: DENG-11344
+  watchers:
+  - nalexander@mozilla.com
+  status: Initiate

--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
@@ -1,3 +1,11 @@
+2026-07-10:
+  start_date: 2026-04-01
+  end_date: 2026-07-10
+  reason: DENG-11344
+  watchers:
+  - nalexander@mozilla.com
+  status: Initiate
+
 2026-05-15:
   start_date: 2026-03-30
   end_date: 2026-05-15
@@ -9,11 +17,3 @@
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false
-
-2026-07-10:
-  start_date: 2026-04-01
-  end_date: 2026-07-10
-  reason: DENG-11344
-  watchers:
-  - nalexander@mozilla.com
-  status: Initiate

--- a/sql_generators/glean_usage/templates/metrics_templating.yaml
+++ b/sql_generators/glean_usage/templates/metrics_templating.yaml
@@ -11,6 +11,10 @@ fenix:
     sql: "LOGICAL_OR(metrics.boolean.metrics_default_browser)"
   is_large_device:
     sql: "LOGICAL_OR(metrics.boolean.metrics_is_large_device)"
+  notifications_allowed:
+    sql: "LOGICAL_OR(metrics.boolean.metrics_notifications_allowed)"
+  marketing_notifications_allowed:
+    sql: "LOGICAL_OR(metrics.boolean.events_marketing_notification_allowed)"
 firefox_ios:
   uri_count:
     sql: "SUM(metrics.counter.tabs_normal_and_private_uri_count)"


### PR DESCRIPTION
…nto `metrics_clients_{daily,last_seen}`.

Backfill from April 2026.  Fenix notification experiments started in May, so this should give sufficient historical data for analysis.

## Description

This aggregates the main two notification allowed booleans, sibling to `is_large_device`.

For the record, I have no idea how to test any of this, but it _looks_ straight forward.

## Related Tickets & Documents
* DENG-11344

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
