### PR TITLE
feat(DENG-11344): Aggregate Fenix [marketing] notifications allowed i…

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/metrics_clients_last_seen_v1/backfill.yaml
@@ -1,10 +1,18 @@
+2026-07-22:
+  start_date: 2026-04-01
+  end_date: 2026-07-22
+  reason: DENG-11344
+  watchers:
+  - nalexander@mozilla.com
+  status: Initiate
+
 2026-07-10:
   start_date: 2026-04-01
   end_date: 2026-07-10
   reason: DENG-11344
   watchers:
   - nalexander@mozilla.com
-  status: Initiate
+  status: Cancelled
 
 2026-05-15:
   start_date: 2026-03-30


### PR DESCRIPTION
…nto `metrics_clients_last_seen`.

Backfill from April 2026.  Fenix notification experiments started in May, so this should give sufficient historical data for analysis.

This ended up depending on
https://mozilla-hub.atlassian.net/browse/DENG-11397 which fixed the 28-day windowing for `metrics_clients_last_seen`.
https://github.com/mozilla/bigquery-etl/pull/9716 then completed the backfill for `metrics_clients_daily`, which should allow `metrics_clients_last_seen` to backfill.

Finally, we'll need to follow-up to backfill downstream tables including `clients_last_seen_joined`.

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
