### PR TITLE
Update schemas for shredder sampling when copy fails

### DIFF
--- a/bigquery_etl/shredder/delete.py
+++ b/bigquery_etl/shredder/delete.py
@@ -13,7 +13,7 @@ from operator import attrgetter
 from textwrap import dedent
 from typing import Callable, Iterable, Optional, Tuple, Union
 
-from google.api_core.exceptions import NotFound
+from google.api_core.exceptions import BadRequest, NotFound
 from google.cloud import bigquery
 from google.cloud.bigquery import CopyJob, QueryJob
 
@@ -481,6 +481,20 @@ def delete_from_partition(
     )
 
 
+def _conform_intermediate_schemas(client, intermediate_tables, target_schema):
+    """Widen each intermediate table's schema to match target_schema.
+
+    Sampled shredding writes intermediates and then copies to the prod partition. If the prod
+    table's schema changes while the intermediate tables are being built, the schemas will diverge
+    and the copy will fail.
+    """
+    for table_id in intermediate_tables:
+        table = client.get_table(table_id)
+        if table.schema != target_schema:
+            table.schema = target_schema
+            client.update_table(table, ["schema"])
+
+
 def delete_from_partition_with_sampling(
     dry_run: bool,
     partition: Partition,
@@ -566,11 +580,34 @@ def delete_from_partition_with_sampling(
             f"{[str(t) for t in intermediate_tables]} to {target_table}"
         )
         if not dry_run:
-            copy_job = client.copy_table(
-                sources=intermediate_tables,
-                destination=target_table,
-                job_config=copy_job_config,
-            )
+
+            def run_copy():
+                job = client.copy_table(
+                    sources=intermediate_tables,
+                    destination=target_table,
+                    job_config=copy_job_config,
+                )
+                job.result()
+                return job
+
+            try:
+                copy_job = run_copy()
+            except BadRequest as e:
+                # If the source table's schema changes mid-sample deletion, the copy will fail.
+                # Conform the schemas if this happens so that the whole sample doesn't need to rerun.
+                # Best-effort based on the error message.
+                if "Incompatible table schemata" not in str(e):
+                    raise
+                logging.warning(
+                    f"Copy to {target_table} failed with incompatible schemas, "
+                    "conforming intermediate table schemas and retrying"
+                )
+                _conform_intermediate_schemas(
+                    client,
+                    intermediate_tables,
+                    client.get_table(destination_table_id).schema,
+                )
+                copy_job = run_copy()
             # simulate query job properties for logging
             copy_job.total_bytes_processed = sum(
                 [r.total_bytes_processed or 0 for r in results]

--- a/tests/shredder/test_delete.py
+++ b/tests/shredder/test_delete.py
@@ -2,7 +2,8 @@ import datetime
 from functools import partial
 from unittest.mock import ANY, Mock, patch
 
-from google.api_core.exceptions import NotFound
+import pytest
+from google.api_core.exceptions import BadRequest, NotFound
 
 from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.schema import Schema
@@ -242,6 +243,139 @@ def test_delete_from_partition_with_sampling_column_removal(mock_delete_from_par
         mock_client.copy_table.call_args.kwargs["destination"]
         == f"{v2_table_id}$20240101"
     )
+
+
+@patch("bigquery_etl.shredder.delete.delete_from_partition")
+def test_delete_from_partition_with_sampling_copy_succeeds(mock_delete_from_partition):
+    """
+    When the copy succeeds, intermediate table schemas are left untouched (no schema
+    conforming, i.e. no get_table/update_table calls for reconciliation).
+    """
+    mock_delete_from_partition.side_effect = lambda **kwargs: lambda client: Mock(
+        destination=f"proj.tmp.intermediate_{kwargs['sample_id_range'][0]}",
+        total_bytes_processed=1,
+    )
+
+    args = {**COMMON_DELETE_ARGS, "dry_run": False}
+    wait_for_job = shredder_delete.delete_from_partition_with_sampling(
+        **args,
+        partition=shredder_delete.Partition(
+            id="20240101", condition="", is_special=False
+        ),
+        sampling_parallelism=10,
+        sampling_batch_size=1,
+        task_id="proj.dataset.table_v1",
+    )
+
+    mock_client = Mock()
+    # get_table (for clustering) returns a normal table; copy succeeds
+    mock_client.get_table.return_value = Mock(clustering_fields=None)
+
+    wait_for_job.keywords["create_job"](mock_client)
+
+    # single copy attempt, and no schema reconciliation
+    assert mock_client.copy_table.call_count == 1
+    assert mock_client.update_table.call_count == 0
+
+
+@patch("bigquery_etl.shredder.delete.delete_from_partition")
+def test_delete_from_partition_with_sampling_conforms_on_copy_failure(
+    mock_delete_from_partition,
+):
+    """
+    If the copy fails with a schema mismatch, the intermediate tables are conformed
+    to the destination table's schema and the copy is retried, without requerying.
+    """
+    mock_delete_from_partition.side_effect = lambda **kwargs: lambda client: Mock(
+        destination=f"proj.tmp.intermediate_{kwargs['sample_id_range'][0]}",
+        total_bytes_processed=1,
+    )
+
+    args = {**COMMON_DELETE_ARGS, "dry_run": False}
+    wait_for_job = shredder_delete.delete_from_partition_with_sampling(
+        **args,
+        partition=shredder_delete.Partition(
+            id="20240101", condition="", is_special=False
+        ),
+        sampling_parallelism=10,
+        sampling_batch_size=1,
+        task_id="proj.dataset.table_v1",
+    )
+
+    # destination table schema is the superset the intermediates get conformed to
+    destination_schema = Schema(
+        {"fields": [{"name": "client_id", "type": "STRING", "mode": "NULLABLE"}]}
+    ).to_bigquery_schema()
+
+    mock_client = Mock()
+
+    # every intermediate table read during conforming has a schema different from
+    # the destination, so each gets an update
+    destination_table_id = shredder_delete.sql_table_id(COMMON_DELETE_ARGS["target"])
+
+    def get_table(table_id):
+        if table_id == destination_table_id:
+            return Mock(schema=destination_schema, clustering_fields=None)
+        return Mock(schema=[])  # intermediate table, differs from destination
+
+    mock_client.get_table.side_effect = get_table
+
+    # first copy fails with a schema mismatch, second succeeds
+    first_copy = Mock()
+    first_copy.result.side_effect = BadRequest("Incompatible table schemata")
+    second_copy = Mock()
+    mock_client.copy_table.side_effect = [first_copy, second_copy]
+
+    result = wait_for_job.keywords["create_job"](mock_client)
+
+    # copy was retried after conforming
+    assert mock_client.copy_table.call_count == 2
+    # all 100 intermediate tables were conformed to the destination schema
+    assert mock_client.update_table.call_count == 100
+    for call in mock_client.update_table.call_args_list:
+        table_arg, fields_arg = call.args
+        assert table_arg.schema == destination_schema
+        assert fields_arg == ["schema"]
+    # the retried (successful) copy job is returned
+    assert result is second_copy
+
+
+@patch("bigquery_etl.shredder.delete.delete_from_partition")
+def test_delete_from_partition_with_sampling_reraises_other_bad_request(
+    mock_delete_from_partition,
+):
+    """
+    A copy failure that isn't a schema mismatch is re-raised without conforming
+    schemas or retrying, so unrelated errors aren't masked by a misleading retry.
+    """
+    mock_delete_from_partition.side_effect = lambda **kwargs: lambda client: Mock(
+        destination=f"proj.tmp.intermediate_{kwargs['sample_id_range'][0]}",
+        total_bytes_processed=1,
+    )
+
+    args = {**COMMON_DELETE_ARGS, "dry_run": False}
+    wait_for_job = shredder_delete.delete_from_partition_with_sampling(
+        **args,
+        partition=shredder_delete.Partition(
+            id="20240101", condition="", is_special=False
+        ),
+        sampling_parallelism=10,
+        sampling_batch_size=1,
+        task_id="proj.dataset.table_v1",
+    )
+
+    mock_client = Mock()
+    mock_client.get_table.return_value = Mock(clustering_fields=None)
+    failed_copy = Mock()
+    failed_copy.result.side_effect = BadRequest("Cannot read a table without a schema")
+    mock_client.copy_table.return_value = failed_copy
+
+    with pytest.raises(BadRequest):
+        wait_for_job.keywords["create_job"](mock_client)
+
+    # no conforming, no retry
+    assert mock_client.copy_table.call_count == 1
+    assert mock_client.update_table.call_count == 0
 
 
 @patch("bigquery_etl.shredder.delete.list_partitions")


### PR DESCRIPTION
## Description

Shredder with sampling creates intermediate tables and then copies them into the prod table. I found that the copy job fails if the schema of the prod table changes mid-sample. This happened ~25 time last few runs for `firefox_desktop_stable.metrics_v1` and the consequence is that the sample set needs to be rerun, which is expensive.

Error is because the schema of the copied tables must match:
```
Incompatible table schemata between tables: moz-fx-data-shredder:shredder_tmp.firefox_desktop_stable__metrics_v1_20260609__sample_0_3, ...  
```

The change here is to update the schemas of the intermediate table if this happens so they all match

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
