### PR TITLE
chore(customer-experience): Add metrics_thunderbird_answers and metrics_thunderbird_questions to syndicate list

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_syndicate/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_syndicate/dataset_metadata.yaml
@@ -17,6 +17,8 @@ syndication:
     - kitsune_wiki_revision
     - kitsune_wiki_document_plus
     - metrics_kb_votes_details
+    - metrics_thunderbird_answers
+    - metrics_thunderbird_questions
   administer_views: false
 workgroup_access:
   - role: roles/bigquery.dataViewer


### PR DESCRIPTION
Adds `metrics_thunderbird_answers` and `metrics_thunderbird_questions` to the list of syndicated tables in the `sumo_syndicate` dataset, so they are exposed from `moz-fx-sumo-prod.sumo`.
