### PR TITLE
fix(DENG-11397): restore carry-forward in metrics_clients_last_seen

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
@@ -18,9 +18,9 @@ WITH
 )
 SELECT
   DATE(@submission_date) AS submission_date,
-  _current.client_id,
-  _current.sample_id,
-  _current.normalized_channel,
+  COALESCE(_current.client_id, _previous.client_id) AS client_id,
+  COALESCE(_current.sample_id, _previous.sample_id) AS sample_id,
+  COALESCE(_current.normalized_channel, _previous.normalized_channel) AS normalized_channel,
   _current.n_metrics_ping,
   udf.combine_adjacent_days_28_bits(_previous.days_sent_metrics_ping_bits,
     _current.days_sent_metrics_ping_bits) AS days_sent_metrics_ping_bits,
@@ -28,7 +28,7 @@ SELECT
   {% for metric in metrics[app_name] -%}
     {# For counters, we're assuming that they don't represent a "dimension" that we'd
        want to persist on days the client isn't active #}
-    {% if metric.counter %}
+    {% if metrics[app_name][metric].counter %}
     _current.{{metric}} AS {{metric}},
     {% else %}
     COALESCE(_current.{{metric}}, _previous.{{metric}}) AS {{metric}},
@@ -55,4 +55,3 @@ FULL JOIN
     _previous.normalized_channel = _current.normalized_channel
     OR (_previous.normalized_channel IS NULL AND _current.normalized_channel IS NULL)
   )
-WHERE _current.client_id IS NOT NULL

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.query.sql
@@ -40,7 +40,7 @@ SELECT
     COALESCE(_current.isp_name, _previous.isp_name) AS isp_name,
   {% endif -%}
   {% if app_name == "firefox_desktop" -%}
-    _current.profile_group_id,
+    COALESCE(_current.profile_group_id, _previous.profile_group_id) AS profile_group_id,
     COALESCE(_current.search_with_ads_count_all, _previous.search_with_ads_count_all) AS search_with_ads_count_all,
     COALESCE(_current.search_count_all, _previous.search_count_all) AS search_count_all,
     COALESCE(_current.ad_clicks_count_all, _previous.ad_clicks_count_all) AS ad_clicks_count_all

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.fenix.metrics_clients_daily.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.fenix.metrics_clients_daily.schema.json
@@ -1,0 +1,15 @@
+[
+  {"name": "submission_date", "type": "DATE", "mode": "NULLABLE"},
+  {"name": "client_id", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "sample_id", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "normalized_channel", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "n_metrics_ping", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "days_sent_metrics_ping_bits", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "uri_count", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "is_default_browser", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "is_large_device", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "notifications_allowed", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "marketing_notifications_allowed", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "device_manufacturer", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "isp_name", "type": "STRING", "mode": "NULLABLE"}
+]

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.fenix_derived.metrics_clients_last_seen_v1.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.fenix_derived.metrics_clients_last_seen_v1.schema.json
@@ -1,0 +1,15 @@
+[
+  {"name": "submission_date", "type": "DATE", "mode": "NULLABLE"},
+  {"name": "client_id", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "sample_id", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "normalized_channel", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "n_metrics_ping", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "days_sent_metrics_ping_bits", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "uri_count", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "is_default_browser", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "is_large_device", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "notifications_allowed", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "marketing_notifications_allowed", "type": "BOOLEAN", "mode": "NULLABLE"},
+  {"name": "device_manufacturer", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "isp_name", "type": "STRING", "mode": "NULLABLE"}
+]

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/expect.yaml
@@ -1,0 +1,44 @@
+---
+# Carried forward: row exists though no ping today. n_metrics_ping and
+# uri_count (a counter) are NULL today, so they are omitted from expect.
+# Bits shift one day: shift_28_bits_one_day(1) = 2. Dimensions are carried.
+- submission_date: 2023-01-02
+  client_id: client-carryforward
+  sample_id: 1
+  normalized_channel: release
+  days_sent_metrics_ping_bits: 2
+  is_default_browser: true
+  is_large_device: false
+  notifications_allowed: true
+  marketing_notifications_allowed: false
+  device_manufacturer: Google
+  isp_name: ISP1
+# Updated: combine_adjacent_days_28_bits(1, 1) = 3. Counter + dims from today.
+- submission_date: 2023-01-02
+  client_id: client-matched
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 3
+  days_sent_metrics_ping_bits: 3
+  uri_count: 7
+  is_default_browser: true
+  is_large_device: true
+  notifications_allowed: true
+  marketing_notifications_allowed: true
+  device_manufacturer: Samsung
+  isp_name: ISP2
+# New client: combine_adjacent_days_28_bits(NULL, 1) = 1.
+- submission_date: 2023-01-02
+  client_id: client-new
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 1
+  uri_count: 3
+  is_default_browser: true
+  is_large_device: false
+  notifications_allowed: false
+  marketing_notifications_allowed: false
+  device_manufacturer: Xiaomi
+  isp_name: ISP3
+# client-expired is intentionally absent: last seen 28 days ago, shifted out.

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.fenix.metrics_clients_daily.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.fenix.metrics_clients_daily.yaml
@@ -1,0 +1,28 @@
+---
+- submission_date: 2023-01-02
+  client_id: client-matched
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 3
+  days_sent_metrics_ping_bits: 1
+  uri_count: 7
+  is_default_browser: true
+  is_large_device: true
+  notifications_allowed: true
+  marketing_notifications_allowed: true
+  device_manufacturer: Samsung
+  isp_name: ISP2
+# Brand-new client, first metrics ping today.
+- submission_date: 2023-01-02
+  client_id: client-new
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 1
+  uri_count: 3
+  is_default_browser: true
+  is_large_device: false
+  notifications_allowed: false
+  marketing_notifications_allowed: false
+  device_manufacturer: Xiaomi
+  isp_name: ISP3

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.fenix_derived.metrics_clients_last_seen_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.fenix_derived.metrics_clients_last_seen_v1.yaml
@@ -27,8 +27,8 @@
   marketing_notifications_allowed: false
   device_manufacturer: Samsung
   isp_name: ISP2
-# Last seen exactly 28 days ago (bit 27). Shifting drops it out of the
-# window, so it must NOT be carried forward (no output row).
+# Last ping at bit 27 (27 days before this row); the one-day shift on the next
+# day pushes it past the 28-day window, so it is dropped (no carry-forward row).
 - submission_date: 2023-01-01
   client_id: client-expired
   sample_id: 1

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.fenix_derived.metrics_clients_last_seen_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.fenix_derived.metrics_clients_last_seen_v1.yaml
@@ -1,0 +1,44 @@
+---
+# Seen yesterday, sends NO metrics ping today -> must be carried forward.
+- submission_date: 2023-01-01
+  client_id: client-carryforward
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 2
+  days_sent_metrics_ping_bits: 1
+  uri_count: 10
+  is_default_browser: true
+  is_large_device: false
+  notifications_allowed: true
+  marketing_notifications_allowed: false
+  device_manufacturer: Google
+  isp_name: ISP1
+# Seen yesterday AND sends a ping today -> updated.
+- submission_date: 2023-01-01
+  client_id: client-matched
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 1
+  uri_count: 5
+  is_default_browser: false
+  is_large_device: false
+  notifications_allowed: false
+  marketing_notifications_allowed: false
+  device_manufacturer: Samsung
+  isp_name: ISP2
+# Last seen exactly 28 days ago (bit 27). Shifting drops it out of the
+# window, so it must NOT be carried forward (no output row).
+- submission_date: 2023-01-01
+  client_id: client-expired
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 134217728
+  uri_count: 99
+  is_default_browser: true
+  is_large_device: true
+  notifications_allowed: true
+  marketing_notifications_allowed: true
+  device_manufacturer: OnePlus
+  isp_name: ISP4

--- a/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/query_params.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/test_carry_forward/query_params.yaml
@@ -1,0 +1,4 @@
+---
+- name: submission_date
+  type: DATE
+  value: 2023-01-02

--- a/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.firefox_desktop.metrics_clients_daily.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.firefox_desktop.metrics_clients_daily.schema.json
@@ -1,0 +1,12 @@
+[
+  {"name": "submission_date", "type": "DATE", "mode": "NULLABLE"},
+  {"name": "client_id", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "sample_id", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "normalized_channel", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "n_metrics_ping", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "days_sent_metrics_ping_bits", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "profile_group_id", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "search_with_ads_count_all", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "search_count_all", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "ad_clicks_count_all", "type": "INTEGER", "mode": "NULLABLE"}
+]

--- a/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_last_seen_v1.schema.json
+++ b/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_last_seen_v1.schema.json
@@ -1,0 +1,12 @@
+[
+  {"name": "submission_date", "type": "DATE", "mode": "NULLABLE"},
+  {"name": "client_id", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "sample_id", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "normalized_channel", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "n_metrics_ping", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "days_sent_metrics_ping_bits", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "profile_group_id", "type": "STRING", "mode": "NULLABLE"},
+  {"name": "search_with_ads_count_all", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "search_count_all", "type": "INTEGER", "mode": "NULLABLE"},
+  {"name": "ad_clicks_count_all", "type": "INTEGER", "mode": "NULLABLE"}
+]

--- a/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/expect.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/expect.yaml
@@ -1,0 +1,39 @@
+---
+# Carried forward: no metrics ping today, so profile_group_id AND the
+# "last seen date" count columns persist from the previous row (the desktop
+# search/ad-click counts are documented as the value on the client's last
+# seen date, so they carry - unlike the mobile uri_count counter).
+# n_metrics_ping is current-only, so it is NULL today (omitted).
+# shift_28_bits_one_day(1) = 2.
+- submission_date: 2023-01-02
+  client_id: d-carryforward
+  sample_id: 1
+  normalized_channel: release
+  days_sent_metrics_ping_bits: 2
+  profile_group_id: pg-A
+  search_with_ads_count_all: 5
+  search_count_all: 10
+  ad_clicks_count_all: 2
+# Updated from today's ping: combine_adjacent_days_28_bits(1, 1) = 3.
+- submission_date: 2023-01-02
+  client_id: d-matched
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 2
+  days_sent_metrics_ping_bits: 3
+  profile_group_id: pg-B
+  search_with_ads_count_all: 7
+  search_count_all: 15
+  ad_clicks_count_all: 3
+# New client: combine_adjacent_days_28_bits(NULL, 1) = 1.
+- submission_date: 2023-01-02
+  client_id: d-new
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 1
+  profile_group_id: pg-C
+  search_with_ads_count_all: 1
+  search_count_all: 2
+  ad_clicks_count_all: 0
+# d-expired intentionally absent (last seen 28 days ago, shifted out).

--- a/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.firefox_desktop.metrics_clients_daily.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.firefox_desktop.metrics_clients_daily.yaml
@@ -1,0 +1,21 @@
+---
+- submission_date: 2023-01-02
+  client_id: d-matched
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 2
+  days_sent_metrics_ping_bits: 1
+  profile_group_id: pg-B
+  search_with_ads_count_all: 7
+  search_count_all: 15
+  ad_clicks_count_all: 3
+- submission_date: 2023-01-02
+  client_id: d-new
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 1
+  profile_group_id: pg-C
+  search_with_ads_count_all: 1
+  search_count_all: 2
+  ad_clicks_count_all: 0

--- a/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_last_seen_v1.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/moz-fx-data-shared-prod.firefox_desktop_derived.metrics_clients_last_seen_v1.yaml
@@ -1,0 +1,36 @@
+---
+# Seen yesterday, no metrics ping today -> carried forward. profile_group_id
+# and the "last seen date" count columns persist from this row.
+- submission_date: 2023-01-01
+  client_id: d-carryforward
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 2
+  days_sent_metrics_ping_bits: 1
+  profile_group_id: pg-A
+  search_with_ads_count_all: 5
+  search_count_all: 10
+  ad_clicks_count_all: 2
+# Seen yesterday AND today -> updated from today's values.
+- submission_date: 2023-01-01
+  client_id: d-matched
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 1
+  profile_group_id: pg-B
+  search_with_ads_count_all: 9
+  search_count_all: 9
+  ad_clicks_count_all: 9
+# Last ping at bit 27 (27 days before this row); the one-day shift pushes it
+# past the 28-day window, so it is dropped (no carry-forward row).
+- submission_date: 2023-01-01
+  client_id: d-expired
+  sample_id: 1
+  normalized_channel: release
+  n_metrics_ping: 1
+  days_sent_metrics_ping_bits: 134217728
+  profile_group_id: pg-D
+  search_with_ads_count_all: 1
+  search_count_all: 1
+  ad_clicks_count_all: 1

--- a/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/query_params.yaml
+++ b/tests/sql/moz-fx-data-shared-prod/firefox_desktop_derived/metrics_clients_last_seen_v1/test_carry_forward/query_params.yaml
@@ -1,0 +1,4 @@
+---
+- name: submission_date
+  type: DATE
+  value: 2023-01-02


### PR DESCRIPTION
The query only emitted a row on days a client appeared in metrics_clients_daily, so there were no rows on inactive days and days_sent_metrics_ping_bits reset after every gap - the table did no 28-day windowing. A `WHERE _current.client_id IS NOT NULL` filter, added as a side effect of the 2022 channel-join fix (#2643), was dropping every carry-forward row.

Changes:
* Coalesce the identity columns across the full join and drop the filter so a row survives for 28 days after the last ping, matching the table's documented contract and the baseline_clients_last_seen pattern.
* Also fix the counter check, which referenced `metric.counter` (a string key, always falsy) instead of `metrics[app_name][metric].counter`. Counters like uri_count were being carried forward; without this they would inflate once carry-forward rows exist. This was previously masked by the filter.
* Add a tests/sql data test covering carry-forward, matched-update, new-client, and 28-day-window-expiry cases.

## Related Tickets & Documents
* DENG-11397