### PR TITLE
[AIMOD-1384] Stratify DE engagement by experiment branch

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Newtab Merino Extract
 description: |-
   Aggregated Newtab events for Merino recommendations using v2 propensity weights.
-  German feed experiment rows are emitted with region values suffixed by experiment branch.
+  de_DE experiment rows are emitted with region values suffixed by experiment branch.
   See https://mozilla-hub.atlassian.net/browse/MC-1256
 owners:
 - mmiermans@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
@@ -1,6 +1,7 @@
 friendly_name: Newtab Merino Extract
 description: |-
   Aggregated Newtab events for Merino recommendations using v2 propensity weights.
+  German feed experiment rows are emitted with region values suffixed by experiment branch.
   See https://mozilla-hub.atlassian.net/browse/MC-1256
 owners:
 - mmiermans@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/metadata.yaml
@@ -1,7 +1,7 @@
 friendly_name: Newtab Merino Extract
 description: |-
   Aggregated Newtab events for Merino recommendations using v2 propensity weights.
-  de_DE experiment rows are emitted with region values suffixed by experiment branch.
+  Configured experiment rows are emitted with region values suffixed by experiment slug and branch.
   See https://mozilla-hub.atlassian.net/browse/MC-1256
 owners:
 - mmiermans@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
@@ -218,7 +218,7 @@ country_aggregates AS (
     corpus_item_id,
     region
 ),
-/* Add experiment-specific German feed rows using the existing region field. */
+/* Add de_DE experiment-specific rows using the existing region field. */
 experiment_region_aggregates AS (
   SELECT
     corpus_item_id,
@@ -230,7 +230,7 @@ experiment_region_aggregates AS (
     aggregated_events
   WHERE
     experiment_branch IS NOT NULL
-    AND normalized_country_code IN ('DE', 'CH', 'AT', 'BE')
+    AND normalized_country_code = 'DE'
   GROUP BY
     corpus_item_id,
     region

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
@@ -7,7 +7,8 @@ WITH private_pings AS (
       metrics.string.newtab_content_surface_id,
       NULL,
       metrics.string.newtab_content_country
-    ) AS normalized_country_code
+    ) AS normalized_country_code,
+    NULLIF(metrics.string.newtab_content_experiment_branch, '') AS experiment_branch
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_live.newtab_content_v1`
   WHERE
@@ -32,6 +33,7 @@ flattened_newtab_events AS (
     document_id,
     submission_timestamp,
     normalized_country_code,
+    experiment_branch,
     unnested_events.name AS event_name,
     mozfun.map.get_key(unnested_events.extra, 'corpus_item_id') AS corpus_item_id,
     SAFE_CAST(mozfun.map.get_key(unnested_events.extra, 'position') AS INT64) AS position,
@@ -53,6 +55,7 @@ flattened_newtab_events AS (
 raw_grouped_totals AS (
   SELECT
     normalized_country_code,
+    experiment_branch,
     corpus_item_id,
     position,
     format,
@@ -64,6 +67,7 @@ raw_grouped_totals AS (
     flattened_newtab_events
   GROUP BY
     normalized_country_code,
+    experiment_branch,
     corpus_item_id,
     position,
     format,
@@ -88,6 +92,7 @@ propensity_weights AS (
 section_events AS (
   SELECT
     rw.normalized_country_code,
+    rw.experiment_branch,
     rw.corpus_item_id,
     rw.raw_impression_count,
     -- apply propensity scaling to impressions only
@@ -130,6 +135,7 @@ section_events AS (
 non_section_events AS (
   SELECT
     normalized_country_code,
+    experiment_branch,
     corpus_item_id,
     raw_impression_count,
     raw_impression_count AS adjusted_impression_count, -- pass through unchanged
@@ -157,6 +163,7 @@ aggregated_events AS (
   SELECT
     fe.corpus_item_id,
     fe.normalized_country_code,
+    fe.experiment_branch,
     SAFE_CAST(SUM(adjusted_impression_count) AS INT64) AS impression_count,
     SUM(click_count) AS click_count,
     SUM(report_count) AS report_count
@@ -164,7 +171,8 @@ aggregated_events AS (
     combined_events fe
   GROUP BY
     1,
-    2
+    2,
+    3
 ),
 /* Aggregate clicks, impressions, and reports across all countries. */
 global_aggregates AS (
@@ -184,9 +192,9 @@ country_aggregates AS (
   SELECT
     corpus_item_id,
     normalized_country_code AS region,
-    impression_count,
-    click_count,
-    report_count
+    SUM(impression_count) AS impression_count,
+    SUM(click_count) AS click_count,
+    SUM(report_count) AS report_count
   FROM
     aggregated_events
   WHERE
@@ -206,6 +214,26 @@ country_aggregates AS (
       'ES',
       'IT'
     )
+  GROUP BY
+    corpus_item_id,
+    region
+),
+/* Add experiment-specific German feed rows using the existing region field. */
+experiment_region_aggregates AS (
+  SELECT
+    corpus_item_id,
+    CONCAT(normalized_country_code, '-', experiment_branch) AS region,
+    SUM(impression_count) AS impression_count,
+    SUM(click_count) AS click_count,
+    SUM(report_count) AS report_count
+  FROM
+    aggregated_events
+  WHERE
+    experiment_branch IS NOT NULL
+    AND normalized_country_code IN ('DE', 'CH', 'AT', 'BE')
+  GROUP BY
+    corpus_item_id,
+    region
 ),
 /* Combine the "global" (no region) with the "regional" breakdown. */
 combined_results AS (
@@ -218,6 +246,11 @@ combined_results AS (
     *
   FROM
     country_aggregates
+  UNION ALL
+  SELECT
+    *
+  FROM
+    experiment_region_aggregates
 )
 SELECT
   *

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
@@ -259,8 +259,7 @@ FROM
 ORDER BY
   impression_count DESC
 LIMIT
-  -- This LIMIT was derived from the 4 MB payload size cap in Merino, the observed average
-  -- record size of ~113 bytes, and recall measurements. At ~20k rows the JSON blob stays
-  -- well below 4 MB while still retaining >99.9% of fresh impressions globally. Smaller
-  -- countries with lower traffic, like BE, still maintain an acceptable recall of about 97%.
-  20000;
+  -- This LIMIT was derived from the 5 MB payload size cap in Merino, the observed average
+  -- record size of ~113 bytes, and recall measurements. At ~25k rows the JSON blob stays
+  -- under 5 MB while preserving more lower-impression rows after adding DE experiment rows.
+  25000;

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
@@ -1,18 +1,39 @@
-WITH private_pings AS (
+WITH experiment_configs AS (
   SELECT
-    submission_timestamp,
-    document_id,
-    events,
-    mozfun.newtab.surface_id_country(
-      metrics.string.newtab_content_surface_id,
-      NULL,
-      metrics.string.newtab_content_country
-    ) AS normalized_country_code,
-    NULLIF(metrics.string.newtab_content_experiment_branch, '') AS experiment_branch
+    *
   FROM
-    `moz-fx-data-shared-prod.firefox_desktop_live.newtab_content_v1`
-  WHERE
-    submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+    UNNEST([STRUCT('DE' AS region, 'publisher-constraint-in-germany' AS experiment_slug)])
+),
+private_pings AS (
+  SELECT
+    p.submission_timestamp,
+    p.document_id,
+    p.events,
+    p.normalized_country_code,
+    ec.experiment_slug,
+    IF(ec.experiment_slug IS NOT NULL, p.experiment_branch, NULL) AS experiment_branch
+  FROM
+    (
+      SELECT
+        submission_timestamp,
+        document_id,
+        events,
+        mozfun.newtab.surface_id_country(
+          metrics.string.newtab_content_surface_id,
+          NULL,
+          metrics.string.newtab_content_country
+        ) AS normalized_country_code,
+        NULLIF(metrics.string.newtab_content_experiment_name, '') AS experiment_slug,
+        NULLIF(metrics.string.newtab_content_experiment_branch, '') AS experiment_branch
+      FROM
+        `moz-fx-data-shared-prod.firefox_desktop_live.newtab_content_v1`
+      WHERE
+        submission_timestamp > TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 DAY)
+    ) p
+  LEFT JOIN
+    experiment_configs ec
+    ON ec.region = p.normalized_country_code
+    AND ec.experiment_slug = p.experiment_slug
 ),
 deduplicated_pings AS (
   SELECT
@@ -33,6 +54,7 @@ flattened_newtab_events AS (
     document_id,
     submission_timestamp,
     normalized_country_code,
+    experiment_slug,
     experiment_branch,
     unnested_events.name AS event_name,
     mozfun.map.get_key(unnested_events.extra, 'corpus_item_id') AS corpus_item_id,
@@ -55,6 +77,7 @@ flattened_newtab_events AS (
 raw_grouped_totals AS (
   SELECT
     normalized_country_code,
+    experiment_slug,
     experiment_branch,
     corpus_item_id,
     position,
@@ -67,6 +90,7 @@ raw_grouped_totals AS (
     flattened_newtab_events
   GROUP BY
     normalized_country_code,
+    experiment_slug,
     experiment_branch,
     corpus_item_id,
     position,
@@ -92,6 +116,7 @@ propensity_weights AS (
 section_events AS (
   SELECT
     rw.normalized_country_code,
+    rw.experiment_slug,
     rw.experiment_branch,
     rw.corpus_item_id,
     rw.raw_impression_count,
@@ -135,6 +160,7 @@ section_events AS (
 non_section_events AS (
   SELECT
     normalized_country_code,
+    experiment_slug,
     experiment_branch,
     corpus_item_id,
     raw_impression_count,
@@ -163,6 +189,7 @@ aggregated_events AS (
   SELECT
     fe.corpus_item_id,
     fe.normalized_country_code,
+    fe.experiment_slug,
     fe.experiment_branch,
     SAFE_CAST(SUM(adjusted_impression_count) AS INT64) AS impression_count,
     SUM(click_count) AS click_count,
@@ -172,7 +199,8 @@ aggregated_events AS (
   GROUP BY
     1,
     2,
-    3
+    3,
+    4
 ),
 /* Aggregate clicks, impressions, and reports across all countries. */
 global_aggregates AS (
@@ -218,19 +246,19 @@ country_aggregates AS (
     corpus_item_id,
     region
 ),
-/* Add de_DE experiment-specific rows using the existing region field. */
+/* Add configured experiment-specific rows using the existing region field. */
 experiment_region_aggregates AS (
   SELECT
     corpus_item_id,
-    CONCAT(normalized_country_code, '-', experiment_branch) AS region,
+    CONCAT(normalized_country_code, '-', experiment_slug, '-', experiment_branch) AS region,
     SUM(impression_count) AS impression_count,
     SUM(click_count) AS click_count,
     SUM(report_count) AS report_count
   FROM
     aggregated_events
   WHERE
-    experiment_branch IS NOT NULL
-    AND normalized_country_code = 'DE'
+    experiment_slug IS NOT NULL
+    AND experiment_branch IS NOT NULL
   GROUP BY
     corpus_item_id,
     region
@@ -251,11 +279,33 @@ combined_results AS (
     *
   FROM
     experiment_region_aggregates
+),
+removed_items AS (
+  SELECT DISTINCT
+    approved_corpus_item_external_id AS corpus_item_id
+  FROM
+    `moz-fx-data-shared-prod.snowflake_migration_derived.section_items_v1`
+  WHERE
+    event_name = 'section_item_removed'
+    AND source = 'MANUAL'
+    AND DATE(happened_at) > DATE_SUB(CURRENT_DATE(), INTERVAL 60 DAY)
+    AND approved_corpus_item_external_id IS NOT NULL
+),
+filtered_results AS (
+  SELECT
+    cr.*
+  FROM
+    combined_results cr
+  LEFT JOIN
+    removed_items ri
+    USING (corpus_item_id)
+  WHERE
+    NOT (ri.corpus_item_id IS NOT NULL AND cr.impression_count < 600)
 )
 SELECT
   *
 FROM
-  combined_results
+  filtered_results
 ORDER BY
   impression_count DESC
 LIMIT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/schema.yaml
@@ -25,5 +25,5 @@ fields:
 - mode: NULLABLE
   name: region
   type: STRING
-  description: The two-letter ISO 3166-1 country code used by Merino regional ranking, or for German
-    feed experiment-specific rows, the country code suffixed with the experiment branch.
+  description: The two-letter ISO 3166-1 country code used by Merino regional ranking, or for de_DE
+    experiment-specific rows, the DE region suffixed with the experiment branch.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/schema.yaml
@@ -25,6 +25,5 @@ fields:
 - mode: NULLABLE
   name: region
   type: STRING
-  description: !include-field-description
-    file: sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
-    field: region
+  description: The two-letter ISO 3166-1 country code used by Merino regional ranking, or for German
+    feed experiment-specific rows, the country code suffixed with the experiment branch.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/schema.yaml
@@ -25,5 +25,5 @@ fields:
 - mode: NULLABLE
   name: region
   type: STRING
-  description: The two-letter ISO 3166-1 country code used by Merino regional ranking, or for de_DE
-    experiment-specific rows, the DE region suffixed with the experiment branch.
+  description: The two-letter ISO 3166-1 country code used by Merino regional ranking, or for configured
+    experiment-specific rows, the region suffixed with the experiment slug and branch.

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Newtab Merino Priors
 description: |-
   Queries New Tab stats used by Merino to calculate Thompson sampling priors.
   These determine how new items (without engagement data) are ranked on New Tab.
-  German feed experiment rows are emitted with region values suffixed by experiment branch.
+  de_DE experiment rows are emitted with region values suffixed by experiment branch.
 owners:
 - mmiermans@mozilla.com
 - rrando@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
@@ -2,6 +2,7 @@ friendly_name: Newtab Merino Priors
 description: |-
   Queries New Tab stats used by Merino to calculate Thompson sampling priors.
   These determine how new items (without engagement data) are ranked on New Tab.
+  German feed experiment rows are emitted with region values suffixed by experiment branch.
 owners:
 - mmiermans@mozilla.com
 - rrando@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/metadata.yaml
@@ -2,7 +2,7 @@ friendly_name: Newtab Merino Priors
 description: |-
   Queries New Tab stats used by Merino to calculate Thompson sampling priors.
   These determine how new items (without engagement data) are ranked on New Tab.
-  de_DE experiment rows are emitted with region values suffixed by experiment branch.
+  Configured experiment rows are emitted with region values suffixed by experiment slug and branch.
 owners:
 - mmiermans@mozilla.com
 - rrando@mozilla.com

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
@@ -276,7 +276,7 @@ experiment_flattened_newtab_events AS (
   WHERE
     event.category IN ('pocket', 'newtab_content')
     AND event.name IN ('impression', 'click')
-    AND dp.region IS NOT NULL
+    AND dp.region = 'DE'
     AND mozfun.map.get_key(event.extra, 'corpus_item_id') IS NOT NULL
 ),
 experiment_base AS (

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
@@ -221,6 +221,205 @@ global_final AS (
     global_impressions_per_item gip
   CROSS JOIN
     global_total_impressions_per_day gtipd
+),
+experiment_target_regions AS (
+  SELECT
+    region
+  FROM
+    UNNEST(['DE', 'CH', 'AT', 'BE']) AS region
+),
+experiment_private_pings AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    submission_timestamp,
+    document_id,
+    events,
+    mozfun.newtab.surface_id_country(
+      metrics.string.newtab_content_surface_id,
+      NULL,
+      metrics.string.newtab_content_country
+    ) AS region,
+    NULLIF(metrics.string.newtab_content_experiment_branch, '') AS experiment_branch
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop.newtab_content`
+  WHERE
+    DATE(submission_timestamp)
+    BETWEEN (SELECT start_date FROM params)
+    AND (SELECT end_date FROM params)
+    AND NULLIF(metrics.string.newtab_content_experiment_branch, '') IS NOT NULL
+),
+experiment_deduplicated_pings AS (
+  SELECT
+    *
+  FROM
+    experiment_private_pings
+  QUALIFY
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        submission_date,
+        document_id
+      ORDER BY
+        submission_timestamp DESC
+    ) = 1
+),
+experiment_flattened_newtab_events AS (
+  SELECT
+    dp.submission_date,
+    dp.region,
+    dp.experiment_branch,
+    event.name AS event_name,
+    mozfun.map.get_key(event.extra, 'corpus_item_id') AS corpus_item_id
+  FROM
+    experiment_deduplicated_pings dp
+  CROSS JOIN
+    UNNEST(dp.events) AS event
+  WHERE
+    event.category IN ('pocket', 'newtab_content')
+    AND event.name IN ('impression', 'click')
+    AND dp.region IS NOT NULL
+    AND mozfun.map.get_key(event.extra, 'corpus_item_id') IS NOT NULL
+),
+experiment_base AS (
+  SELECT
+    submission_date,
+    corpus_item_id,
+    region,
+    experiment_branch,
+    SUM(CASE WHEN event_name = 'impression' THEN 1 ELSE 0 END) AS impression_count,
+    SUM(CASE WHEN event_name = 'click' THEN 1 ELSE 0 END) AS click_count
+  FROM
+    experiment_flattened_newtab_events
+  GROUP BY
+    submission_date,
+    corpus_item_id,
+    region,
+    experiment_branch
+),
+experiment_filtered_base AS (
+  SELECT
+    b.submission_date,
+    b.corpus_item_id,
+    b.region,
+    b.experiment_branch,
+    b.impression_count,
+    b.click_count
+  FROM
+    experiment_base b
+  INNER JOIN
+    corpus_items c
+    ON b.corpus_item_id = c.corpus_item_id
+),
+experiment_target_branches AS (
+  SELECT DISTINCT
+    experiment_branch
+  FROM
+    experiment_filtered_base
+),
+experiment_aggregated_events AS (
+  SELECT
+    corpus_item_id,
+    region,
+    experiment_branch,
+    SUM(impression_count) AS impression_count,
+    SUM(click_count) AS click_count
+  FROM
+    experiment_filtered_base
+  GROUP BY
+    corpus_item_id,
+    region,
+    experiment_branch
+),
+experiment_per_region_ctr AS (
+  SELECT
+    corpus_item_id,
+    region,
+    experiment_branch,
+    SAFE_DIVIDE(click_count, impression_count) AS ctr,
+    impression_count,
+    click_count
+  FROM
+    experiment_aggregated_events
+  WHERE
+    impression_count > 2000
+),
+experiment_per_region_impressions_per_item AS (
+  SELECT
+    region,
+    experiment_branch,
+    ROUND(AVG(impression_count)) AS impressions_per_item
+  FROM
+    experiment_aggregated_events
+  GROUP BY
+    region,
+    experiment_branch
+),
+experiment_ranked_per_region AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (PARTITION BY region, experiment_branch ORDER BY click_count DESC) AS rank
+  FROM
+    experiment_per_region_ctr
+),
+experiment_per_region_stats AS (
+  SELECT
+    region,
+    experiment_branch,
+    AVG(CASE WHEN rank <= 10 THEN ctr END) AS average_ctr_top10_items,
+    AVG(CASE WHEN rank <= 2 THEN ctr END) AS average_ctr_top2_items
+  FROM
+    experiment_ranked_per_region
+  GROUP BY
+    region,
+    experiment_branch
+),
+experiment_daily_region_totals AS (
+  SELECT
+    submission_date,
+    region,
+    experiment_branch,
+    SUM(impression_count) AS total_impressions
+  FROM
+    experiment_filtered_base
+  GROUP BY
+    submission_date,
+    region,
+    experiment_branch
+),
+experiment_per_region_total_impressions_per_day AS (
+  SELECT
+    tr.region,
+    tb.experiment_branch,
+    ROUND(AVG(COALESCE(drt.total_impressions, 0))) AS total_impressions_per_day
+  FROM
+    experiment_target_regions tr
+  CROSS JOIN
+    experiment_target_branches tb
+  CROSS JOIN
+    date_span ds
+  LEFT JOIN
+    experiment_daily_region_totals drt
+    ON drt.region = tr.region
+    AND drt.experiment_branch = tb.experiment_branch
+    AND drt.submission_date = ds.day
+  GROUP BY
+    tr.region,
+    tb.experiment_branch
+),
+experiment_per_region_final AS (
+  SELECT
+    CONCAT(s.region, '-', s.experiment_branch) AS region,
+    s.average_ctr_top10_items,
+    s.average_ctr_top2_items,
+    i.impressions_per_item,
+    d.total_impressions_per_day
+  FROM
+    experiment_per_region_stats s
+  JOIN
+    experiment_per_region_impressions_per_item i
+    USING (region, experiment_branch)
+  JOIN
+    experiment_per_region_total_impressions_per_day d
+    USING (region, experiment_branch)
 )
 SELECT
   region,
@@ -241,5 +440,14 @@ SELECT
   total_impressions_per_day
 FROM
   global_final
+UNION ALL
+SELECT
+  region,
+  average_ctr_top10_items,
+  average_ctr_top2_items,
+  impressions_per_item,
+  total_impressions_per_day
+FROM
+  experiment_per_region_final
 ORDER BY
   impressions_per_item DESC;

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
@@ -226,7 +226,7 @@ experiment_target_regions AS (
   SELECT
     region
   FROM
-    UNNEST(['DE', 'CH', 'AT', 'BE']) AS region
+    UNNEST(['DE']) AS region
 ),
 experiment_private_pings AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
@@ -17,6 +17,12 @@ target_regions AS (
   FROM
     UNNEST(['US', 'CA', 'DE', 'CH', 'AT', 'GB', 'IE', 'BE', 'PL', 'FR', 'ES', 'IT']) AS region
 ),
+experiment_configs AS (
+  SELECT
+    *
+  FROM
+    UNNEST([STRUCT('DE' AS region, 'publisher-constraint-in-germany' AS experiment_slug)])
+),
 corpus_items AS (
   SELECT DISTINCT
     corpus_item_id
@@ -222,31 +228,42 @@ global_final AS (
   CROSS JOIN
     global_total_impressions_per_day gtipd
 ),
-experiment_target_regions AS (
-  SELECT
-    region
-  FROM
-    UNNEST(['DE']) AS region
-),
 experiment_private_pings AS (
   SELECT
-    DATE(submission_timestamp) AS submission_date,
-    submission_timestamp,
-    document_id,
-    events,
-    mozfun.newtab.surface_id_country(
-      metrics.string.newtab_content_surface_id,
-      NULL,
-      metrics.string.newtab_content_country
-    ) AS region,
-    NULLIF(metrics.string.newtab_content_experiment_branch, '') AS experiment_branch
+    p.submission_date,
+    p.submission_timestamp,
+    p.document_id,
+    p.events,
+    p.region,
+    ec.experiment_slug,
+    p.experiment_branch
   FROM
-    `moz-fx-data-shared-prod.firefox_desktop.newtab_content`
+    (
+      SELECT
+        DATE(submission_timestamp) AS submission_date,
+        submission_timestamp,
+        document_id,
+        events,
+        mozfun.newtab.surface_id_country(
+          metrics.string.newtab_content_surface_id,
+          NULL,
+          metrics.string.newtab_content_country
+        ) AS region,
+        NULLIF(metrics.string.newtab_content_experiment_name, '') AS experiment_slug,
+        NULLIF(metrics.string.newtab_content_experiment_branch, '') AS experiment_branch
+      FROM
+        `moz-fx-data-shared-prod.firefox_desktop.newtab_content`
+      WHERE
+        DATE(submission_timestamp)
+        BETWEEN (SELECT start_date FROM params)
+        AND (SELECT end_date FROM params)
+    ) p
+  JOIN
+    experiment_configs ec
+    ON ec.region = p.region
+    AND ec.experiment_slug = p.experiment_slug
   WHERE
-    DATE(submission_timestamp)
-    BETWEEN (SELECT start_date FROM params)
-    AND (SELECT end_date FROM params)
-    AND NULLIF(metrics.string.newtab_content_experiment_branch, '') IS NOT NULL
+    p.experiment_branch IS NOT NULL
 ),
 experiment_deduplicated_pings AS (
   SELECT
@@ -266,6 +283,7 @@ experiment_flattened_newtab_events AS (
   SELECT
     dp.submission_date,
     dp.region,
+    dp.experiment_slug,
     dp.experiment_branch,
     event.name AS event_name,
     mozfun.map.get_key(event.extra, 'corpus_item_id') AS corpus_item_id
@@ -276,7 +294,6 @@ experiment_flattened_newtab_events AS (
   WHERE
     event.category IN ('pocket', 'newtab_content')
     AND event.name IN ('impression', 'click')
-    AND dp.region = 'DE'
     AND mozfun.map.get_key(event.extra, 'corpus_item_id') IS NOT NULL
 ),
 experiment_base AS (
@@ -284,6 +301,7 @@ experiment_base AS (
     submission_date,
     corpus_item_id,
     region,
+    experiment_slug,
     experiment_branch,
     SUM(CASE WHEN event_name = 'impression' THEN 1 ELSE 0 END) AS impression_count,
     SUM(CASE WHEN event_name = 'click' THEN 1 ELSE 0 END) AS click_count
@@ -293,6 +311,7 @@ experiment_base AS (
     submission_date,
     corpus_item_id,
     region,
+    experiment_slug,
     experiment_branch
 ),
 experiment_filtered_base AS (
@@ -300,6 +319,7 @@ experiment_filtered_base AS (
     b.submission_date,
     b.corpus_item_id,
     b.region,
+    b.experiment_slug,
     b.experiment_branch,
     b.impression_count,
     b.click_count
@@ -309,8 +329,10 @@ experiment_filtered_base AS (
     corpus_items c
     ON b.corpus_item_id = c.corpus_item_id
 ),
-experiment_target_branches AS (
+experiment_target_enrollments AS (
   SELECT DISTINCT
+    region,
+    experiment_slug,
     experiment_branch
   FROM
     experiment_filtered_base
@@ -319,6 +341,7 @@ experiment_aggregated_events AS (
   SELECT
     corpus_item_id,
     region,
+    experiment_slug,
     experiment_branch,
     SUM(impression_count) AS impression_count,
     SUM(click_count) AS click_count
@@ -327,12 +350,14 @@ experiment_aggregated_events AS (
   GROUP BY
     corpus_item_id,
     region,
+    experiment_slug,
     experiment_branch
 ),
 experiment_per_region_ctr AS (
   SELECT
     corpus_item_id,
     region,
+    experiment_slug,
     experiment_branch,
     SAFE_DIVIDE(click_count, impression_count) AS ctr,
     impression_count,
@@ -345,24 +370,34 @@ experiment_per_region_ctr AS (
 experiment_per_region_impressions_per_item AS (
   SELECT
     region,
+    experiment_slug,
     experiment_branch,
     ROUND(AVG(impression_count)) AS impressions_per_item
   FROM
     experiment_aggregated_events
   GROUP BY
     region,
+    experiment_slug,
     experiment_branch
 ),
 experiment_ranked_per_region AS (
   SELECT
     *,
-    ROW_NUMBER() OVER (PARTITION BY region, experiment_branch ORDER BY click_count DESC) AS rank
+    ROW_NUMBER() OVER (
+      PARTITION BY
+        region,
+        experiment_slug,
+        experiment_branch
+      ORDER BY
+        click_count DESC
+    ) AS rank
   FROM
     experiment_per_region_ctr
 ),
 experiment_per_region_stats AS (
   SELECT
     region,
+    experiment_slug,
     experiment_branch,
     AVG(CASE WHEN rank <= 10 THEN ctr END) AS average_ctr_top10_items,
     AVG(CASE WHEN rank <= 2 THEN ctr END) AS average_ctr_top2_items
@@ -370,12 +405,14 @@ experiment_per_region_stats AS (
     experiment_ranked_per_region
   GROUP BY
     region,
+    experiment_slug,
     experiment_branch
 ),
 experiment_daily_region_totals AS (
   SELECT
     submission_date,
     region,
+    experiment_slug,
     experiment_branch,
     SUM(impression_count) AS total_impressions
   FROM
@@ -383,31 +420,33 @@ experiment_daily_region_totals AS (
   GROUP BY
     submission_date,
     region,
+    experiment_slug,
     experiment_branch
 ),
 experiment_per_region_total_impressions_per_day AS (
   SELECT
-    tr.region,
-    tb.experiment_branch,
+    te.region,
+    te.experiment_slug,
+    te.experiment_branch,
     ROUND(AVG(COALESCE(drt.total_impressions, 0))) AS total_impressions_per_day
   FROM
-    experiment_target_regions tr
-  CROSS JOIN
-    experiment_target_branches tb
+    experiment_target_enrollments te
   CROSS JOIN
     date_span ds
   LEFT JOIN
     experiment_daily_region_totals drt
-    ON drt.region = tr.region
-    AND drt.experiment_branch = tb.experiment_branch
+    ON drt.region = te.region
+    AND drt.experiment_slug = te.experiment_slug
+    AND drt.experiment_branch = te.experiment_branch
     AND drt.submission_date = ds.day
   GROUP BY
-    tr.region,
-    tb.experiment_branch
+    te.region,
+    te.experiment_slug,
+    te.experiment_branch
 ),
 experiment_per_region_final AS (
   SELECT
-    CONCAT(s.region, '-', s.experiment_branch) AS region,
+    CONCAT(s.region, '-', s.experiment_slug, '-', s.experiment_branch) AS region,
     s.average_ctr_top10_items,
     s.average_ctr_top2_items,
     i.impressions_per_item,
@@ -416,10 +455,10 @@ experiment_per_region_final AS (
     experiment_per_region_stats s
   JOIN
     experiment_per_region_impressions_per_item i
-    USING (region, experiment_branch)
+    USING (region, experiment_slug, experiment_branch)
   JOIN
     experiment_per_region_total_impressions_per_day d
-    USING (region, experiment_branch)
+    USING (region, experiment_slug, experiment_branch)
 )
 SELECT
   region,

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/schema.yaml
@@ -2,8 +2,8 @@ fields:
 - mode: NULLABLE
   name: region
   type: STRING
-  description: The two-letter ISO 3166-1 country code used by Merino regional priors, or for German
-    feed experiment-specific rows, the country code suffixed with the experiment branch.
+  description: The two-letter ISO 3166-1 country code used by Merino regional priors, or for de_DE
+    experiment-specific rows, the DE region suffixed with the experiment branch.
 - mode: NULLABLE
   name: average_ctr_top2_items
   type: FLOAT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/schema.yaml
@@ -2,9 +2,8 @@ fields:
 - mode: NULLABLE
   name: region
   type: STRING
-  description: !include-field-description
-    file: sql/moz-fx-data-shared-prod/telemetry_derived/telemetry_derived.yaml
-    field: region
+  description: The two-letter ISO 3166-1 country code used by Merino regional priors, or for German
+    feed experiment-specific rows, the country code suffixed with the experiment branch.
 - mode: NULLABLE
   name: average_ctr_top2_items
   type: FLOAT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/schema.yaml
@@ -2,8 +2,8 @@ fields:
 - mode: NULLABLE
   name: region
   type: STRING
-  description: The two-letter ISO 3166-1 country code used by Merino regional priors, or for de_DE
-    experiment-specific rows, the DE region suffixed with the experiment branch.
+  description: The two-letter ISO 3166-1 country code used by Merino regional priors, or for configured
+    experiment-specific rows, the region suffixed with the experiment slug and branch.
 - mode: NULLABLE
   name: average_ctr_top2_items
   type: FLOAT


### PR DESCRIPTION
## Description

 This PR modifies the Merino engagement artifact to add experiment-stratified rows for the `de_DE` content experiment. The existing schema is unchanged: experiment-specific rows are emitted by suffixing the `region` value as
  `DE-<content_experiment_branch>`. The existing plain `DE` rows are still produced and continue to aggregate across all experiment branches, including clients with no experiment branch.

  This also updates the Merino priors artifact to produce matching branch-stratified `DE-<content_experiment_branch>` rows.

  One implementation note: the existing priors query reads from `firefox_desktop_derived.newtab_content_items_daily_combined_v1`, which does not expose `newtab_content_experiment_branch`. To keep this change local to the Merino artifacts
  and avoid changing the schema/grain of that shared daily table, this PR computes the experiment-specific priors from raw `firefox_desktop.newtab_content` pings. The normal non-experiment priors path remains unchanged.


## Related Tickets & Documents
* [AIMOD-1384]


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[AIMOD-1384]: https://mozilla-hub.atlassian.net/browse/AIMOD-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ