### PR TITLE
feat(customer_experience): add authorship and engagement columns to kitsune_retrieval_index

### DIFF
--- a/sql/moz-fx-data-shared-prod/customer_experience/kitsune_retrieval_index/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/customer_experience/kitsune_retrieval_index/schema.yaml
@@ -7,6 +7,14 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Unique identifier for the support question in Kitsune (SUMO).
+- name: question_creator
+  type: STRING
+  mode: NULLABLE
+  description: Kitsune (SUMO) username of the user who created the support question.
+- name: answer_creator
+  type: STRING
+  mode: NULLABLE
+  description: Kitsune (SUMO) username of the user who created the answer; NULL when no answer exists.
 - name: answer_id
   type: INTEGER
   mode: NULLABLE
@@ -80,6 +88,23 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of unhelpful votes the answer has received from Kitsune users.
+- name: page_views
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of page views the support question has received on Kitsune (SUMO).
+- name: is_solved
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the support question has been marked as solved on Kitsune (SUMO).
+- name: is_locked
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the support question thread is locked on Kitsune (SUMO). The query
+    filters to unlocked questions (`is_locked = FALSE`), so this is effectively always FALSE.
+- name: num_votes
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of votes (e.g. "me too" / interest votes) the support question has received on Kitsune (SUMO).
 - name: question_summary_llm
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/query.sql
@@ -24,7 +24,11 @@ WITH kitsune_questions AS (
     q.tier2_topic,
     q.tier3_topic,
     q.title,
-    q.question_content AS content
+    q.question_content AS content,
+    q.page_views,
+    q.is_solved,
+    q.is_locked,
+    q.num_votes
   FROM
     `moz-fx-data-shared-prod.sumo_syndicate.kitsune_questions_plus` q
   WHERE
@@ -87,6 +91,8 @@ kitsune_embedding AS (
 SELECT
   DATE(kitsune_joined.question_created_at) AS creation_date,
   question_id,
+  question_creator,
+  answer_creator,
   answer_id,
   kitsune_joined.title,
   kitsune_joined.content,
@@ -107,6 +113,10 @@ SELECT
   END AS is_self_answer,
   num_helpful_votes,
   num_unhelpful_votes,
+  page_views,
+  is_solved,
+  is_locked,
+  num_votes,
   kitsune_llm.llm_result.question_summary_llm,
   kitsune_llm.llm_result.question_category_llm,
   kitsune_llm.llm_result.question_language_llm,

--- a/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/customer_experience_derived/kitsune_retrieval_index_v1/schema.yaml
@@ -7,6 +7,14 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Unique identifier for the support question in Kitsune (SUMO).
+- name: question_creator
+  type: STRING
+  mode: NULLABLE
+  description: Kitsune (SUMO) username of the user who created the support question.
+- name: answer_creator
+  type: STRING
+  mode: NULLABLE
+  description: Kitsune (SUMO) username of the user who created the answer; NULL when no answer exists.
 - name: answer_id
   type: INTEGER
   mode: NULLABLE
@@ -77,6 +85,23 @@ fields:
   type: INTEGER
   mode: NULLABLE
   description: Number of unhelpful votes the answer has received from Kitsune users.
+- name: page_views
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of page views the support question has received on Kitsune (SUMO).
+- name: is_solved
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the support question has been marked as solved on Kitsune (SUMO).
+- name: is_locked
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the support question thread is locked on Kitsune (SUMO). The query
+    filters to unlocked questions (`is_locked = FALSE`), so this is effectively always FALSE.
+- name: num_votes
+  type: INTEGER
+  mode: NULLABLE
+  description: Number of votes (e.g. "me too" / interest votes) the support question has received on Kitsune (SUMO).
 - name: question_summary_llm
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
## Description

Adds six new output columns to the Kitsune retrieval index
(`customer_experience_derived.kitsune_retrieval_index_v1` and the downstream
`customer_experience.kitsune_retrieval_index` view) so consumers can see
question/answer authorship and engagement signals.

### New columns

**Authorship** (from `creator_username`)
- `question_creator` (STRING) — username of the question author
- `answer_creator` (STRING) — username of the answer author; NULL when no answer

**Engagement** (from `sumo_syndicate.kitsune_questions_plus`)
- `page_views` (INTEGER) — page views the question has received
- `is_solved` (BOOLEAN) — whether the question is marked solved
- `is_locked` (BOOLEAN) — whether the thread is locked (the query filters
  `is_locked = FALSE`, so this is effectively always FALSE for stored rows)
- `num_votes` (INTEGER) — "me too" / interest votes on the question

### Changes
- `kitsune_retrieval_index_v1/query.sql` — select the six new columns.
- `kitsune_retrieval_index_v1/schema.yaml` — declare the new fields.
- `kitsune_retrieval_index/schema.yaml` (view) — declare the new fields; the view
  is `SELECT * EXCEPT(product)` so it inherits the columns with no view.sql change.

### Notes
- Local `bqetl query validate` dry-run was not run (expired GCP
  application-default credentials); CI runs the same dry-run + schema check.
- Assumed column types are best-effort; if the CI dry-run reports different types
  for any of the six, the schema.yaml files will need a quick adjustment.