### PR TITLE
chore(DENG-11413): Complete backfill of ech and doh adoption rate and resume DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2344,7 +2344,6 @@ bqetl_ech_adoption_rate:
       - efilho@mozilla.com
     email_on_failure: true
     email_on_retry: true
-    end_date: '2025-10-31'
     owner: efilho@mozilla.com
     retries: 2
     retry_delay: 30m

--- a/dags.yaml
+++ b/dags.yaml
@@ -2350,8 +2350,7 @@ bqetl_ech_adoption_rate:
     start_date: '2025-04-28'
   description: |
     Tracks ECH adoption across countries and ISPs over time.
-    To be disabled after 2025-10-31.
-    bug 1957082
+    bugs 1957082, 2057822
   repo: bigquery-etl
   schedule_interval: daily
   tags:

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/doh_adoption_rate_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/doh_adoption_rate_v1/backfill.yaml
@@ -4,7 +4,7 @@
   reason: 'Bug 2057822'
   watchers:
   - efilho@mozilla.com
-  status: Initiate
+  status: Complete
 
 2025-11-03:
   start_date: 2025-01-01

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/ech_adoption_rate_v1/backfill.yaml
@@ -4,4 +4,4 @@
   reason: 'Bug 2057822'
   watchers:
   - efilho@mozilla.com
-  status: Initiate
+  status: Complete


### PR DESCRIPTION
## Description

Completes backfill https://github.com/mozilla/bigquery-etl/pull/9747
Also removes `bqetl_ech_adoption_rate`'s `end_date` to keep the DAG running, as requested in the ticket. I will manually run the DAG to cover any gaps from the backfilled data to date.

## Related Tickets & Documents
* DENG-11413


<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
