### PR TITLE
chore(DENG-11021): initiate remaining four tier 2 backfills

### DIFF
--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_churn_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_daily_churn_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-07-22:
+  start_date: 2026-07-06
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
 2026-07-06:
   start_date: 2025-01-01
   end_date: 2026-07-06

--- a/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/glean_telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-07-22:
+  start_date: 2026-07-06
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
 2026-07-06:
   start_date: 2025-01-01
   end_date: 2026-07-06

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_churn_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_daily_churn_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-07-22:
+  start_date: 2026-07-06
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
 2026-07-06:
   start_date: 2025-01-01
   end_date: 2026-07-06

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/cohort_weekly_cfs_staging_v1/backfill.yaml
@@ -1,3 +1,14 @@
+2026-07-22:
+  start_date: 2026-07-06
+  end_date: 2026-07-06
+  reason: DENG-11021 add install_source
+  watchers:
+  - kbammarito@mozilla.com
+  - pissac@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  ignore_date_partition_offset: false
 2026-07-06:
   start_date: 2025-01-01
   end_date: 2026-07-06


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

`Initiate`s the four Tier 2 `cohort_daily_churn_v1` / `cohort_weekly_cfs_staging_v1` `install_source` backfills as single-date, replacing the multi-date range cancelled in #9708 (DENG-11021).

- `telemetry_derived.cohort_daily_churn_v1`
- `glean_telemetry_derived.cohort_daily_churn_v1`
- `telemetry_derived.cohort_weekly_cfs_staging_v1`
- `glean_telemetry_derived.cohort_weekly_cfs_staging_v1`

All four set `scheduling.date_partition_parameter: null`, so each run `WRITE_TRUNCATE`s the whole table and rebuilds a trailing rolling window off `@submission_date` (`churn` 180 days, `cfs_staging` 768 days) rather than writing a single partition. The cancelled `2025-01-01 → 2026-07-06` range therefore re-truncated each table ~550 times with only the last run surviving; these entries use `start_date == end_date == 2026-07-06` so one run rebuilds the full window.

## Related Tickets & Documents
* DENG-11021
* https://github.com/mozilla/bigquery-etl/pull/9708

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
