### PR TITLE
Handle glean v2 schema in shredder

### DIFF
--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -20,8 +20,8 @@ from ..util.bigquery_id import qualified_table_id
 
 MOZDATA = "mozdata"
 SHARED_PROD = "moz-fx-data-shared-prod"
-GLEAN_SCHEMA_ID = "glean_ping_1"
-GLEAN_MIN_SCHEMA_ID = "glean-min_ping_1"
+GLEAN_SCHEMA_ID_PREFIX = "glean_ping_"
+GLEAN_MIN_SCHEMA_ID_PREFIX = "glean-min_ping_"
 
 
 @dataclass(frozen=True)
@@ -796,7 +796,12 @@ def find_glean_targets(
 
     datasets = {dataset.dataset_id for dataset in client.list_datasets(project)}
 
-    def stable_tables_by_schema(schema_id):
+    def stable_tables_by_schema(schema_id_prefix):
+        """Return _v1 stable tables whose schema id matches the given prefix.
+
+        Matches any schema version (glean_ping_1, glean_ping_2, ...) but
+        only includes _v1 tables; _v2+ tables are ignored.
+        """
         return [
             table
             for tables in pool.map(
@@ -809,10 +814,11 @@ def find_glean_targets(
                 chunksize=1,
             )
             for table in tables
-            if table.labels.get("schema_id") == schema_id
+            if table.labels.get("schema_id", "").startswith(schema_id_prefix)
+            and table.table_id.endswith("_v1")
         ]
 
-    glean_stable_tables = stable_tables_by_schema(GLEAN_SCHEMA_ID)
+    glean_stable_tables = stable_tables_by_schema(GLEAN_SCHEMA_ID_PREFIX)
 
     channel_to_app_name = get_glean_app_id_to_app_name_mapping()
 
@@ -894,7 +900,7 @@ def find_glean_targets(
     skipped_tables = manually_added_tables | GLEAN_IGNORE_LIST
 
     # Handle custom deletion requests for usage_reporting pings
-    glean_min_stable_tables = stable_tables_by_schema(GLEAN_MIN_SCHEMA_ID)
+    glean_min_stable_tables = stable_tables_by_schema(GLEAN_MIN_SCHEMA_ID_PREFIX)
     usage_reporting_sources: dict[str, tuple[DeleteSource, ...]] = defaultdict(tuple)
     for table in glean_min_stable_tables:
         if table.table_id == "usage_deletion_request_v1":

--- a/bigquery_etl/shredder/config.py
+++ b/bigquery_etl/shredder/config.py
@@ -799,8 +799,9 @@ def find_glean_targets(
     def stable_tables_by_schema(schema_id_prefix):
         """Return _v1 stable tables whose schema id matches the given prefix.
 
-        Matches any schema version (glean_ping_1, glean_ping_2, ...) but
-        only includes _v1 tables; _v2+ tables are ignored.
+        Matches any schema version (glean_ping_1, glean_ping_2, ...) but only includes _v1 tables;
+        _v2+ tables are ignored. This is for https://mozilla-hub.atlassian.net/browse/DENG-8494
+        where the _v1 tables are still the user-facing data.
         """
         return [
             table

--- a/tests/shredder/test_config.py
+++ b/tests/shredder/test_config.py
@@ -360,6 +360,80 @@ def test_glean_targets(mock_requests):
 
 
 @mock.patch("bigquery_etl.cli.utils.requests")
+def test_glean_targets_schema_version_and_v1_suffix(mock_requests):
+    """Match any glean_ping_ schema version but only include _v1 tables.
+
+    metrics_v1 carries the newer glean_ping_2 schema id and should still be
+    picked up. metrics_v2 carries a glean schema id too but must be ignored
+    because it does not have the _v1 suffix.
+    """
+
+    class SchemaVersionClient:
+        def list_datasets(self, project):
+            return [
+                bigquery.DatasetReference(project, name)
+                for name in [
+                    "firefox_desktop_stable",
+                    "firefox_desktop_derived",
+                ]
+            ]
+
+        def list_tables(self, dataset_ref):
+            if dataset_ref.dataset_id == "firefox_desktop_stable":
+                table_ids = [
+                    ("metrics_v1", {"schema_id": "glean_ping_2"}),
+                    ("metrics_v2", {"schema_id": "glean_ping_2"}),  # ignored: _v2 suffix
+                    ("deletion_request_v1", {"schema_id": "glean_ping_2"}),
+                ]
+            elif dataset_ref.dataset_id == "firefox_desktop_derived":
+                table_ids = ["clients_daily_v1"]
+            else:
+                raise Exception(f"unexpected dataset: {dataset_ref}")
+            return [
+                bigquery.table.TableListItem(
+                    {
+                        "tableReference": bigquery.TableReference(
+                            dataset_ref, table_id[0]
+                        ).to_api_repr(),
+                        "labels": table_id[1],
+                    }
+                )
+                for table_id in [
+                    t if isinstance(t, tuple) else (t, {}) for t in table_ids
+                ]
+            ]
+
+        def get_table(self, table_ref):
+            table = bigquery.Table(table_ref)
+            table._properties[table._PROPERTY_TO_API_FIELD["type"]] = "TABLE"
+            if table.dataset_id.endswith("stable"):
+                table.schema = [
+                    bigquery.SchemaField(
+                        "client_info",
+                        "RECORD",
+                        fields=[bigquery.SchemaField("client_id", "STRING")],
+                    )
+                ]
+            else:
+                table.schema = [bigquery.SchemaField("client_id", "STRING")]
+            return table
+
+    mock_response = mock.Mock()
+    mock_response.json.return_value = GLEAN_APP_LISTING
+    mock_requests.get.return_value = mock_response
+
+    with ThreadPool(1) as pool:
+        targets = find_glean_targets(pool, SchemaVersionClient())
+
+    target_tables = {target.table for target in targets}
+
+    # metrics_v1 has the glean_ping_2 schema id and the _v1 suffix, so it's shredded
+    assert "firefox_desktop_stable.metrics_v1" in target_tables
+    # metrics_v2 has a glean schema id but the _v2 suffix, so it's ignored
+    assert "firefox_desktop_stable.metrics_v2" not in target_tables
+
+
+@mock.patch("bigquery_etl.cli.utils.requests")
 def test_glean_targets_override(mock_requests):
     """Targets in GLEAN_DERIVED_OVERRIDES should override the target in find_glean_targets."""
 

--- a/tests/shredder/test_config.py
+++ b/tests/shredder/test_config.py
@@ -382,7 +382,10 @@ def test_glean_targets_schema_version_and_v1_suffix(mock_requests):
             if dataset_ref.dataset_id == "firefox_desktop_stable":
                 table_ids = [
                     ("metrics_v1", {"schema_id": "glean_ping_2"}),
-                    ("metrics_v2", {"schema_id": "glean_ping_2"}),  # ignored: _v2 suffix
+                    (
+                        "metrics_v2",
+                        {"schema_id": "glean_ping_2"},
+                    ),  # ignored: _v2 suffix
                     ("deletion_request_v1", {"schema_id": "glean_ping_2"}),
                 ]
             elif dataset_ref.dataset_id == "firefox_desktop_derived":


### PR DESCRIPTION
## Description

Fix following https://github.com/mozilla/mozilla-schema-generator/pull/321. `_v1` tables with `glean_ping_2` schemas aren't being picked up

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
