### PR TITLE
Fix various bugs in the shredder_progress view

### DIFF
--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
@@ -112,13 +112,31 @@ successful_jobs AS (
     AND state = "DONE"
     AND error_result IS NULL
 ),
+-- When each run finished copying a task's shredded data into place. A task is shredded
+-- again by every run, all within the query window below, so this is what attributes the
+-- shredding query jobs to a run: a query belongs to the run whose copy finished first
+-- among those that finished at or after it.
+copy_completed AS (
+  SELECT
+    REGEXP_REPLACE(task_id, r"__sample_[0-9_]+$", "") AS task_id,
+    end_date,
+    MAX(job_created) AS copied_at,
+  FROM
+    `moz-fx-data-shredder.shredder_state.shredder_state`
+  GROUP BY
+    task_id,
+    end_date
+),
 -- Sampled tables are shredded by writing survivors to a per-sample temp table in
 -- shredder_tmp and then copying it into place. shredder_state records only the copy
--- job, which reports no bytes or slot_ms, so the query jobs that do the actual work
--- are recovered here. The temp table name encodes the task it belongs to:
+-- job, which reports no bytes or slot_ms, so the query jobs that do the actual work are
+-- recovered here. The temp table name encodes the task:
 -- <dataset>__<table>_<YYYYMMDD>__sample_N_M maps back to
--- moz-fx-data-shared-prod.<dataset>.<table>$<YYYYMMDD>.
-shredder_tmp_jobs AS (
+-- moz-fx-data-shared-prod.<dataset>.<table>$<YYYYMMDD>. The project is hardcoded on
+-- purpose: sampling is only used for the largest tables, which all live in
+-- moz-fx-data-shared-prod, so a sampled table in another project is unlikely enough not
+-- to warrant deriving the project here.
+shredder_query_jobs AS (
   SELECT
     CONCAT(
       "moz-fx-data-shared-prod.",
@@ -130,8 +148,10 @@ shredder_tmp_jobs AS (
         r"$\1"
       )
     ) AS task_id,
-    SUM(total_bytes_processed) AS bytes_complete,
-    SUM(total_slot_ms) AS slot_ms,
+    job_id,
+    creation_time,
+    total_bytes_processed,
+    total_slot_ms,
   FROM
     `moz-fx-data-shared-prod.monitoring_derived.jobs_by_organization_v1`
   WHERE
@@ -141,8 +161,39 @@ shredder_tmp_jobs AS (
     AND destination_table.project_id = "moz-fx-data-shredder"
     AND destination_table.dataset_id = "shredder_tmp"
     AND REGEXP_CONTAINS(destination_table.table_id, r"__sample_[0-9_]+$")
+),
+shredder_tmp_jobs AS (
+  SELECT
+    task_id,
+    end_date,
+    SUM(total_bytes_processed) AS bytes_complete,
+    SUM(total_slot_ms) AS slot_ms,
+  FROM
+    -- attribute each query job to the run whose copy completed first among those that
+    -- completed at or after it, so a task re-shredded by a later run is not counted
+    -- under this run
+    (
+      SELECT
+        task_id,
+        ARRAY_AGG(end_date ORDER BY copied_at LIMIT 1)[OFFSET(0)] AS end_date,
+        total_bytes_processed,
+        total_slot_ms,
+      FROM
+        shredder_query_jobs
+      JOIN
+        copy_completed
+        USING (task_id)
+      WHERE
+        copied_at >= creation_time
+      GROUP BY
+        task_id,
+        job_id,
+        total_bytes_processed,
+        total_slot_ms
+    )
   GROUP BY
-    task_id
+    task_id,
+    end_date
 ),
 progress_by_target AS (
   SELECT
@@ -182,7 +233,7 @@ progress_by_target AS (
     USING (project_id, job_id)
   LEFT JOIN
     shredder_tmp_jobs AS tmp
-    USING (task_id)
+    USING (task_id, end_date)
   LEFT JOIN
     run_activity
     USING (airflow_task_id, end_date)

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
@@ -312,25 +312,31 @@ SELECT
     ),
     STRUCT(
       NULL AS actual,
-      -- SAFE guards against overflow when an early run projects an absurd interval;
-      -- such an estimate is meaningless anyway and returns NULL instead of failing
+      -- an early run can project an absurd interval; SAFE_DIVIDE, SAFE_CAST and
+      -- SAFE.TIMESTAMP_ADD each return NULL rather than failing on a zero divisor, an
+      -- out-of-range cast, or a timestamp overflow, since the estimate is meaningless then
       SAFE.TIMESTAMP_ADD(
         start_time,
-        INTERVAL CAST(
-          IFNULL(slot_ms_total / slot_ms_complete, 1) * seconds_complete AS INT64
+        INTERVAL SAFE_CAST(
+          IFNULL(SAFE_DIVIDE(slot_ms_total, slot_ms_complete), 1) * seconds_complete AS INT64
         ) SECOND
       ) AS estimate_by_slot_ms,
       SAFE.TIMESTAMP_ADD(
         start_time,
-        INTERVAL CAST(bytes_total / bytes_complete * seconds_complete AS INT64) SECOND
+        INTERVAL SAFE_CAST(
+          SAFE_DIVIDE(bytes_total, bytes_complete) * seconds_complete AS INT64
+        ) SECOND
       ) AS estimate_by_bytes,
       SAFE.TIMESTAMP_ADD(
         start_time,
-        INTERVAL CAST(tasks_total / tasks_complete * seconds_complete AS INT64) SECOND
+        INTERVAL SAFE_CAST(
+          SAFE_DIVIDE(tasks_total, tasks_complete) * seconds_complete AS INT64
+        ) SECOND
       ) AS estimate_by_tasks
     )
   ) AS completion_time,
-  slot_ms_total,
+  progress.slot_ms_total,
+  progress.slot_ms_total / 1000 / 60 / 60 slot_hours_total,
   bytes_total / POW(2, 50) AS petabytes_total,
   tasks_total,
 FROM

--- a/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
+++ b/sql/moz-fx-data-shared-prod/monitoring/shredder_progress/view.sql
@@ -37,9 +37,10 @@ shredder AS (
     -- newest job
     ARRAY_AGG(
       STRUCT(
-        -- a task with no shredder_state row for this run had nothing to shred.
-        -- since runs don't overlap per airflow task and an active run always has
-        -- an in-flight job, such a task is complete once the run is finished.
+        -- a task with no shredder_state row is either something the run had nothing to
+        -- shred for, or a task the run has not reached yet. These are only distinguished
+        -- once the run is finished (see run_activity), so no_work alone does not imply
+        -- complete for a run that is still writing shredder_state rows.
         job_created IS NULL AS no_work,
         -- job metadata over 28 days old is not queried
         job_created <= TIMESTAMP_SUB(CURRENT_TIMESTAMP, INTERVAL 28 DAY) AS job_too_old,
@@ -66,6 +67,27 @@ shredder AS (
     end_date,
     sampling_tasks.task_id
 ),
+-- A run is considered finished once it stops recording new shredder_state jobs. An
+-- in-progress run writes rows continuously (gaps of minutes), while a finished run's
+-- most recent job is hours to days old, so a generous 24 hour threshold separates the
+-- two. This gates the no_work assumption: only a finished run's tasks with no job can
+-- be assumed to have had nothing to shred rather than not being reached yet.
+run_activity AS (
+  SELECT
+    airflow_task_id,
+    end_date,
+    -- default to finished when a run recorded no jobs at all, so a run that genuinely
+    -- had nothing to shred anywhere is not stuck looking incomplete forever
+    IFNULL(
+      MAX(job_created) < TIMESTAMP_SUB(CURRENT_TIMESTAMP, INTERVAL 24 HOUR),
+      TRUE
+    ) AS run_finished,
+  FROM
+    shredder
+  GROUP BY
+    airflow_task_id,
+    end_date
+),
 jobs AS (
   SELECT
     creation_time,
@@ -90,27 +112,80 @@ successful_jobs AS (
     AND state = "DONE"
     AND error_result IS NULL
 ),
+-- Sampled tables are shredded by writing survivors to a per-sample temp table in
+-- shredder_tmp and then copying it into place. shredder_state records only the copy
+-- job, which reports no bytes or slot_ms, so the query jobs that do the actual work
+-- are recovered here. The temp table name encodes the task it belongs to:
+-- <dataset>__<table>_<YYYYMMDD>__sample_N_M maps back to
+-- moz-fx-data-shared-prod.<dataset>.<table>$<YYYYMMDD>.
+shredder_tmp_jobs AS (
+  SELECT
+    CONCAT(
+      "moz-fx-data-shared-prod.",
+      REGEXP_EXTRACT(destination_table.table_id, r"^(.+?)__"),
+      ".",
+      REGEXP_REPLACE(
+        REGEXP_EXTRACT(destination_table.table_id, r"^.+?__(.+)__sample_[0-9_]+$"),
+        r"_(\d{8})$",
+        r"$\1"
+      )
+    ) AS task_id,
+    SUM(total_bytes_processed) AS bytes_complete,
+    SUM(total_slot_ms) AS slot_ms,
+  FROM
+    `moz-fx-data-shared-prod.monitoring_derived.jobs_by_organization_v1`
+  WHERE
+    creation_time > TIMESTAMP_SUB(CURRENT_TIMESTAMP, INTERVAL 28 DAY)
+    AND state = "DONE"
+    AND error_result IS NULL
+    AND destination_table.project_id = "moz-fx-data-shredder"
+    AND destination_table.dataset_id = "shredder_tmp"
+    AND REGEXP_CONTAINS(destination_table.table_id, r"__sample_[0-9_]+$")
+  GROUP BY
+    task_id
+),
 progress_by_target AS (
   SELECT
     airflow_task_id,
     end_date,
-    MIN(IFNULL(start_time, job_created)) AS start_time,
-    MAX(end_time) AS end_time,
-    -- a task is complete if it had nothing to shred, if its job is too old for
-    -- metadata (assumed complete), or if its job finished
-    LOGICAL_AND(no_work OR job_too_old IS TRUE OR end_time IS NOT NULL) AS complete,
-    COUNTIF(no_work OR job_too_old IS TRUE OR end_time IS NOT NULL) AS tasks_complete,
+    MIN(IFNULL(job.start_time, job_created)) AS start_time,
+    MAX(job.end_time) AS end_time,
+    -- a task is complete if it had nothing to shred (only trusted once the run is
+    -- finished, otherwise the task may just not be reached yet), if its job is too old
+    -- for metadata (assumed complete), or if its copy job finished. The copy job is the
+    -- authoritative completion signal; a finished shredding query does not mean the
+    -- copy has run yet.
+    LOGICAL_AND(
+      (no_work AND run_finished)
+      OR job_too_old IS TRUE
+      OR job.end_time IS NOT NULL
+    ) AS complete,
+    COUNTIF(
+      (no_work AND run_finished)
+      OR job_too_old IS TRUE
+      OR job.end_time IS NOT NULL
+    ) AS tasks_complete,
     COUNT(*) AS tasks_total,
-    SUM(bytes_complete) AS bytes_complete,
+    -- copy jobs report no bytes/slot_ms, so fall back to the shredding query jobs
+    -- that wrote the survivors to shredder_tmp for the actual work done
+    SUM(IFNULL(job.bytes_complete, tmp.bytes_complete)) AS bytes_complete,
     -- count target_bytes once per table and source_bytes once per task
     MIN(target_bytes) + SUM(source_bytes) AS bytes_total,
-    SUM(slot_ms) AS slot_ms,
-    NULLIF(SUM(bytes_complete), 0) / SUM(slot_ms) AS bytes_per_slot_ms,
+    SUM(IFNULL(job.slot_ms, tmp.slot_ms)) AS slot_ms,
+    NULLIF(SUM(IFNULL(job.bytes_complete, tmp.bytes_complete)), 0) / SUM(
+      IFNULL(job.slot_ms, tmp.slot_ms)
+    ) AS bytes_per_slot_ms,
   FROM
     shredder
   LEFT JOIN
-    successful_jobs
+    successful_jobs AS job
     USING (project_id, job_id)
+  LEFT JOIN
+    shredder_tmp_jobs AS tmp
+    USING (task_id)
+  LEFT JOIN
+    run_activity
+    USING (airflow_task_id, end_date)
   GROUP BY
     target,
     airflow_task_id,
@@ -186,17 +261,19 @@ SELECT
     ),
     STRUCT(
       NULL AS actual,
-      TIMESTAMP_ADD(
+      -- SAFE guards against overflow when an early run projects an absurd interval;
+      -- such an estimate is meaningless anyway and returns NULL instead of failing
+      SAFE.TIMESTAMP_ADD(
         start_time,
         INTERVAL CAST(
           IFNULL(slot_ms_total / slot_ms_complete, 1) * seconds_complete AS INT64
         ) SECOND
       ) AS estimate_by_slot_ms,
-      TIMESTAMP_ADD(
+      SAFE.TIMESTAMP_ADD(
         start_time,
         INTERVAL CAST(bytes_total / bytes_complete * seconds_complete AS INT64) SECOND
       ) AS estimate_by_bytes,
-      TIMESTAMP_ADD(
+      SAFE.TIMESTAMP_ADD(
         start_time,
         INTERVAL CAST(tasks_total / tasks_complete * seconds_complete AS INT64) SECOND
       ) AS estimate_by_tasks


### PR DESCRIPTION
## Description

Found some bugs now that it's actually being used:
- timestamp for estimated completion time can overflow if sample count is low
- the per-sample id queries for queries with sampling are now considered
- non-started jobs were considered complete

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
