### PR TITLE
chore(DENG-11344): complete backfill for fenix_derived.metrics_clients_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_daily_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: DENG-11344
   watchers:
   - nalexander@mozilla.com
-  status: Initiate
+  status: Complete
 
 2026-05-15:
   start_date: 2026-03-30


### PR DESCRIPTION
This completes backfill of fenix_derived.metrics_clients_daily_v1

## Related Tickets & Documents
* DENG-11344
* https://mozilla-hub.atlassian.net/browse/DENG-11397?focusedCommentId=1571179