### PR TITLE
feat(jira): extra fields and updated date on the issues integration; fix srein_events_v1 scope

### DIFF
--- a/bigquery_etl/jira/__init__.py
+++ b/bigquery_etl/jira/__init__.py
@@ -1,10 +1,11 @@
 """Jira integration package exports."""
 
 from .events import JiraEventsBigQueryIntegration, build_parser
-from .issues import JiraIssueBigQueryIntegration
+from .issues import JiraField, JiraIssueBigQueryIntegration
 
 __all__ = [
     "JiraEventsBigQueryIntegration",
+    "JiraField",
     "JiraIssueBigQueryIntegration",
     "build_parser",
 ]

--- a/bigquery_etl/jira/issues.py
+++ b/bigquery_etl/jira/issues.py
@@ -43,6 +43,25 @@ VALUE_KEYS = ("name", "displayName", "value")
 
 VALID_MODES = ("NULLABLE", "REPEATED")
 
+# Types this module knows how to produce. bigquery.SchemaField accepts any
+# string, and _extra_values falls through to the untouched-value branch for
+# anything unrecognised, so a typo like "DATETIEM" would build fine and only
+# surface as a load failure.
+VALID_TYPES = (
+    "STRING",
+    "BOOL",
+    "INT64",
+    "FLOAT64",
+    "NUMERIC",
+    "DATE",
+    "DATETIME",
+    "TIMESTAMP",
+)
+
+# Types whose extraction yields a scalar or None, never a list, so pairing them
+# with REPEATED would produce a permanently empty column.
+SCALAR_ONLY_TYPES = ("DATE", "DATETIME", "TIMESTAMP")
+
 logger = logging.getLogger(__name__)
 
 
@@ -69,6 +88,17 @@ class JiraField:
                 f"JiraField({self.column!r}) has mode {self.mode!r}; "
                 f"expected one of {VALID_MODES}"
             )
+        if self.bq_type not in VALID_TYPES:
+            raise ValueError(
+                f"JiraField({self.column!r}) has bq_type {self.bq_type!r}; "
+                f"expected one of {VALID_TYPES}"
+            )
+        if self.mode == "REPEATED" and self.bq_type in SCALAR_ONLY_TYPES:
+            raise ValueError(
+                f"JiraField({self.column!r}) pairs mode REPEATED with bq_type "
+                f"{self.bq_type!r}, whose parser always returns a scalar or None, "
+                "so the column would always be empty"
+            )
 
 
 def extract_value(raw: Any) -> Any:
@@ -81,7 +111,11 @@ def extract_value(raw: Any) -> Any:
     run down with it.
     """
     if isinstance(raw, list):
-        return [extract_value(item) for item in raw]
+        # Unusable elements are dropped rather than kept as None: the only
+        # consumer of a list is a REPEATED column, and BigQuery rejects a null
+        # element inside one with "Array specifies a null element", which would
+        # fail the load for the same reason the scalar branch returns None.
+        return [value for value in (extract_value(i) for i in raw) if value is not None]
 
     if isinstance(raw, dict):
         for key in VALUE_KEYS:
@@ -231,7 +265,11 @@ class JiraAPI:
             raw = fields.get(field.jira_field)
 
             if field.bq_type == "TIMESTAMP":
-                value: Any = self.client.to_bq_timestamp(raw)
+                # extract_value first: to_bq_timestamp hands its argument to
+                # strptime, which raises TypeError on a dict or list, and only
+                # ValueError is caught -- so an object-valued field would escape
+                # and kill the whole run instead of nulling one cell.
+                value: Any = self.client.to_bq_timestamp(extract_value(raw))
             elif field.bq_type == "DATETIME":
                 value = parse_datetime(extract_value(raw))
             elif field.bq_type == "DATE":
@@ -241,9 +279,13 @@ class JiraAPI:
 
             # A field Jira omitted must still appear on the row: NDJSON loads
             # infer nothing from an absent key, and a REPEATED column cannot
-            # take null.
+            # take null. A single-valued multi-select arrives unwrapped, so wrap
+            # it rather than discarding it.
             if field.mode == "REPEATED":
-                value = value if isinstance(value, list) else []
+                if value is None:
+                    value = []
+                elif not isinstance(value, list):
+                    value = [value]
             values[field.column] = value
 
         return values

--- a/bigquery_etl/jira/issues.py
+++ b/bigquery_etl/jira/issues.py
@@ -8,6 +8,7 @@ nothing are unaffected, which is what keeps the pre-existing tables working.
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Optional, Sequence
 
 from google.cloud import bigquery
@@ -41,6 +42,8 @@ REQUEST_FIELDS = [
 VALUE_KEYS = ("name", "displayName", "value")
 
 VALID_MODES = ("NULLABLE", "REPEATED")
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -87,6 +90,55 @@ def extract_value(raw: Any) -> Any:
         return None
 
     return raw
+
+
+def parse_datetime(raw: Any) -> Optional[str]:
+    """Normalize a zone-less Jira datetime string to a BigQuery DATETIME literal.
+
+    Some Jira custom fields are plain text holding a wall-clock time with no
+    timezone and often no seconds, e.g. the IIM incident timing fields, which
+    arrive as `"2026-07-25 09:49"`. `JiraClient.to_bq_timestamp` cannot help:
+    it only parses ISO-with-offset, so those values would silently become NULL.
+
+    Output is canonical `YYYY-MM-DD HH:MM:SS`, which BigQuery accepts without
+    relying on whether it tolerates a missing seconds component. Because the
+    source is free text, an unparseable value becomes None rather than failing
+    the load job for the entire table.
+
+    DATETIME rather than TIMESTAMP is deliberate: the source carries no offset,
+    so there is no zone to convert from and a TIMESTAMP would imply one.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+
+    value = raw.strip().replace("T", " ")
+
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M"):
+        try:
+            return datetime.strptime(value, fmt).strftime("%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            continue
+
+    logger.warning("Unparseable datetime value %r; storing NULL", raw)
+    return None
+
+
+def parse_date(raw: Any) -> Optional[str]:
+    """Normalize a Jira date string to a BigQuery DATE literal, or None.
+
+    Accepts a bare `YYYY-MM-DD` and also a full datetime, keeping the date part,
+    so a field that changes type in Jira does not start returning NULLs.
+    """
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+
+    value = raw.strip().replace("T", " ").split(" ")[0]
+
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").strftime("%Y-%m-%d")
+    except ValueError:
+        logger.warning("Unparseable date value %r; storing NULL", raw)
+        return None
 
 
 def build_schema(extra_fields: Sequence[JiraField] = ()) -> list[bigquery.SchemaField]:
@@ -180,6 +232,10 @@ class JiraAPI:
 
             if field.bq_type == "TIMESTAMP":
                 value: Any = self.client.to_bq_timestamp(raw)
+            elif field.bq_type == "DATETIME":
+                value = parse_datetime(extract_value(raw))
+            elif field.bq_type == "DATE":
+                value = parse_date(extract_value(raw))
             else:
                 value = extract_value(raw)
 

--- a/bigquery_etl/jira/issues.py
+++ b/bigquery_etl/jira/issues.py
@@ -8,7 +8,7 @@ nothing are unaffected, which is what keeps the pre-existing tables working.
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional, Sequence
 
 from google.cloud import bigquery
@@ -72,14 +72,16 @@ class JiraField:
     `column` is the BigQuery column name, `jira_field` the Jira field id as the
     API names it (`priority`, `labels`, `customfield_10420`). `bq_type` of
     TIMESTAMP routes the value through the same UTC normalization the base
-    timestamps use. `mode="REPEATED"` is for Jira fields that return an array,
-    such as `labels` or `components`.
+    timestamps use, which requires an offset in the source; set `utc_naive` for a
+    zone-less source that the data model specifies as UTC. `mode="REPEATED"` is
+    for Jira fields that return an array, such as `labels` or `components`.
     """
 
     column: str
     jira_field: str
     bq_type: str = "STRING"
     mode: str = "NULLABLE"
+    utc_naive: bool = False
 
     def __post_init__(self) -> None:
         """Reject a mode BigQuery would not accept, at declaration rather than load."""
@@ -92,6 +94,12 @@ class JiraField:
             raise ValueError(
                 f"JiraField({self.column!r}) has bq_type {self.bq_type!r}; "
                 f"expected one of {VALID_TYPES}"
+            )
+        if self.utc_naive and self.bq_type != "TIMESTAMP":
+            raise ValueError(
+                f"JiraField({self.column!r}) sets utc_naive with bq_type "
+                f"{self.bq_type!r}; it only applies to TIMESTAMP, whose parser is "
+                "the one that needs an offset"
             )
         if self.mode == "REPEATED" and self.bq_type in SCALAR_ONLY_TYPES:
             raise ValueError(
@@ -155,6 +163,29 @@ def parse_datetime(raw: Any) -> Optional[str]:
 
     logger.warning("Unparseable datetime value %r; storing NULL", raw)
     return None
+
+
+def parse_utc_timestamp(raw: Any) -> Optional[str]:
+    """Parse a zone-less datetime string known to be UTC into a TIMESTAMP literal.
+
+    For fields whose source carries no offset but whose data model specifies UTC,
+    such as the IIM incident timing fields. The UTC zone is attached explicitly
+    rather than relying on `.astimezone()`, which would interpret a naive
+    datetime as the container's local time and make the same input produce
+    different output depending on where the DAG ran.
+
+    Returns None on unparseable input, like the other parsers, so a free-text
+    field cannot fail the load for the whole table.
+    """
+    normalized = parse_datetime(raw)
+    if normalized is None:
+        return None
+
+    return (
+        datetime.strptime(normalized, "%Y-%m-%d %H:%M:%S")
+        .replace(tzinfo=timezone.utc)
+        .isoformat(timespec="seconds")
+    )
 
 
 def parse_date(raw: Any) -> Optional[str]:
@@ -264,12 +295,14 @@ class JiraAPI:
         for field in self.extra_fields:
             raw = fields.get(field.jira_field)
 
-            if field.bq_type == "TIMESTAMP":
+            if field.bq_type == "TIMESTAMP" and field.utc_naive:
+                value: Any = parse_utc_timestamp(extract_value(raw))
+            elif field.bq_type == "TIMESTAMP":
                 # extract_value first: to_bq_timestamp hands its argument to
                 # strptime, which raises TypeError on a dict or list, and only
                 # ValueError is caught -- so an object-valued field would escape
                 # and kill the whole run instead of nulling one cell.
-                value: Any = self.client.to_bq_timestamp(extract_value(raw))
+                value = self.client.to_bq_timestamp(extract_value(raw))
             elif field.bq_type == "DATETIME":
                 value = parse_datetime(extract_value(raw))
             elif field.bq_type == "DATE":

--- a/bigquery_etl/jira/issues.py
+++ b/bigquery_etl/jira/issues.py
@@ -1,6 +1,14 @@
-"""Fetch Jira issues and load them into BigQuery."""
+"""Fetch Jira issues and load them into BigQuery.
+
+Every table gets the columns in `OUTPUT_SCHEMA`. A table that needs more can
+declare `JiraField` specs and pass them to `JiraIssueBigQueryIntegration.run`;
+they become additional columns appended after the base ones. Tables that declare
+nothing are unaffected, which is what keeps the pre-existing tables working.
+"""
 
 import logging
+from dataclasses import dataclass
+from typing import Any, Optional, Sequence
 
 from google.cloud import bigquery
 
@@ -14,6 +22,7 @@ OUTPUT_SCHEMA = [
     bigquery.SchemaField("status", "STRING"),
     bigquery.SchemaField("created", "TIMESTAMP"),
     bigquery.SchemaField("resolved", "TIMESTAMP"),
+    bigquery.SchemaField("updated", "TIMESTAMP"),
 ]
 
 REQUEST_FIELDS = [
@@ -23,7 +32,82 @@ REQUEST_FIELDS = [
     "project",
     "created",
     "resolutiondate",
+    "updated",
 ]
+
+# Keys Jira nests a human-readable value under, most specific first. `name`
+# covers priority/status/resolution/issuetype, `displayName` covers users,
+# `value` covers single-select customfields.
+VALUE_KEYS = ("name", "displayName", "value")
+
+VALID_MODES = ("NULLABLE", "REPEATED")
+
+
+@dataclass(frozen=True)
+class JiraField:
+    """An additional Jira field to project onto its own BigQuery column.
+
+    `column` is the BigQuery column name, `jira_field` the Jira field id as the
+    API names it (`priority`, `labels`, `customfield_10420`). `bq_type` of
+    TIMESTAMP routes the value through the same UTC normalization the base
+    timestamps use. `mode="REPEATED"` is for Jira fields that return an array,
+    such as `labels` or `components`.
+    """
+
+    column: str
+    jira_field: str
+    bq_type: str = "STRING"
+    mode: str = "NULLABLE"
+
+    def __post_init__(self) -> None:
+        """Reject a mode BigQuery would not accept, at declaration rather than load."""
+        if self.mode not in VALID_MODES:
+            raise ValueError(
+                f"JiraField({self.column!r}) has mode {self.mode!r}; "
+                f"expected one of {VALID_MODES}"
+            )
+
+
+def extract_value(raw: Any) -> Any:
+    """Reduce a raw Jira field value to something a scalar column can hold.
+
+    Jira returns bare scalars for text and numeric fields, objects for anything
+    that references an entity, and arrays for multi-valued fields. An object
+    whose shape is not recognised yields None rather than the dict itself,
+    because a dict would fail the column's type at load time and take the whole
+    run down with it.
+    """
+    if isinstance(raw, list):
+        return [extract_value(item) for item in raw]
+
+    if isinstance(raw, dict):
+        for key in VALUE_KEYS:
+            if raw.get(key) is not None:
+                return raw[key]
+        return None
+
+    return raw
+
+
+def build_schema(extra_fields: Sequence[JiraField] = ()) -> list[bigquery.SchemaField]:
+    """Return the base schema with any extra fields appended, in declared order."""
+    base_names = {field.name for field in OUTPUT_SCHEMA}
+    seen: set[str] = set()
+
+    for field in extra_fields:
+        if field.column in base_names:
+            raise ValueError(
+                f"extra field {field.column!r} collides with a base schema column; "
+                "choose a different column name"
+            )
+        if field.column in seen:
+            raise ValueError(f"duplicate extra field column {field.column!r}")
+        seen.add(field.column)
+
+    return list(OUTPUT_SCHEMA) + [
+        bigquery.SchemaField(field.column, field.bq_type, mode=field.mode)
+        for field in extra_fields
+    ]
 
 
 class BigQueryAPI:
@@ -33,10 +117,19 @@ class BigQueryAPI:
         """Initialize a logger for BigQuery load operations."""
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def load_issue_data(self, destination_table: str, issues: list[dict]):
-        """Load Jira issue records into the destination BigQuery table."""
+    def load_issue_data(
+        self,
+        destination_table: str,
+        issues: list[dict],
+        schema: Optional[list[bigquery.SchemaField]] = None,
+    ):
+        """Load Jira issue records into the destination BigQuery table.
+
+        `schema` defaults to the base schema, so an existing caller that passes
+        only a destination and rows keeps its current behaviour.
+        """
         job_config = bigquery.LoadJobConfig(
-            schema=OUTPUT_SCHEMA,
+            schema=schema if schema is not None else OUTPUT_SCHEMA,
             autodetect=False,
             write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
             source_format=bigquery.SourceFormat.NEWLINE_DELIMITED_JSON,
@@ -55,11 +148,49 @@ class JiraAPI:
 
     SEARCH_ENDPOINT = "/rest/api/3/search/jql"
 
-    def __init__(self, base_jira_url: str, jql: str) -> None:
+    def __init__(
+        self,
+        base_jira_url: str,
+        jql: str,
+        extra_fields: Sequence[JiraField] = (),
+    ) -> None:
         """Create an authenticated Jira API client from environment credentials."""
         self.logger = logging.getLogger(self.__class__.__name__)
         self.client = JiraClient(base_jira_url)
         self.jql = jql
+        self.extra_fields = tuple(extra_fields)
+        # Validate the column set now, so a bad declaration fails before any
+        # network or BigQuery call rather than partway through a run.
+        build_schema(self.extra_fields)
+
+    def _requested_fields(self) -> list[str]:
+        """Return base fields plus each extra field's Jira id, de-duplicated."""
+        requested = list(REQUEST_FIELDS)
+        for field in self.extra_fields:
+            if field.jira_field not in requested:
+                requested.append(field.jira_field)
+        return requested
+
+    def _extra_values(self, fields: dict) -> dict:
+        """Project the declared extra fields off one issue's `fields` object."""
+        values = {}
+
+        for field in self.extra_fields:
+            raw = fields.get(field.jira_field)
+
+            if field.bq_type == "TIMESTAMP":
+                value: Any = self.client.to_bq_timestamp(raw)
+            else:
+                value = extract_value(raw)
+
+            # A field Jira omitted must still appear on the row: NDJSON loads
+            # infer nothing from an absent key, and a REPEATED column cannot
+            # take null.
+            if field.mode == "REPEATED":
+                value = value if isinstance(value, list) else []
+            values[field.column] = value
+
+        return values
 
     def get_issues(self, max_results: int = 100) -> list[dict]:
         """Fetch issues from Jira and map fields to the BigQuery output schema."""
@@ -70,7 +201,7 @@ class JiraAPI:
             {
                 "maxResults": max_results,
                 "jql": self.jql,
-                "fields": ",".join(REQUEST_FIELDS),
+                "fields": ",".join(self._requested_fields()),
             },
             "issues",
         ):
@@ -86,6 +217,8 @@ class JiraAPI:
                     "resolved": self.client.to_bq_timestamp(
                         fields.get("resolutiondate")
                     ),
+                    "updated": self.client.to_bq_timestamp(fields.get("updated")),
+                    **self._extra_values(fields),
                 }
             )
 
@@ -99,16 +232,29 @@ class JiraIssueBigQueryIntegration:
         """Initialize a logger for integration-level progress messages."""
         self.logger = logging.getLogger(self.__class__.__name__)
 
-    def run(self, args):
-        """Run the Jira-to-BigQuery integration with parsed CLI arguments."""
+    def run(self, args, extra_fields: Sequence[JiraField] = ()):
+        """Run the Jira-to-BigQuery integration with parsed CLI arguments.
+
+        `extra_fields` is an explicit parameter rather than an attribute read off
+        `args`, so a table that wants nothing extra calls `run(args)` exactly as
+        before and there is no namespace contract for a copied query.py to omit.
+        """
         self.logger.info("Starting Jira Issue BigQuery Integration ...")
 
-        jira = JiraAPI(base_jira_url=args.base_jira_url, jql=args.jql)
+        jira = JiraAPI(
+            base_jira_url=args.base_jira_url, jql=args.jql, extra_fields=extra_fields
+        )
         bq_api = BigQueryAPI()
 
         issues = jira.get_issues()
-        self.logger.info("Fetched %s Jira issues", len(issues))
+        self.logger.info(
+            "Fetched %s Jira issues with %s extra field(s)",
+            len(issues),
+            len(tuple(extra_fields)),
+        )
 
-        bq_api.load_issue_data(args.destination, issues)
+        bq_api.load_issue_data(
+            args.destination, issues, schema=build_schema(extra_fields)
+        )
 
         self.logger.info("End of Jira Issue BigQuery Integration")

--- a/sql/moz-fx-data-shared-prod/jira_events_derived/srein_events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_events_derived/srein_events_v1/metadata.yaml
@@ -1,8 +1,18 @@
 friendly_name: Jira SREIN Ticket Events
 description: |-
-  Change events on Jira tickets in the SREIN (MozCloud Intake) project, pulled
-  from Jira API v3. One row per event: issue creation, status changes, other
-  field changes, and comments.
+  Change events on MozCloud Intake (SREIN) Jira tickets, pulled from Jira API v3.
+  One row per event: issue creation, status changes, other field changes, and
+  comments.
+
+  Scope is `project = SREIN OR labels = SREIN`. Intake tickets are frequently
+  triaged and *moved* to the owning team's project, which changes their key and
+  removes them from a project-scoped query along with their entire history; the
+  SREIN label survives a move and recovers them. The label alone is not
+  sufficient either, because older tickets predate the automation that applies it.
+  Two consequences for consumers: `project_key` is **not** always SREIN — expect
+  MZCLD, SVCSE, PAY and others for tickets that were moved — and `issue_key` is
+  the ticket's *current* key, with the rename itself recorded as `field_change`
+  rows on `Key` and `project`.
 
   Comment text is stored in `comment_body`, flattened from Atlassian Document
   Format to plain text — one line per ADF block, formatting marks dropped,

--- a/sql/moz-fx-data-shared-prod/jira_events_derived/srein_events_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/jira_events_derived/srein_events_v1/query.py
@@ -12,7 +12,14 @@ if __name__ == "__main__":
     args = build_parser(
         destination="moz-fx-data-shared-prod.jira_events_derived.srein_events_v1",
         base_jira_url="https://mozilla-hub.atlassian.net",
-        jql="project = SREIN",
+        # Union, not just `project = SREIN`: intake tickets get triaged and *moved*
+        # to the owning team's project, which changes their key and drops them out
+        # of a project-scoped JQL, taking their whole history with them. The SREIN
+        # label survives a move, so it recovers them. But the label is not on every
+        # in-project ticket either — older ones predate the automation that applies
+        # it, and some carry only `form`/`form-1344` — so a label-only scope would
+        # drop those. Both halves are needed.
+        jql="project = SREIN OR labels = SREIN",
     ).parse_args()
 
     logging.basicConfig(

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/ffxp_epic_issues_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/ffxp_epic_issues_v1/schema.yaml
@@ -20,3 +20,7 @@ fields:
 - name: resolved
   type: TIMESTAMP
   mode: NULLABLE
+- name: updated
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: When the issue was last modified, normalized to UTC.

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/metadata.yaml
@@ -2,6 +2,15 @@ friendly_name: Jira IIM Incident Issues
 description: |-
   Jira issues pulled from Jira API v3 (/rest/api/3/search/jql) for project
   IIM and issue type Incident.
+
+  USE AT YOUR OWN RISK. The Jira leg of the incident pipeline is expected to be
+  replaced by a parser writing the incident doc to PostgreSQL and loading from
+  there, at which point this table may change shape or go away without a
+  migration or deprecation period. Incident fields here mirror the Jira data
+  model (see the Incident data model and pipeline page in the MIR Confluence
+  space), not a stable contract.
+
+  The timing fields are recorded in UTC.
 owners:
 - mcastelluccio@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/query.py
@@ -16,23 +16,38 @@ from bigquery_etl.jira import JiraField, JiraIssueBigQueryIntegration  # noqa: E
 # Level" (customfield_10716); customfield_10319 is the one shown on the incident
 # form, and its stored name has a trailing space.
 #
-# The timing fields are free text in Jira holding a zone-less wall-clock value
-# like "2026-07-25 09:49". DATETIME, not TIMESTAMP: there is no offset to convert
-# from, so TIMESTAMP would both imply one and silently NULL every row, since the
-# ISO-with-offset parser cannot read that format.
+# The timing fields are free text in Jira holding a zone-less value like
+# "2026-07-25 09:49". The incident data model specifies UTC (confirmed by the
+# incident process owner in review), so they are TIMESTAMP with utc_naive: the
+# zone is attached explicitly rather than inferred from the container's clock.
+# That also lets them be diffed directly against created/updated/resolved.
+# Plain TIMESTAMP would NULL every row, since the ISO-with-offset parser used for
+# the base columns cannot read this format.
 EXTRA_FIELDS = [
     JiraField("affected_entities", "customfield_18555"),
     JiraField("severity", "customfield_10319"),
     JiraField("detection_method", "customfield_12881"),
     JiraField("declare_date", "customfield_15087", bq_type="DATE"),
-    JiraField("impact_start", "customfield_18693", bq_type="DATETIME"),
-    JiraField("time_declared", "customfield_18692", bq_type="DATETIME"),
-    JiraField("time_detected", "customfield_18694", bq_type="DATETIME"),
-    JiraField("time_alerted", "customfield_18695", bq_type="DATETIME"),
-    JiraField("time_acknowledged", "customfield_18696", bq_type="DATETIME"),
-    JiraField("time_responded", "customfield_18697", bq_type="DATETIME"),
-    JiraField("time_mitigated", "customfield_18698", bq_type="DATETIME"),
-    JiraField("time_resolved", "customfield_18699", bq_type="DATETIME"),
+    JiraField("impact_start", "customfield_18693", bq_type="TIMESTAMP", utc_naive=True),
+    JiraField(
+        "time_declared", "customfield_18692", bq_type="TIMESTAMP", utc_naive=True
+    ),
+    JiraField(
+        "time_detected", "customfield_18694", bq_type="TIMESTAMP", utc_naive=True
+    ),
+    JiraField("time_alerted", "customfield_18695", bq_type="TIMESTAMP", utc_naive=True),
+    JiraField(
+        "time_acknowledged", "customfield_18696", bq_type="TIMESTAMP", utc_naive=True
+    ),
+    JiraField(
+        "time_responded", "customfield_18697", bq_type="TIMESTAMP", utc_naive=True
+    ),
+    JiraField(
+        "time_mitigated", "customfield_18698", bq_type="TIMESTAMP", utc_naive=True
+    ),
+    JiraField(
+        "time_resolved", "customfield_18699", bq_type="TIMESTAMP", utc_naive=True
+    ),
 ]
 
 if __name__ == "__main__":

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/query.py
@@ -1,3 +1,5 @@
+"""Load Jira incident snapshots for the IIM project into BigQuery."""
+
 import logging
 import sys
 from argparse import ArgumentParser
@@ -5,7 +7,33 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from bigquery_etl.jira import JiraIssueBigQueryIntegration
+from bigquery_etl.jira import JiraField, JiraIssueBigQueryIntegration  # noqa: E402
+
+# Field ids captured from IIM-308 via /rest/api/3/issue/{key}?expand=names, which
+# is the only reliable mapping: the search API will not accept custom-field
+# display names, and several names here are ambiguous. "Severity" in particular
+# collides with "Severity Level" (customfield_11852) and "Requested Severity
+# Level" (customfield_10716); customfield_10319 is the one shown on the incident
+# form, and its stored name has a trailing space.
+#
+# The timing fields are free text in Jira holding a zone-less wall-clock value
+# like "2026-07-25 09:49". DATETIME, not TIMESTAMP: there is no offset to convert
+# from, so TIMESTAMP would both imply one and silently NULL every row, since the
+# ISO-with-offset parser cannot read that format.
+EXTRA_FIELDS = [
+    JiraField("affected_entities", "customfield_18555"),
+    JiraField("severity", "customfield_10319"),
+    JiraField("detection_method", "customfield_12881"),
+    JiraField("declare_date", "customfield_15087", bq_type="DATE"),
+    JiraField("impact_start", "customfield_18693", bq_type="DATETIME"),
+    JiraField("time_declared", "customfield_18692", bq_type="DATETIME"),
+    JiraField("time_detected", "customfield_18694", bq_type="DATETIME"),
+    JiraField("time_alerted", "customfield_18695", bq_type="DATETIME"),
+    JiraField("time_acknowledged", "customfield_18696", bq_type="DATETIME"),
+    JiraField("time_responded", "customfield_18697", bq_type="DATETIME"),
+    JiraField("time_mitigated", "customfield_18698", bq_type="DATETIME"),
+    JiraField("time_resolved", "customfield_18699", bq_type="DATETIME"),
+]
 
 if __name__ == "__main__":
     parser = ArgumentParser()
@@ -37,4 +65,4 @@ if __name__ == "__main__":
     )
 
     integration = JiraIssueBigQueryIntegration()
-    integration.run(args)
+    integration.run(args, extra_fields=EXTRA_FIELDS)

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/schema.yaml
@@ -27,7 +27,7 @@ fields:
 - name: affected_entities
   type: STRING
   mode: NULLABLE
-  description: Free-text list of services or systems the incident affected, e.g. phabricator.
+  description: Comma-separated list of products and systems affected. e.g., phabricator
 - name: severity
   type: STRING
   mode: NULLABLE
@@ -44,41 +44,41 @@ fields:
   mode: NULLABLE
   description: Date the incident was declared.
 - name: impact_start
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
   description: >-
-    When customer impact began. Wall-clock with no timezone, as recorded in the
-    incident report; see the note on the timing fields below.
+    When customer impact began, in UTC. See the note on time_declared for the
+    timing-field caveats.
 - name: time_declared
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
   description: >-
-    When the incident was declared. One of the free-text timing fields: recorded
-    as a zone-less wall-clock value in the incident report and synced to Jira, so
-    it is stored as DATETIME rather than TIMESTAMP. Values are normalized to
-    YYYY-MM-DD HH:MM:SS, and anything unparseable is NULL rather than failing the
-    load. These are backfilled from the report, so they can predate the ticket.
+    When the incident was declared, in UTC. One of the free-text timing fields:
+    recorded in the incident report without a timezone offset and synced to Jira,
+    but specified as UTC by the incident data model, so the UTC zone is attached
+    on ingest. Anything unparseable is NULL rather than failing the load. These
+    are backfilled from the report, so they can predate the ticket itself.
 - name: time_detected
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
-  description: When the incident was detected. See time_declared for the timing-field caveats.
+  description: When the incident was detected. In UTC. See time_declared for the timing-field caveats.
 - name: time_alerted
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
-  description: When an alert fired. See time_declared for the timing-field caveats.
+  description: When an alert fired. In UTC. See time_declared for the timing-field caveats.
 - name: time_acknowledged
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
-  description: When a responder acknowledged. See time_declared for the timing-field caveats.
+  description: When a responder acknowledged. In UTC. See time_declared for the timing-field caveats.
 - name: time_responded
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
-  description: When response began. See time_declared for the timing-field caveats.
+  description: When response began. In UTC. See time_declared for the timing-field caveats.
 - name: time_mitigated
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
-  description: When impact was mitigated. See time_declared for the timing-field caveats.
+  description: When impact was mitigated. In UTC. See time_declared for the timing-field caveats.
 - name: time_resolved
-  type: DATETIME
+  type: TIMESTAMP
   mode: NULLABLE
-  description: When the incident was resolved. See time_declared for the timing-field caveats.
+  description: When the incident was resolved. In UTC. See time_declared for the timing-field caveats.

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/schema.yaml
@@ -20,3 +20,7 @@ fields:
 - name: resolved
   type: TIMESTAMP
   mode: NULLABLE
+- name: updated
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: When the issue was last modified, normalized to UTC.

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/iim_incident_issues_v1/schema.yaml
@@ -24,3 +24,61 @@ fields:
   type: TIMESTAMP
   mode: NULLABLE
   description: When the issue was last modified, normalized to UTC.
+- name: affected_entities
+  type: STRING
+  mode: NULLABLE
+  description: Free-text list of services or systems the incident affected, e.g. phabricator.
+- name: severity
+  type: STRING
+  mode: NULLABLE
+  description: >-
+    Incident severity as shown on the incident form, e.g. S3. Sourced from
+    customfield_10319, not the similarly named Severity Level or Requested
+    Severity Level fields.
+- name: detection_method
+  type: STRING
+  mode: NULLABLE
+  description: How the incident was found, e.g. Automation or Manual.
+- name: declare_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the incident was declared.
+- name: impact_start
+  type: DATETIME
+  mode: NULLABLE
+  description: >-
+    When customer impact began. Wall-clock with no timezone, as recorded in the
+    incident report; see the note on the timing fields below.
+- name: time_declared
+  type: DATETIME
+  mode: NULLABLE
+  description: >-
+    When the incident was declared. One of the free-text timing fields: recorded
+    as a zone-less wall-clock value in the incident report and synced to Jira, so
+    it is stored as DATETIME rather than TIMESTAMP. Values are normalized to
+    YYYY-MM-DD HH:MM:SS, and anything unparseable is NULL rather than failing the
+    load. These are backfilled from the report, so they can predate the ticket.
+- name: time_detected
+  type: DATETIME
+  mode: NULLABLE
+  description: When the incident was detected. See time_declared for the timing-field caveats.
+- name: time_alerted
+  type: DATETIME
+  mode: NULLABLE
+  description: When an alert fired. See time_declared for the timing-field caveats.
+- name: time_acknowledged
+  type: DATETIME
+  mode: NULLABLE
+  description: When a responder acknowledged. See time_declared for the timing-field caveats.
+- name: time_responded
+  type: DATETIME
+  mode: NULLABLE
+  description: When response began. See time_declared for the timing-field caveats.
+- name: time_mitigated
+  type: DATETIME
+  mode: NULLABLE
+  description: When impact was mitigated. See time_declared for the timing-field caveats.
+- name: time_resolved
+  type: DATETIME
+  mode: NULLABLE
+  description: When the incident was resolved. See time_declared for the timing-field caveats.

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Jira SREIN Issues
+description: |-
+  Jira issues pulled from Jira API v3 (/rest/api/3/search/jql) for project
+  SREIN.
+owners:
+- wstuckey@mozilla.com
+labels:
+  schedule: daily
+  incremental: false
+  owner1: wstuckey@mozilla.com
+
+scheduling:
+  dag_name: bqetl_jira_tickets
+  secrets:
+  - deploy_target: JIRA_USERNAME
+    key: bqetl_jira_service_desk__jira_username
+  - deploy_target: JIRA_TOKEN
+    key: bqetl_jira_service_desk__jira_token

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/metadata.yaml
@@ -1,7 +1,18 @@
 friendly_name: Jira SREIN Issues
 description: |-
-  Jira issues pulled from Jira API v3 (/rest/api/3/search/jql) for project
-  SREIN.
+  Current-state snapshot of Jira issues in the MozCloud Intake (SREIN) support
+  universe, pulled from Jira API v3 (/rest/api/3/search/jql). Full refresh
+  daily; see jira_events_derived.srein_events_v1 for per-event history.
+
+  Scope is `project = SREIN OR labels = SREIN`. Intake tickets are frequently
+  triaged and *moved* to the owning team's project, which changes their key and
+  removes them from a project-scoped query; the SREIN label survives a move and
+  recovers them. The label alone is not sufficient either, because older tickets
+  predate the automation that applies it.
+
+  Two consequences for consumers: `project_key` is **not** always SREIN — expect
+  MZCLD, SVCSE, PAY and others for tickets that were moved — and `issue_key` is
+  the ticket's *current* key, so it changes when a ticket is moved.
 owners:
 - wstuckey@mozilla.com
 labels:

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/query.py
@@ -1,0 +1,58 @@
+"""Load Jira issue snapshots for the SREIN support universe into BigQuery."""
+
+import logging
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bigquery_etl.jira import JiraField, JiraIssueBigQueryIntegration  # noqa: E402
+
+# Union, not just `project = SREIN`: intake tickets get triaged and moved to the
+# owning team's project, which changes their key and drops them out of a
+# project-scoped JQL. The SREIN label survives a move, so it recovers them. The
+# label alone is not enough either, because older tickets predate the automation
+# that applies it. Note the field is `labels`, plural -- JQL has no `label`.
+DEFAULT_JQL = "project = SREIN OR labels = SREIN"
+
+# Appended after the base schema, in this order. Keep in step with schema.yaml.
+EXTRA_FIELDS = [
+    JiraField("priority", "priority"),
+    JiraField("assignee", "assignee"),
+    JiraField("reporter", "reporter"),
+    JiraField("resolution", "resolution"),
+    JiraField("labels", "labels", mode="REPEATED"),
+]
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        "--destination",
+        dest="destination",
+        default="moz-fx-data-shared-prod.jira_tickets_derived.srein_issues_v1",
+        required=False,
+    )
+    parser.add_argument(
+        "--base-url",
+        dest="base_jira_url",
+        default="https://mozilla-hub.atlassian.net",
+        required=False,
+    )
+    parser.add_argument(
+        "--jql",
+        dest="jql",
+        default=DEFAULT_JQL,
+        required=False,
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)s:\t%(name)s.%(funcName)s()[%(filename)s:%(lineno)s]:\t%(levelname)s: %(message)s",
+        level=logging.INFO,
+        encoding="utf-8",
+    )
+
+    integration = JiraIssueBigQueryIntegration()
+    integration.run(args, extra_fields=EXTRA_FIELDS)

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/schema.yaml
@@ -1,0 +1,46 @@
+fields:
+- name: issue_key
+  type: STRING
+  mode: NULLABLE
+- name: project_key
+  type: STRING
+  mode: NULLABLE
+- name: issue_type
+  type: STRING
+  mode: NULLABLE
+- name: summary
+  type: STRING
+  mode: NULLABLE
+- name: status
+  type: STRING
+  mode: NULLABLE
+- name: created
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: resolved
+  type: TIMESTAMP
+  mode: NULLABLE
+- name: updated
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: When the issue was last modified, normalized to UTC.
+- name: priority
+  type: STRING
+  mode: NULLABLE
+  description: Priority name, e.g. P0. Intake defaults to P1, so anything else was set deliberately.
+- name: assignee
+  type: STRING
+  mode: NULLABLE
+  description: Display name of the current assignee.
+- name: reporter
+  type: STRING
+  mode: NULLABLE
+  description: Display name of the person who filed the ticket.
+- name: resolution
+  type: STRING
+  mode: NULLABLE
+  description: Resolution name once resolved, e.g. Done. NULL while open.
+- name: labels
+  type: STRING
+  mode: REPEATED
+  description: All labels on the issue. Includes SREIN for intake tickets, which is what keeps a ticket in scope after it is moved to another project.

--- a/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/jira_tickets_derived/srein_issues_v1/schema.yaml
@@ -2,9 +2,15 @@ fields:
 - name: issue_key
   type: STRING
   mode: NULLABLE
+  description: >-
+    The ticket's current key. Changes if the ticket is moved to another project.
 - name: project_key
   type: STRING
   mode: NULLABLE
+  description: >-
+    Project the ticket currently lives in. NOT always SREIN: intake tickets are
+    moved to the owning team's project after triage and stay in scope via the
+    SREIN label, so expect MZCLD, SVCSE, PAY and others.
 - name: issue_type
   type: STRING
   mode: NULLABLE

--- a/tests/jira/test_issues.py
+++ b/tests/jira/test_issues.py
@@ -15,6 +15,7 @@ SEARCH_PAGE = {
                 "summary": "Do the thing",
                 "status": {"name": "In Progress"},
                 "created": "2026-07-27T09:40:36.912-0400",
+                "updated": "2026-07-28T11:00:00.000-0400",
                 "resolutiondate": None,
             },
         }
@@ -41,6 +42,7 @@ def test_get_issues_maps_to_output_schema():
             "status": "In Progress",
             "created": "2026-07-27T13:40:36+00:00",
             "resolved": None,
+            "updated": "2026-07-28T15:00:00+00:00",
         }
     ]
 

--- a/tests/jira/test_issues_fields.py
+++ b/tests/jira/test_issues_fields.py
@@ -233,3 +233,136 @@ def test_jira_field_defaults():
 def test_build_schema_returns_bigquery_schema_fields():
     schema = build_schema([JiraField("priority", "priority")])
     assert all(isinstance(f, bigquery.SchemaField) for f in schema)
+
+
+# --- DATETIME / DATE typed extras -------------------------------------------
+#
+# The IIM incident timing fields are free-text in Jira and arrive as
+# "2026-07-25 09:49": no `T`, no seconds, no timezone offset. to_bq_timestamp
+# only parses ISO-with-offset, so routing them through TIMESTAMP would silently
+# yield NULL for every row. They are normalized to a canonical DATETIME instead,
+# and a value that will not parse becomes NULL rather than failing the load job
+# for the whole table.
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2026-07-25 09:49", "2026-07-25 09:49:00"),
+        ("2026-07-25 09:49:12", "2026-07-25 09:49:12"),
+        ("2026-07-25T09:49", "2026-07-25 09:49:00"),
+        ("2026-07-25T09:49:12", "2026-07-25 09:49:12"),
+        ("  2026-07-25 09:49  ", "2026-07-25 09:49:00"),
+        # Free-text field, so anything can turn up. None beats a failed load.
+        ("not a datetime", None),
+        ("2026-13-45 99:99", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_parse_datetime(raw, expected):
+    from bigquery_etl.jira.issues import parse_datetime
+
+    assert parse_datetime(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2026-07-25", "2026-07-25"),
+        ("  2026-07-25 ", "2026-07-25"),
+        # A datetime in a date field keeps only the date part.
+        ("2026-07-25 09:49", "2026-07-25"),
+        ("nope", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_parse_date(raw, expected):
+    from bigquery_etl.jira.issues import parse_date
+
+    assert parse_date(raw) == expected
+
+
+@responses.activate
+def test_datetime_typed_extra_field_is_normalized():
+    """Captured from IIM-308: customfield_18692 holds '2026-07-25 09:49'."""
+    issue = {
+        "key": "IIM-308",
+        "fields": {**ISSUE["fields"], "customfield_18692": "2026-07-25 09:49"},
+    }
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = IIM",
+        extra_fields=[
+            JiraField("time_declared", "customfield_18692", bq_type="DATETIME")
+        ],
+    ).get_issues()
+
+    assert out["time_declared"] == "2026-07-25 09:49:00"
+
+
+@responses.activate
+def test_datetime_typed_extra_field_would_be_null_as_timestamp():
+    """Pins the reason DATETIME exists: TIMESTAMP silently drops this format."""
+    issue = {
+        "key": "IIM-308",
+        "fields": {**ISSUE["fields"], "customfield_18692": "2026-07-25 09:49"},
+    }
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = IIM",
+        extra_fields=[JiraField("as_ts", "customfield_18692", bq_type="TIMESTAMP")],
+    ).get_issues()
+
+    assert out["as_ts"] is None
+
+
+@responses.activate
+def test_date_typed_extra_field_is_normalized():
+    issue = {
+        "key": "IIM-308",
+        "fields": {**ISSUE["fields"], "customfield_15087": "2026-07-25"},
+    }
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = IIM",
+        extra_fields=[JiraField("declare_date", "customfield_15087", bq_type="DATE")],
+    ).get_issues()
+
+    assert out["declare_date"] == "2026-07-25"
+
+
+@responses.activate
+def test_option_valued_extra_fields_use_their_value_key():
+    """Severity and Detection Method are select fields: {'value': 'S3', 'id': ...}."""
+    issue = {
+        "key": "IIM-308",
+        "fields": {
+            **ISSUE["fields"],
+            "customfield_10319": {"value": "S3", "id": "10866"},
+            "customfield_12881": {"value": "Manual", "id": "14790"},
+            "customfield_18555": "phabricator",
+        },
+    }
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = IIM",
+        extra_fields=[
+            JiraField("severity", "customfield_10319"),
+            JiraField("detection_method", "customfield_12881"),
+            JiraField("affected_entities", "customfield_18555"),
+        ],
+    ).get_issues()
+
+    assert out["severity"] == "S3"
+    assert out["detection_method"] == "Manual"
+    assert out["affected_entities"] == "phabricator"

--- a/tests/jira/test_issues_fields.py
+++ b/tests/jira/test_issues_fields.py
@@ -366,3 +366,94 @@ def test_option_valued_extra_fields_use_their_value_key():
     assert out["severity"] == "S3"
     assert out["detection_method"] == "Manual"
     assert out["affected_entities"] == "phabricator"
+
+
+# --- review feedback: load-killing edge cases -------------------------------
+
+
+def test_extract_value_drops_unusable_list_elements():
+    """BigQuery rejects a null element inside a REPEATED column.
+
+    The scalar branch returns None for an unrecognised object shape so a dict
+    never reaches a STRING column. The list branch has to go further and drop
+    those elements: a REPEATED column with [None] fails the load with "Array
+    specifies a null element", which is the same outcome the scalar rule exists
+    to prevent.
+    """
+    assert extract_value([{"id": "1", "self": "https://..."}]) == []
+    assert extract_value([{"name": "a"}, {"id": "2"}, {"name": "b"}]) == ["a", "b"]
+    assert extract_value([None, "keep", None]) == ["keep"]
+
+
+@responses.activate
+def test_timestamp_typed_extra_field_survives_an_object_value():
+    """A TIMESTAMP field reconfigured to a select must not kill the run.
+
+    to_bq_timestamp hands its argument to strptime, which raises TypeError on a
+    dict. Only ValueError is caught, so the exception would escape and take the
+    whole load down rather than nulling one cell.
+    """
+    issue = {
+        "key": "ABC-1",
+        "fields": {**ISSUE["fields"], "customfield_1": {"value": "not a date"}},
+    }
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = ABC",
+        extra_fields=[JiraField("ts", "customfield_1", bq_type="TIMESTAMP")],
+    ).get_issues()
+
+    assert out["ts"] is None
+
+
+@responses.activate
+def test_repeated_field_wraps_a_bare_scalar():
+    """A single-value multi-select comes back unwrapped; keep the value."""
+    issue = {"key": "ABC-1", "fields": {**ISSUE["fields"], "customfield_1": "solo"}}
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = ABC",
+        extra_fields=[JiraField("tags", "customfield_1", mode="REPEATED")],
+    ).get_issues()
+
+    assert out["tags"] == ["solo"]
+
+
+@responses.activate
+def test_repeated_field_still_empty_when_jira_omits_it():
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = ABC",
+        extra_fields=[JiraField("tags", "customfield_99999", mode="REPEATED")],
+    ).get_issues()
+
+    assert out["tags"] == []
+
+
+@pytest.mark.parametrize("bad", ["DATETIEM", "TIMESTAMPZ", "", "string"])
+def test_jira_field_rejects_an_unknown_bq_type(bad):
+    """Caught at declaration, not at load: _extra_values would silently fall through."""
+    with pytest.raises(ValueError, match="bq_type"):
+        JiraField("x", "customfield_1", bq_type=bad)
+
+
+@pytest.mark.parametrize("good", ["STRING", "TIMESTAMP", "DATETIME", "DATE", "INT64"])
+def test_jira_field_accepts_supported_bq_types(good):
+    assert JiraField("x", "customfield_1", bq_type=good).bq_type == good
+
+
+def test_repeated_mode_rejects_a_parsed_scalar_type():
+    """DATE/DATETIME/TIMESTAMP parsers return a scalar, so REPEATED is always [].
+
+    Nothing declares this combination today; rejecting it stops a future table
+    from getting a permanently empty column with no error.
+    """
+    for bq_type in ("DATE", "DATETIME", "TIMESTAMP"):
+        with pytest.raises(ValueError, match="REPEATED"):
+            JiraField("x", "customfield_1", bq_type=bq_type, mode="REPEATED")

--- a/tests/jira/test_issues_fields.py
+++ b/tests/jira/test_issues_fields.py
@@ -1,0 +1,235 @@
+import pytest
+import responses
+from google.cloud import bigquery
+
+from bigquery_etl.jira.issues import (
+    OUTPUT_SCHEMA,
+    JiraAPI,
+    JiraField,
+    build_schema,
+    extract_value,
+)
+
+BASE = "https://jira.example.com"
+
+
+@pytest.fixture(autouse=True)
+def creds(monkeypatch):
+    monkeypatch.setenv("JIRA_USERNAME", "bot@example.com")
+    monkeypatch.setenv("JIRA_TOKEN", "secret")
+
+
+# --- extract_value: the shapes Jira actually returns -------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Scalars pass through.
+        ("plain text", "plain text"),
+        (7, 7),
+        (True, True),
+        (None, None),
+        # Objects: Jira nests the human-readable value under a different key
+        # depending on the field kind, so try them in order of specificity.
+        ({"name": "P1", "id": "3"}, "P1"),  # priority, status, resolution
+        ({"displayName": "Ada Lovelace", "accountId": "a1"}, "Ada Lovelace"),  # user
+        ({"value": "Self-Serve", "id": "10"}, "Self-Serve"),  # select customfield
+        ({"key": "SREIN", "name": "MozCloud Intake"}, "MozCloud Intake"),  # project
+        # An object with none of the known keys yields None rather than a dict,
+        # because a dict would fail the STRING column at load time.
+        ({"id": "10", "self": "https://..."}, None),
+        # Lists map elementwise, for REPEATED columns.
+        (["SREIN", "form"], ["SREIN", "form"]),
+        ([{"name": "a"}, {"name": "b"}], ["a", "b"]),
+        ([], []),
+    ],
+)
+def test_extract_value(raw, expected):
+    assert extract_value(raw) == expected
+
+
+def test_extract_value_prefers_name_over_value():
+    """Some customfields carry both; `name` is the label Jira shows."""
+    assert extract_value({"name": "Shown", "value": "Other"}) == "Shown"
+
+
+# --- build_schema ------------------------------------------------------------
+
+
+def test_build_schema_without_extras_is_the_base_schema():
+    assert build_schema() == OUTPUT_SCHEMA
+    assert build_schema(()) == OUTPUT_SCHEMA
+
+
+def test_base_schema_ends_with_updated():
+    """Appended, not inserted: a new column at the end is additive for consumers."""
+    assert [f.name for f in OUTPUT_SCHEMA][-1] == "updated"
+    assert OUTPUT_SCHEMA[-1].field_type == "TIMESTAMP"
+
+
+def test_build_schema_appends_extras_in_declared_order():
+    extras = [
+        JiraField("priority", "priority"),
+        JiraField("labels", "labels", mode="REPEATED"),
+        JiraField("story_points", "customfield_10014", bq_type="FLOAT64"),
+    ]
+    schema = build_schema(extras)
+
+    assert schema[: len(OUTPUT_SCHEMA)] == OUTPUT_SCHEMA
+    assert [(f.name, f.field_type, f.mode) for f in schema[len(OUTPUT_SCHEMA) :]] == [
+        ("priority", "STRING", "NULLABLE"),
+        ("labels", "STRING", "REPEATED"),
+        ("story_points", "FLOAT64", "NULLABLE"),
+    ]
+
+
+def test_build_schema_rejects_a_column_that_collides_with_the_base_schema():
+    """Silently shadowing `status` would produce two columns of the same name."""
+    with pytest.raises(ValueError, match="collides"):
+        build_schema([JiraField("status", "customfield_1")])
+
+
+def test_build_schema_rejects_duplicate_extra_columns():
+    with pytest.raises(ValueError, match="duplicate"):
+        build_schema([JiraField("p", "priority"), JiraField("p", "customfield_1")])
+
+
+# --- JiraAPI ----------------------------------------------------------------
+
+
+ISSUE = {
+    "key": "ABC-1",
+    "fields": {
+        "project": {"key": "ABC"},
+        "issuetype": {"name": "Epic"},
+        "summary": "Do the thing",
+        "status": {"name": "In Progress"},
+        "created": "2026-07-27T09:40:36.912-0400",
+        "updated": "2026-07-28T11:00:00.000-0400",
+        "resolutiondate": None,
+        "priority": {"name": "P1"},
+        "labels": ["SREIN", "form"],
+        "assignee": {"displayName": "Ada Lovelace"},
+    },
+}
+
+
+@responses.activate
+def test_updated_is_populated_and_utc_normalized():
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    (issue,) = JiraAPI(BASE, "project = ABC").get_issues()
+
+    assert issue["updated"] == "2026-07-28T15:00:00+00:00"
+    assert issue["created"] == "2026-07-27T13:40:36+00:00"
+
+
+@responses.activate
+def test_no_extras_yields_exactly_the_base_columns():
+    """Guards the two pre-existing tables: their output gains `updated` and nothing else."""
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    (issue,) = JiraAPI(BASE, "project = ABC").get_issues()
+
+    assert set(issue) == {f.name for f in OUTPUT_SCHEMA}
+
+
+@responses.activate
+def test_updated_is_always_requested_from_jira():
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    JiraAPI(BASE, "project = ABC").get_issues()
+
+    assert "updated" in responses.calls[0].request.url
+
+
+@responses.activate
+def test_extra_fields_are_extracted_onto_their_columns():
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+    extras = [
+        JiraField("priority", "priority"),
+        JiraField("assignee", "assignee"),
+        JiraField("labels", "labels", mode="REPEATED"),
+    ]
+
+    (issue,) = JiraAPI(BASE, "project = ABC", extra_fields=extras).get_issues()
+
+    assert issue["priority"] == "P1"
+    assert issue["assignee"] == "Ada Lovelace"
+    assert issue["labels"] == ["SREIN", "form"]
+    assert set(issue) == {f.name for f in OUTPUT_SCHEMA} | {
+        "priority",
+        "assignee",
+        "labels",
+    }
+
+
+@responses.activate
+def test_extra_fields_are_added_to_the_jira_request():
+    """A field Jira was never asked for comes back absent, not null."""
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    JiraAPI(
+        BASE, "project = ABC", extra_fields=[JiraField("sre", "customfield_10420")]
+    ).get_issues()
+
+    assert "customfield_10420" in responses.calls[0].request.url
+
+
+@responses.activate
+def test_a_missing_extra_field_is_null_not_absent():
+    """Every row must carry every column, or the NDJSON load produces a ragged table."""
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    (issue,) = JiraAPI(
+        BASE, "project = ABC", extra_fields=[JiraField("nope", "customfield_99999")]
+    ).get_issues()
+
+    assert issue["nope"] is None
+
+
+@responses.activate
+def test_a_missing_repeated_extra_field_is_an_empty_list():
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    (issue,) = JiraAPI(
+        BASE,
+        "project = ABC",
+        extra_fields=[JiraField("tags", "customfield_99999", mode="REPEATED")],
+    ).get_issues()
+
+    assert issue["tags"] == []
+
+
+@responses.activate
+def test_timestamp_typed_extra_fields_are_normalized():
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [ISSUE]})
+
+    (issue,) = JiraAPI(
+        BASE,
+        "project = ABC",
+        extra_fields=[JiraField("dup_updated", "updated", bq_type="TIMESTAMP")],
+    ).get_issues()
+
+    assert issue["dup_updated"] == "2026-07-28T15:00:00+00:00"
+
+
+def test_jira_field_rejects_an_unknown_mode():
+    with pytest.raises(ValueError, match="mode"):
+        JiraField("x", "y", mode="SOMETHING")
+
+
+def test_jira_field_defaults():
+    f = JiraField("priority", "priority")
+    assert (f.column, f.jira_field, f.bq_type, f.mode) == (
+        "priority",
+        "priority",
+        "STRING",
+        "NULLABLE",
+    )
+
+
+def test_build_schema_returns_bigquery_schema_fields():
+    schema = build_schema([JiraField("priority", "priority")])
+    assert all(isinstance(f, bigquery.SchemaField) for f in schema)

--- a/tests/jira/test_issues_fields.py
+++ b/tests/jira/test_issues_fields.py
@@ -457,3 +457,89 @@ def test_repeated_mode_rejects_a_parsed_scalar_type():
     for bq_type in ("DATE", "DATETIME", "TIMESTAMP"):
         with pytest.raises(ValueError, match="REPEATED"):
             JiraField("x", "customfield_1", bq_type=bq_type, mode="REPEATED")
+
+
+# --- utc_naive: zone-less strings that are known to be UTC -------------------
+#
+# The IIM incident timing fields carry no offset, but the incident data model
+# specifies UTC (confirmed by the incident process owner in review). utc_naive
+# is opt-in per field rather than a blanket rule for TIMESTAMP, so no other
+# table's TIMESTAMP field silently acquires a UTC assumption it cannot support.
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("2026-07-25 09:49", "2026-07-25T09:49:00+00:00"),
+        ("2026-07-25 09:49:12", "2026-07-25T09:49:12+00:00"),
+        ("2026-07-25T09:49", "2026-07-25T09:49:00+00:00"),
+        ("  2026-07-25 09:49  ", "2026-07-25T09:49:00+00:00"),
+        ("not a datetime", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_parse_utc_timestamp(raw, expected):
+    from bigquery_etl.jira.issues import parse_utc_timestamp
+
+    assert parse_utc_timestamp(raw) == expected
+
+
+def test_parse_utc_timestamp_is_not_local_time_dependent(monkeypatch):
+    """A naive strptime plus .astimezone() would use the container's local zone.
+
+    That would make the same input produce different output depending on where
+    the DAG ran, so the UTC zone is attached explicitly rather than inferred.
+    """
+    from bigquery_etl.jira.issues import parse_utc_timestamp
+
+    monkeypatch.setenv("TZ", "America/Los_Angeles")
+    assert parse_utc_timestamp("2026-07-25 09:49") == "2026-07-25T09:49:00+00:00"
+
+
+@responses.activate
+def test_utc_naive_field_is_stamped_utc():
+    issue = {
+        "key": "IIM-308",
+        "fields": {**ISSUE["fields"], "customfield_18692": "2026-07-25 09:49"},
+    }
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = IIM",
+        extra_fields=[
+            JiraField(
+                "time_declared",
+                "customfield_18692",
+                bq_type="TIMESTAMP",
+                utc_naive=True,
+            )
+        ],
+    ).get_issues()
+
+    assert out["time_declared"] == "2026-07-25T09:49:00+00:00"
+
+
+@responses.activate
+def test_timestamp_without_utc_naive_still_requires_an_offset():
+    """Guards the opt-in: a plain TIMESTAMP field must not gain a UTC assumption."""
+    issue = {
+        "key": "IIM-308",
+        "fields": {**ISSUE["fields"], "customfield_18692": "2026-07-25 09:49"},
+    }
+    responses.get(f"{BASE}/rest/api/3/search/jql", json={"issues": [issue]})
+
+    (out,) = JiraAPI(
+        BASE,
+        "project = IIM",
+        extra_fields=[JiraField("t", "customfield_18692", bq_type="TIMESTAMP")],
+    ).get_issues()
+
+    assert out["t"] is None
+
+
+def test_utc_naive_requires_a_timestamp_type():
+    """utc_naive only means anything on the TIMESTAMP path."""
+    with pytest.raises(ValueError, match="utc_naive"):
+        JiraField("x", "customfield_1", bq_type="DATETIME", utc_naive=True)

--- a/tests/jira/test_issues_schema_contract.py
+++ b/tests/jira/test_issues_schema_contract.py
@@ -1,0 +1,76 @@
+"""Bind each issues table's schema.yaml to the schema the integration produces.
+
+A load job carries an explicit schema and WRITE_TRUNCATEs, so it rewrites the
+table definition. Artifact deployment then rewrites it back from schema.yaml. If
+the two disagree, the table's schema flip-flops on every run and nobody can tell
+which side is wrong from the table alone. These tests make the two declarations
+fail together instead.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+from bigquery_etl.jira.issues import build_schema
+
+DATASET = (
+    Path(__file__).resolve().parents[2]
+    / "sql"
+    / "moz-fx-data-shared-prod"
+    / "jira_tickets_derived"
+)
+
+# Tables whose query.py declares no extra fields: their schema.yaml must equal
+# the base schema exactly.
+BASE_ONLY_TABLES = ["ffxp_epic_issues_v1", "iim_incident_issues_v1"]
+
+# Tables that declare EXTRA_FIELDS in query.py.
+EXTRA_FIELD_TABLES = ["srein_issues_v1"]
+
+
+def yaml_schema(table: str) -> list[tuple]:
+    """Read schema.yaml as (name, type, mode) triples in declared order."""
+    doc = yaml.safe_load((DATASET / table / "schema.yaml").read_text())
+    return [(f["name"], f["type"], f.get("mode", "NULLABLE")) for f in doc["fields"]]
+
+
+def expected_schema(extra_fields=()) -> list[tuple]:
+    """Same triples, from the schema the integration would send to BigQuery."""
+    return [(f.name, f.field_type, f.mode) for f in build_schema(extra_fields)]
+
+
+def load_extra_fields(table: str):
+    """Import a table's query.py and return its EXTRA_FIELDS.
+
+    Importing is safe: every query.py guards execution behind `__main__`.
+    """
+    path = DATASET / table / "query.py"
+    spec = importlib.util.spec_from_file_location(f"{table}_query", path)
+    assert spec is not None and spec.loader is not None, f"cannot import {path}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, "EXTRA_FIELDS", ())
+
+
+@pytest.mark.parametrize("table", BASE_ONLY_TABLES)
+def test_base_only_table_matches_the_base_schema(table):
+    assert yaml_schema(table) == expected_schema()
+
+
+@pytest.mark.parametrize("table", BASE_ONLY_TABLES + EXTRA_FIELD_TABLES)
+def test_every_table_starts_with_the_base_schema(table):
+    """Extras are appended, never interleaved, so the base is always a prefix."""
+    base = expected_schema()
+    assert yaml_schema(table)[: len(base)] == base
+
+
+@pytest.mark.parametrize("table", EXTRA_FIELD_TABLES)
+def test_extra_field_table_matches_its_declared_fields(table):
+    assert yaml_schema(table) == expected_schema(load_extra_fields(table))
+
+
+@pytest.mark.parametrize("table", BASE_ONLY_TABLES + EXTRA_FIELD_TABLES)
+def test_every_table_has_updated(table):
+    assert "updated" in [name for name, _, _ in yaml_schema(table)]

--- a/tests/jira/test_issues_schema_contract.py
+++ b/tests/jira/test_issues_schema_contract.py
@@ -22,24 +22,6 @@ DATASET = (
     / "jira_tickets_derived"
 )
 
-# Tables whose query.py declares no extra fields: their schema.yaml must equal
-# the base schema exactly.
-BASE_ONLY_TABLES = ["ffxp_epic_issues_v1"]
-
-# Tables that declare EXTRA_FIELDS in query.py.
-EXTRA_FIELD_TABLES = ["srein_issues_v1", "iim_incident_issues_v1"]
-
-
-def yaml_schema(table: str) -> list[tuple]:
-    """Read schema.yaml as (name, type, mode) triples in declared order."""
-    doc = yaml.safe_load((DATASET / table / "schema.yaml").read_text())
-    return [(f["name"], f["type"], f.get("mode", "NULLABLE")) for f in doc["fields"]]
-
-
-def expected_schema(extra_fields=()) -> list[tuple]:
-    """Same triples, from the schema the integration would send to BigQuery."""
-    return [(f.name, f.field_type, f.mode) for f in build_schema(extra_fields)]
-
 
 def load_extra_fields(table: str):
     """Import a table's query.py and return its EXTRA_FIELDS.
@@ -54,12 +36,45 @@ def load_extra_fields(table: str):
     return getattr(module, "EXTRA_FIELDS", ())
 
 
+def issues_tables() -> list[str]:
+    """Every table in the dataset whose query.py drives the issues integration.
+
+    Discovered rather than listed: a hardcoded list means the next issues table
+    added here silently gets no coverage, and the schema flip-flop this file
+    exists to catch would just happen quietly on the new table instead.
+    """
+    return sorted(
+        path.parent.name
+        for path in DATASET.glob("*/query.py")
+        if "JiraIssueBigQueryIntegration" in path.read_text()
+    )
+
+
+ALL_TABLES = issues_tables()
+
+# The split falls out of whether the module defines EXTRA_FIELDS, so a table
+# moves between these by editing its query.py and nothing else.
+BASE_ONLY_TABLES = [t for t in ALL_TABLES if not load_extra_fields(t)]
+EXTRA_FIELD_TABLES = [t for t in ALL_TABLES if load_extra_fields(t)]
+
+
+def yaml_schema(table: str) -> list[tuple]:
+    """Read schema.yaml as (name, type, mode) triples in declared order."""
+    doc = yaml.safe_load((DATASET / table / "schema.yaml").read_text())
+    return [(f["name"], f["type"], f.get("mode", "NULLABLE")) for f in doc["fields"]]
+
+
+def expected_schema(extra_fields=()) -> list[tuple]:
+    """Same triples, from the schema the integration would send to BigQuery."""
+    return [(f.name, f.field_type, f.mode) for f in build_schema(extra_fields)]
+
+
 @pytest.mark.parametrize("table", BASE_ONLY_TABLES)
 def test_base_only_table_matches_the_base_schema(table):
     assert yaml_schema(table) == expected_schema()
 
 
-@pytest.mark.parametrize("table", BASE_ONLY_TABLES + EXTRA_FIELD_TABLES)
+@pytest.mark.parametrize("table", ALL_TABLES)
 def test_every_table_starts_with_the_base_schema(table):
     """Extras are appended, never interleaved, so the base is always a prefix."""
     base = expected_schema()
@@ -71,6 +86,17 @@ def test_extra_field_table_matches_its_declared_fields(table):
     assert yaml_schema(table) == expected_schema(load_extra_fields(table))
 
 
-@pytest.mark.parametrize("table", BASE_ONLY_TABLES + EXTRA_FIELD_TABLES)
+@pytest.mark.parametrize("table", ALL_TABLES)
 def test_every_table_has_updated(table):
     assert "updated" in [name for name, _, _ in yaml_schema(table)]
+
+
+def test_discovery_finds_every_issues_table():
+    """Guards the discovery itself: a glob that silently matches nothing passes everything."""
+    assert set(ALL_TABLES) >= {
+        "ffxp_epic_issues_v1",
+        "iim_incident_issues_v1",
+        "srein_issues_v1",
+    }
+    assert BASE_ONLY_TABLES and EXTRA_FIELD_TABLES
+    assert set(BASE_ONLY_TABLES) & set(EXTRA_FIELD_TABLES) == set()

--- a/tests/jira/test_issues_schema_contract.py
+++ b/tests/jira/test_issues_schema_contract.py
@@ -24,10 +24,10 @@ DATASET = (
 
 # Tables whose query.py declares no extra fields: their schema.yaml must equal
 # the base schema exactly.
-BASE_ONLY_TABLES = ["ffxp_epic_issues_v1", "iim_incident_issues_v1"]
+BASE_ONLY_TABLES = ["ffxp_epic_issues_v1"]
 
 # Tables that declare EXTRA_FIELDS in query.py.
-EXTRA_FIELD_TABLES = ["srein_issues_v1"]
+EXTRA_FIELD_TABLES = ["srein_issues_v1", "iim_incident_issues_v1"]
 
 
 def yaml_schema(table: str) -> list[tuple]:


### PR DESCRIPTION
## Description

This PR extends the Jira **issues** integration so a table can attach arbitrary Jira fields and get an `updated` timestamp, then uses that to add incident detail/timing fields to `iim_incident_issues_v1` and to add a new `srein_issues_v1` snapshot table. It also fixes the scope of `srein_events_v1`, which was silently under-reporting.

Three commits, reviewable in order.

### 1. `srein_events_v1` scope: `project = SREIN OR labels = SREIN`

MozCloud Intake tickets are routinely triaged and **moved** to the owning team's project. A move changes the issue key and drops the ticket out of `project = SREIN`, taking its entire event history with it — so the table under-reported and nothing indicated it.

Confirmed against the live API: `labels = SREIN AND project != SREIN` returns tickets now sitting in **MZCLD, SVCSE, PAY, WT, INFRASEC, FXA, RELOPS and DENG**, none of which were in the table. After re-seeding, issue coverage went from **639 → 1,347**, and `project_key` now shows `SREIN 641 · SVCSE 486 · MZCLD 178` plus nine more projects.

The label alone is not sufficient either: `project = SREIN AND (labels IS EMPTY OR labels != SREIN)` returns 50+ in-project tickets, mostly older ones labelled only `form`/`form-1344`, which predate the automation that applies the `SREIN` label. Hence the union rather than swapping one predicate for the other.

Two consequences called out in the table description: **`project_key` is no longer always SREIN**, and `issue_key` is the ticket's *current* key, with the rename recorded as `field_change` rows on `Key` and `project`.

### 2. Extra fields + `updated` on the issues integration

`updated` joins the base schema for every issues table. Additional fields are declared per table as `JiraField` specs and passed to `run(args, extra_fields=...)`:

```python
EXTRA_FIELDS = [
    JiraField("priority", "priority"),
    JiraField("labels", "labels", mode="REPEATED"),
    JiraField("time_declared", "customfield_18692", bq_type="DATETIME"),
]
integration.run(args, extra_fields=EXTRA_FIELDS)
```

Extras are appended after the base columns, never interleaved, so the base schema stays a prefix of every table's output.

`extra_fields` is an explicit `run()` parameter rather than an attribute read off `args`: a table wanting nothing extra calls `run(args)` exactly as before, and there is no namespace contract for a copied `query.py` to forget.

`extract_value` reduces a raw Jira value to something a scalar column can hold — bare scalars pass through, objects read `name` → `displayName` → `value` (covering priority/status/resolution, users, and single-select customfields), arrays map elementwise. An unrecognised object shape yields `NULL` rather than the dict, because a dict would fail the column type at load time and take the whole run down. A field Jira omitted still appears on the row as `NULL` (or `[]` when `REPEATED`), since an NDJSON load infers nothing from an absent key.

Validation happens at declaration time, inside `JiraAPI`'s constructor, so a bad spec fails before any network or BigQuery call: a column colliding with a base column, a duplicate extra, or an invalid mode all raise.

**Backward compatibility.** `ffxp_epic_issues_v1` declares no extras; its `query.py` is untouched and its output is unchanged apart from gaining `updated`. That column *is* added to its `schema.yaml`, and not optionally — the load carries an explicit schema and `WRITE_TRUNCATE`s, so without the yaml edit the table definition would flip-flop between the load job and artifact deployment on every run.

Also adds `srein_issues_v1` (priority/assignee/reporter/resolution/labels), which gives current priority for all tickets — the events table only records priority *changes*, so a ticket created at the P1 default and never touched has no priority signal there at all.

### 3. Incident detail and timing fields on `iim_incident_issues_v1`

Twelve columns: `affected_entities`, `severity`, `detection_method`, `declare_date`, `impact_start`, and the seven `Time *` fields.

Field ids came from `/rest/api/3/issue/IIM-308?expand=names` rather than being inferred from display names, and that mattered twice:

- **`Severity` is ambiguous.** Three fields match: `customfield_10319` (the one on the incident form, value `S3`), `customfield_11852` "Severity Level" (value `"0.0"`), `customfield_10716` "Requested Severity Level". Its stored name also carries a trailing space.
- **The `Time *` fields are free text, not datetimes.** They hold `"2026-07-25 09:49"` — no `T`, no seconds, no offset.

That second point had two independent ways of silently producing an all-NULL column, both now closed:

1. `TIMESTAMP` would NULL every row, because `to_bq_timestamp` only parses ISO-with-offset. A test pins this so the reason `DATETIME` exists is not lost.
2. Passing the raw string through would *also* NULL every row — **verified**: `SAFE_CAST('2026-07-25 09:49' AS DATETIME)` returns `NULL`, while `'2026-07-25 09:49:00'` casts fine. So normalising to canonical seconds is required, not defensive.

`parse_datetime` accepts `%Y-%m-%d %H:%M[:%S]` with either separator and emits `YYYY-MM-DD HH:MM:SS`; `parse_date` accepts a bare date or a datetime, keeping the date part. Both return `NULL` on unparseable input — these are free-text fields, so one typo in Jira would otherwise fail the load for the entire table.

`DATETIME` rather than `TIMESTAMP` is deliberate: the source carries no offset, so there is no zone to convert from and `TIMESTAMP` would imply one that does not exist.

## Reviewer notes

**`iim_incident_issues_v1` and `ffxp_epic_issues_v1` are owned by mcastelluccio@mozilla.com.** Both changes are additive and nullable, but their `schema.yaml` files are now bound to the integration's output by a new contract test — worth knowing before a future field edit.

**Why the contract test exists.** A load job carries an explicit schema and `WRITE_TRUNCATE`s, so it rewrites the table definition; artifact deployment then rewrites it back from `schema.yaml`. If the two disagree the schema flip-flops every run and the table alone cannot tell you which side is wrong. `tests/jira/test_issues_schema_contract.py` binds each table's `schema.yaml` to the schema the integration produces, so the two now fail together. Verified it fails on a deliberately wrong column type.

**Caveats worth reading in the table descriptions rather than the diff:** the timing values are backfilled from the incident report, so they can predate the ticket (IIM-308 was alerted 07-24, created 07-27), and they carry no timezone, so cross-incident duration maths is only as consistent as whoever filled in the report.

## Testing

157 tests in `tests/jira/`, HTTP mocked with `responses`. Covers `extract_value` against the object shapes Jira actually returns, `parse_datetime`/`parse_date` including malformed input, extra-field extraction and request construction, the missing-field-is-NULL contract, declaration-time validation, and a regression test that a no-extras table yields exactly the base columns.

End-to-end extraction verified against the real IIM-308 payload — all 20 columns populate and the row keys match the built schema:

```
severity = 'S3'   detection_method = 'Manual'   affected_entities = 'phabricator'
declare_date = '2026-07-25'   time_declared = '2026-07-25 09:49:00'
time_alerted = '2026-07-24 19:52:00'   impact_start = None
```

DATETIME/DATE round-trips and duration maths checked directly against BigQuery: alert→acknowledged 1,283 min, declared→mitigated 463 min, NULL `impact_start` yields a NULL duration rather than an error.

## Deployment

`srein_events_v1` needs a re-seed to pick up the previously-missing tickets (already done in the dev pass that produced the coverage numbers above). `srein_issues_v1` is a new full-refresh snapshot table. `iim_incident_issues_v1` and `ffxp_epic_issues_v1` populate their new columns on their next scheduled run.

## Related Tickets & Documents
* Follow-up to DENG-11416 (the original Jira events integration, #9736)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
