### PR TITLE
chore(DENG-11413): Initiate backfill of ech and doh adoption rate

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/doh_adoption_rate_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/doh_adoption_rate_v1/backfill.yaml
@@ -1,3 +1,11 @@
+2026-07-30:
+  start_date: 2025-11-03
+  end_date: 2026-07-29
+  reason: 'Bug 2057822'
+  watchers:
+  - efilho@mozilla.com
+  status: Initiate
+
 2025-11-03:
   start_date: 2025-01-01
   end_date: 2025-11-02

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/backfill.yaml
@@ -1,0 +1,7 @@
+2026-07-30:
+  start_date: 2025-11-01
+  end_date: 2026-07-29
+  reason: 'Bug 2057822'
+  watchers:
+  - efilho@mozilla.com
+  status: Initiate


### PR DESCRIPTION
## Description

bug [2057822](https://bugzilla.mozilla.org/show_bug.cgi?id=2057822)

The researchers who consume the data need an extension.

Start dates are based on checks done on the public tables (`mozilla-public-data.telemetry_derived.doh_adoption_rate_v1` and `mozilla-public-data.telemetry_derived.ech_adoption_rate_v1`) for their `MAX(submission_date)` 
  
## Related Tickets & Documents
* DENG-11413

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
