### PR TITLE
chore(DENG-11021): complete certain tier 2 backfills

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_statistics_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_statistics_v1/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_statistics_v2/backfill.yaml
@@ -5,7 +5,7 @@
   watchers:
   - kbammarito@mozilla.com
   - pissac@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   ignore_date_partition_offset: false


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

`Complete`s the two Tier 2 `cohort_daily_statistics` `install_source` backfills initiated in #9690:
- `telemetry_derived.cohort_daily_statistics_v2`
- `glean_telemetry_derived.cohort_daily_statistics_v1`

Validated both staging tables. Reading one in-range `activity_date` per check gives complete cohort coverage (the query `LEFT JOIN`s actives onto the full in-range cohort, so every cohort emits all its buckets at full size each day).

**Within-staging structural gates — clean for both families:**
- No duplicate rows on the full dimension key now that `install_source` is part of it.
- Grain strictly got finer — the `install_source` split happened, not a no-op.
- Pre-2025 cohorts stay `install_source = NULL` at one row per dimension combo (no bleed-through, no fan-out).                                     
- Non-fenix rows are all `install_source = NULL`.

**Live-prod comparisons — drift-tolerant (frozen snapshot gone; prod shredder-shrunk since build), both benign:**
- Cohort-size reconciliation: uniform +0.9% for telemetry (staging >= prod, no recent-cohort spike) — expected shredder gap.
- Value existence: 112 telemetry orphan pairs, all 1-2-client buckets with real rare installer package names (shredder-emptied from prod, not invented).
- Glean: exactly clean, 0 rows on every check.

Both families promote-safe.

## Related Tickets & Documents
* DENG-11021
* DENG-11362

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
