### PR TITLE
chore(firefox_referral): align bqetl_firefox_referral schedule with its GA4 upstream

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -1921,7 +1921,12 @@ bqetl_firefox_referral:
     referral_installs_totals_v1. The CSV-to-GCS export is a fast-follow, pending
     the Website team's bucket + IAM.
   repo: bigquery-etl
-  schedule_interval: 0 4 * * *
+  # Aligned with bqetl_ga4_firefoxdotcom (0 14 * * *) so the external task
+  # sensor's execution_delta is 0. At 0 4 * * * the run for ds=D started 10h
+  # before its upstream GA4 run for the same ds even began, so every run sat in
+  # a ~10h no-op sensor wait. Completion time is unchanged (still gated by
+  # firefoxdotcom_derived.ga_sessions_v2); this only removes the dead wait.
+  schedule_interval: 0 14 * * *
   tags:
     - impact/tier_3
 


### PR DESCRIPTION
## Description

`bqetl_firefox_referral` runs are sitting in an external task sensor for **15–20 hours** every day.

Most of that is a scheduling offset, not a slow upstream. Both DAGs are daily, so the generated `ExternalTaskSensor` targets the upstream run with the **same `ds`**:

| DAG | cron | run for `ds=D` fires at |
|---|---|---|
| `bqetl_firefox_referral` | `0 4 * * *` | D+1 **04:00** |
| `bqetl_google_analytics_derived_ga4` (`mozilla_org_derived.ga_sessions_v3`) | `0 12 * * *` | D+1 **12:00** |
| `bqetl_ga4_firefoxdotcom` (`firefoxdotcom_derived.ga_sessions_v2`) | `0 14 * * *` | D+1 **14:00** |

That gave the firefoxdotcom sensor an `execution_delta` of **-10h**: the referral run for `ds=D` started ten hours before its upstream run for the same `ds` even began, and only then started waiting on the actual task.

Note it never waited on the *whole* GA4 DAG — only on `ga_sessions_v2`, which sits directly behind `wait_for_firefoxdotcom_events_table`, i.e. the first real task. The 5–10h GA4 DAG duration is downstream work this query doesn't touch.

## Change

One line in `dags.yaml`: `schedule_interval: 0 4 * * *` → `0 14 * * *`.

## What this does and doesn't do

- **Does:** removes ~10h of no-op sensor time per run. A long wait now actually means GA4 is late, instead of being the normal state.
- **Doesn't:** make the data land any earlier. Completion is gated by `ga_sessions_v2` either way, which in turn is gated by Google's GA4 export landing.

Sensors are `mode='reschedule'`, so this was never burning a worker slot — it's a legibility/triage fix.

Related: DENG-11237.