### PR TITLE
Add more tasks to shredder_progress and make authorized

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -291,6 +291,8 @@ dry_run:
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v2/mobile_search_clients_daily.template.sql
   # Query too complex
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_history_v1/query.sql
+  # Requires project-level permissions for INFORMATION_SCHEMA views
+  - sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
   # Tests
   - sql/moz-fx-data-test-project/test/simple_view/view.sql
   default_projects:  # projects to use for query dry run jobs

--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -291,8 +291,6 @@ dry_run:
   - sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v2/mobile_search_clients_daily.template.sql
   # Query too complex
   - sql/moz-fx-data-shared-prod/firefox_accounts_derived/event_types_history_v1/query.sql
-  # Requires project-level permissions for INFORMATION_SCHEMA views
-  - sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
   # Tests
   - sql/moz-fx-data-test-project/test/simple_view/view.sql
   default_projects:  # projects to use for query dry run jobs

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Shredder Progress
 description: |-
-  Shredder stats broken down per airflow task (run time, slot usage, bytes scanned, task count, etc.).
-  Some minor tasks are still grouped into "all", e.g. force-no-dml.
+  Estimated Shredder stats broken down per airflow task. Estimates total run time, slot usage, 
+  bytes scanned, and task count. Some minor tasks are still grouped into "all", e.g. force-no-dml.
 owners:
   - bewu@mozilla.com
 authorized: true

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/metadata.yaml
@@ -1,7 +1,8 @@
 friendly_name: Shredder Progress
 description: |-
-  Estimated Shredder stats broken down per airflow task. Estimates total run time, slot usage, 
+  Estimated Shredder stats broken down per airflow task. Estimates total run time, slot usage,
   bytes scanned, and task count. Some minor tasks are still grouped into "all", e.g. force-no-dml.
 owners:
   - bewu@mozilla.com
-authorized: true
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Shredder Progress
+description: |-
+  Shredder stats broken down per airflow task (run time, slot usage, bytes scanned, task count, etc.).
+  Some minor tasks are still grouped into "all", e.g. force-no-dml.
+owners:
+  - bewu@mozilla.com
+authorized: true

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
@@ -34,6 +34,10 @@ shredder AS (
     -- newest job
     ARRAY_AGG(
       STRUCT(
+        -- a task with no shredder_state row for this run had nothing to shred.
+        -- since runs don't overlap per airflow task and an active run always has
+        -- an in-flight job, such a task is complete once the run is finished.
+        job_created IS NULL AS no_work,
         -- job metadata over 28 days old is not queried
         job_created <= TIMESTAMP_SUB(CURRENT_TIMESTAMP, INTERVAL 28 DAY) AS job_too_old,
         job_created,
@@ -60,7 +64,6 @@ shredder AS (
     sampling_tasks.task_id
 ),
 jobs AS (
-  -- https://cloud.google.com/bigquery/docs/information-schema-jobs
   SELECT
     creation_time,
     start_time,
@@ -72,20 +75,7 @@ jobs AS (
     total_bytes_processed AS bytes_complete,
     total_slot_ms AS slot_ms,
   FROM
-    `moz-fx-data-shredder.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
-  UNION ALL
-  SELECT
-    creation_time,
-    start_time,
-    end_time,
-    state,
-    error_result,
-    job_id,
-    project_id,
-    total_bytes_processed AS bytes_complete,
-    total_slot_ms AS slot_ms,
-  FROM
-    `moz-fx-data-bq-batch-prod.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
+    `moz-fx-data-shared-prod.monitoring_derived.jobs_by_organization_v1`
 ),
 successful_jobs AS (
   SELECT
@@ -103,9 +93,10 @@ progress_by_target AS (
     end_date,
     MIN(IFNULL(start_time, job_created)) AS start_time,
     MAX(end_time) AS end_time,
-    -- assume jobs too old for metadata are complete
-    LOGICAL_AND(job_too_old IS TRUE OR end_time IS NOT NULL) AS complete,
-    COUNTIF(job_too_old IS TRUE OR end_time IS NOT NULL) AS tasks_complete,
+    -- a task is complete if it had nothing to shred, if its job is too old for
+    -- metadata (assumed complete), or if its job finished
+    LOGICAL_AND(no_work OR job_too_old IS TRUE OR end_time IS NOT NULL) AS complete,
+    COUNTIF(no_work OR job_too_old IS TRUE OR end_time IS NOT NULL) AS tasks_complete,
     COUNT(*) AS tasks_total,
     SUM(bytes_complete) AS bytes_complete,
     -- count target_bytes once per table and source_bytes once per task

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
@@ -29,8 +29,7 @@ shredder AS (
     END AS airflow_task_id,
     target,
     end_date,
-    -- oldest table size
-    ARRAY_AGG(STRUCT(target_bytes, source_bytes) ORDER BY _PARTITIONTIME LIMIT 1)[OFFSET(0)].*,
+    ARRAY_AGG(STRUCT(target_bytes, source_bytes) ORDER BY target_bytes LIMIT 1)[OFFSET(0)].*,
     -- newest job
     ARRAY_AGG(
       STRUCT(

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
@@ -29,7 +29,11 @@ shredder AS (
     END AS airflow_task_id,
     target,
     end_date,
-    ARRAY_AGG(STRUCT(target_bytes, source_bytes) ORDER BY target_bytes LIMIT 1)[OFFSET(0)].*,
+    -- Initial recorded table size for the run, assuming shredding outpaces ingestion
+    -- this used to order by _PARTITIONTIME to take the oldest recording, but that pseudo column
+    -- can't be referenced in stage deploys. This is usually equivalent but it's still
+    -- close enough even when it's not
+    ARRAY_AGG(STRUCT(target_bytes, source_bytes) ORDER BY target_bytes DESC LIMIT 1)[OFFSET(0)].*,
     -- newest job
     ARRAY_AGG(
       STRUCT(

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
@@ -1,14 +1,30 @@
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.monitoring.shredder_progress`
 AS
-WITH shredder AS (
+WITH sampling_tasks AS (
+  SELECT DISTINCT
+    REGEXP_REPLACE(task_id, r"__sample_[0-9_]+$", "") AS task_id,
+    end_date,
+  FROM
+    `moz-fx-data-shredder.shredder_state.shredder_state`
+  WHERE
+    REGEXP_CONTAINS(task_id, r"__sample_[0-9_]+$")
+),
+shredder AS (
   SELECT
     task_id,
     CASE
+      WHEN target LIKE "moz-fx-data-experiments.%"
+        THEN "experiments"
       WHEN target = "moz-fx-data-shared-prod.telemetry_stable.main_v5"
         THEN "telemetry_main_v5"
       WHEN target = "moz-fx-data-shared-prod.telemetry_stable.main_use_counter_v4"
         THEN "telemetry_main_use_counter"
+      WHEN target = "moz-fx-data-shared-prod.firefox_desktop_stable.metrics_v1"
+        THEN "firefox_desktop_metrics"
+      -- previous groups can also have sampling but they're in their own groups
+      WHEN sampling_tasks.task_id IS NOT NULL
+        THEN "with_sampling"
       ELSE "all"
     END AS airflow_task_id,
     target,
@@ -34,10 +50,14 @@ WITH shredder AS (
   LEFT JOIN
     `moz-fx-data-shredder.shredder_state.shredder_state`
     USING (task_id, end_date)
+  LEFT JOIN
+    sampling_tasks
+    USING (task_id, end_date)
   GROUP BY
     task_id,
     target, -- every task has exactly one target
-    end_date
+    end_date,
+    sampling_tasks.task_id
 ),
 jobs AS (
   -- https://cloud.google.com/bigquery/docs/information-schema-jobs


### PR DESCRIPTION
## Description

- Adds more airflow tasks to the output for more granularity
- Makes the view authorized since the shredder state tables aren't moz-confidential
- Fixes a bug with the task completion logic that wasn't marking tasks as finished correctly

This is to make it usable in monitoring dashboards

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
