### PR TITLE
chore(schema): apply base schema imports for firefox_desktop_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_aggregates_v1/schema.yaml
@@ -35,7 +35,9 @@ fields:
 - name: city
   type: STRING
   mode: NULLABLE
-  description: |
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: city
 
 - name: locale
   type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/baseline_active_users_v1/schema.yaml
@@ -125,6 +125,9 @@ fields:
 - name: windows_build_number
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: windows_build_number
 - name: browser_engagement_uri_count
   type: INTEGER
   mode: NULLABLE
@@ -134,6 +137,9 @@ fields:
 - name: legacy_telemetry_client_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: legacy_telemetry_client_id
 - name: is_default_browser
   type: BOOLEAN
   mode: NULLABLE
@@ -144,18 +150,33 @@ fields:
 - name: attribution_dlsource
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_dlsource
 - name: attribution_experiment
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_experiment
 - name: attribution_variation
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_variation
 - name: attribution_ua
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_ua
 - name: experiments
   type: RECORD
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: experiments
   fields:
   - name: key
     type: STRING
@@ -227,12 +248,18 @@ fields:
 - name: os
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: os
 - name: os_grouped
   type: STRING
   mode: NULLABLE
 - name: os_version
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: os_version
 - name: os_version_build
   type: STRING
   mode: NULLABLE
@@ -284,9 +311,15 @@ fields:
 - name: attribution_medium
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_medium
 - name: attribution_source
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_source
 - name: attribution_term
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/cfs_ga4_attr_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/cfs_ga4_attr_v1/schema.yaml
@@ -51,6 +51,9 @@ fields:
 - name: legacy_telemetry_client_id
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: legacy_telemetry_client_id
 - name: legacy_telemetry_profile_group_id
   type: STRING
   mode: NULLABLE
@@ -66,6 +69,9 @@ fields:
 - name: windows_build_number
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: windows_build_number
 - name: locale
   type: STRING
   mode: NULLABLE
@@ -95,12 +101,18 @@ fields:
 - name: attribution_dlsource
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_dlsource
 - name: attribution_dltoken
   type: STRING
   mode: NULLABLE
 - name: attribution_ua
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_ua
 - name: attribution_experiment
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/clients_first_seen_28_days_later_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/clients_first_seen_28_days_later_v1/schema.yaml
@@ -70,6 +70,9 @@ fields:
 - name: attribution_dlsource
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_dlsource
 - name: attribution_experiment
   type: STRING
   mode: NULLABLE
@@ -85,6 +88,9 @@ fields:
 - name: attribution_ua
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: attribution_ua
 - name: attribution_variation
   type: STRING
   mode: NULLABLE
@@ -166,6 +172,9 @@ fields:
 - name: windows_build_number
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: windows_build_number
 - name: windows_version
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/schema.yaml
@@ -15,6 +15,9 @@ fields:
 - name: normalized_channel
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: normalized_channel
 - name: n_metrics_ping
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/newtab_content_items_daily_v1/schema.yaml
@@ -6,9 +6,15 @@ fields:
 - name: channel
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: channel
 - name: country
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: country
 - name: newtab_content_surface_id
   type: STRING
   mode: NULLABLE
@@ -73,3 +79,6 @@ fields:
 - name: app_version
   type: INTEGER
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: app_version

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_hourly_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_hourly_v2/schema.yaml
@@ -165,6 +165,9 @@ fields:
 - name: normalized_os_version
   mode: NULLABLE
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: normalized_os_version
 - name: release_channel
   mode: NULLABLE
   type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/onboarding_v2/schema.yaml
@@ -165,6 +165,9 @@ fields:
 - name: normalized_os_version
   mode: NULLABLE
   type: STRING
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: normalized_os_version
 - name: release_channel
   mode: NULLABLE
   type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_events_v1/schema.yaml
@@ -25,6 +25,9 @@ fields:
 - name: experiments
   type: RECORD
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: experiments
   fields:
   - name: key
     type: STRING
@@ -63,6 +66,9 @@ fields:
 - name: os_version
   type: NUMERIC
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: os_version
 - name: profile_group_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_events_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_events_v1/schema.yaml
@@ -66,9 +66,6 @@ fields:
 - name: os_version
   type: NUMERIC
   mode: NULLABLE
-  description: !include-field-description
-    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
-    field: os_version
 - name: profile_group_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/schema.yaml
@@ -20,6 +20,9 @@ fields:
 - name: os_version
   type: NUMERIC
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: os_version
 - name: submission_date
   type: DATE
   mode: NULLABLE
@@ -54,6 +57,9 @@ fields:
 - name: experiments
   type: RECORD
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: experiments
   fields:
   - name: key
     type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/review_checker_microsurvey_v1/schema.yaml
@@ -20,9 +20,6 @@ fields:
 - name: os_version
   type: NUMERIC
   mode: NULLABLE
-  description: !include-field-description
-    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
-    field: os_version
 - name: submission_date
   type: DATE
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/snippets_v2/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/snippets_v2/schema.yaml
@@ -157,6 +157,9 @@ fields:
 - name: normalized_os_version
   type: STRING
   mode: NULLABLE
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: normalized_os_version
 - name: release_channel
   type: STRING
   mode: NULLABLE
@@ -172,6 +175,9 @@ fields:
 - name: experiments
   type: RECORD
   mode: REPEATED
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: experiments
   fields:
   - name: key
     type: STRING

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/urlbar_events_daily_engagement_by_product_result_type_v1/schema.yaml
@@ -39,6 +39,9 @@ fields:
   mode: REPEATED
   name: experiments
   type: RECORD
+  description: !include-field-description
+    file: sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml
+    field: experiments
 - mode: NULLABLE
   name: normalized_channel
   type: STRING


### PR DESCRIPTION
## Base Schema Imports

Applies `!include-field-description` tags to 12 table `schema.yaml`s in `firefox_desktop_derived`, referencing `sql/moz-fx-data-shared-prod/firefox_desktop_derived/firefox_desktop_derived.yaml` (dataset base schema added in #9686).

Base schema fields: 37

## Related Tickets

[DENG-11283](https://mozilla-hub.atlassian.net/browse/DENG-11283) — follow-up to #9686 (base schema)

> [!NOTE]
> `force=False`: columns with existing descriptions are left untouched and only covers the empty gaps. 

## Checklist

- [ ] Import tags reviewed


[DENG-11283]: https://mozilla-hub.atlassian.net/browse/DENG-11283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ