### PR TITLE
Remove Bigeye check for n_metrics_ping

### DIFF
--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.bigconfig.yml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.bigconfig.yml
@@ -14,7 +14,6 @@ tag_deployments:
         metrics:
           - saved_metric_id: is_not_null
       - column_selectors:
-          - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.n_metrics_ping
           - name: {{ project_id }}.{{ project_id }}.{{ derived_dataset }}.{{ target_table }}.days_sent_metrics_ping_bits
         metrics:
           - saved_metric_id: is_99_percent_not_null


### PR DESCRIPTION
## Description

#9707 (DENG-11397) restored carry-forward for `n_metrics_ping` which is now in some cases `NULL` for carry-forward rows (for clients that sent no metrics ping that day). Its null rate now exceeds 1% and the monitor alerts on expected behavior. This PR removes the %null monitor for this column

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
