### PR TITLE
fix(search_terms_derived): resolve resources-exceeded in search_terms_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/metadata.yaml
@@ -1,6 +1,16 @@
 friendly_name: Search Terms Daily
 description: |-
   Daily count of terminal search terms collected by Merino.
+
+  Known data gap: partitions from 2026-06-18 through 2026-07-13 are missing or
+  incomplete. The query began failing on 2026-06-18 with a "Resources exceeded"
+  error (Bug 2048966) and was not producing output until the fix landed. Because
+  the source table `merino_log_sanitized_v3` only retains ~14 days of data
+  (oldest available at time of fix: 2026-07-08), the 2026-06-18 through
+  2026-07-07 partitions are permanently unrecoverable (the source rows have aged
+  out). Backfilled partitions from 2026-07-08 through 2026-07-13 are
+  under-reported, since the trailing 7-day threshold window extends past the
+  oldest available source data. Partitions from 2026-07-14 onward are complete.
 owners:
   - ctroy@mozilla.com
   - rburwei@mozilla.com

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/query.sql
@@ -1,6 +1,6 @@
 WITH terminal_queries AS (
   SELECT
-    ARRAY_REVERSE(ARRAY_AGG(sanitized ORDER BY sequence_no, `timestamp` ASC))[SAFE_OFFSET(0)].*
+    ARRAY_AGG(sanitized ORDER BY sequence_no DESC, `timestamp` DESC LIMIT 1)[SAFE_OFFSET(0)].*
   FROM
     `moz-fx-data-shared-prod.search_terms_derived.merino_log_sanitized_v3` sanitized
   WHERE

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/query.sql
@@ -5,6 +5,7 @@ WITH terminal_queries AS (
     `moz-fx-data-shared-prod.search_terms_derived.merino_log_sanitized_v3` sanitized
   WHERE
     DATE(`timestamp`) > DATE_SUB(@submission_date, INTERVAL 7 DAY)
+    AND DATE(`timestamp`) <= @submission_date
   GROUP BY
     sanitized.session_id
 ),


### PR DESCRIPTION
## Summary

`search_terms_derived.search_terms_daily_v1` has been failing in Airflow since 2026-06-18 with `Resources exceeded during query ... Peak usage: 103% of limit` (aggregate/GROUP BY dominant), [Bug 2048966](https://bugzilla.mozilla.org/show_bug.cgi?id=2048966). This PR fixes the memory error, makes backfills deterministic, and documents the resulting data gap.

## Changes

### 1. Fix the resources-exceeded error
The `terminal_queries` CTE selected the last row per session via `ARRAY_REVERSE(ARRAY_AGG(sanitized ORDER BY ...))[0]`, which materializes the full array of wide row-structs per session across the 7-day window before discarding all but one element. As merino traffic grew, those per-group arrays exceeded the memory limit. Rewritten to `ARRAY_AGG(sanitized ORDER BY sequence_no DESC, timestamp DESC LIMIT 1)[SAFE_OFFSET(0)]`, which keeps only one row per group in memory while selecting the same row.

**Equivalence verified** over the full 7/20 7-day window; the downstream CTEs consume only `submission_date` (= `DATE(timestamp)`) and `query`:

| metric | count |
|---|---|
| total_sessions | 98,296,294 |
| sessions_with_top_ties | 40,537,623 |
| sessions_where_query_is_ambiguous | **0** |

Every top-rank tie shares the same `query` (and, being a tie, the same `timestamp`), so the tiebreak cannot change the output. Old and new logic are identical and deterministic.

### 2. Bound the source window for deterministic backfills
The timestamp filter had no upper bound, so a backfill run for date `D` pulled source rows *after* `D`, reassigning terminal queries for sessions that spilled into later days and under-counting `D` relative to the original same-day run. Added `AND DATE(timestamp) <= @submission_date` to reproduce the intended end-of-day-`D` terminal query.

### 3. Document the data gap in metadata.yaml
Source `merino_log_sanitized_v3` retains ~14 days (oldest available: 2026-07-08), so:
- **2026-06-18 → 2026-07-07**: permanently unrecoverable (source aged out).
- **2026-07-08 → 2026-07-13**: backfillable but under-reported (partial 7-day threshold window).
- **2026-07-14 onward**: complete.

## Files
- `sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/query.sql` - `ARRAY_AGG(... LIMIT 1)` rewrite + `DATE(timestamp) <= @submission_date` bound.
- `sql/moz-fx-data-shared-prod/search_terms_derived/search_terms_daily_v1/metadata.yaml` - documents the data gap.

## Backfill follow-up
After merge/deploy, backfill from **2026-07-08** forward (partitions 07-08–07-13 knowingly under-reported; 07-14+ complete).