### PR TITLE
chore(DENG-11021): cancel cohort_daily_churn_v1 and cohort_weekly_cfs_staging_v1 tier 2 backfills

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_churn_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_churn_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Cancelled
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Cancelled
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_churn_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_churn_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Cancelled
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Cancelled
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

`Cancel`s the four Tier 2 `cohort_daily_churn_v1` / `cohort_weekly_cfs_staging_v1` `install_source` backfills initiated in #9690, to be redone as single-date backfills:
- `telemetry_derived.cohort_daily_churn_v1`
- `glean_telemetry_derived.cohort_daily_churn_v1`
- `telemetry_derived.cohort_weekly_cfs_staging_v1`
- `glean_telemetry_derived.cohort_weekly_cfs_staging_v1`

All four set `scheduling.date_partition_parameter: null`, which tells the backfill machinery to `WRITE_TRUNCATE` the whole table each run rather than write a single partition. Each run then rebuilds a trailing rolling window off `@submission_date` (`churn` 180 days, `cfs_staging` 768 days) — so the initiated `2025-01-01 -> 2026-07-06` range just re-truncates each table ~550 times and only the last run survives. They'll be re-initiated single-date (`start_date == end_date`) so one run rebuilds the full window.

## Related Tickets & Documents
* DENG-11021
* DENG-11362

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
