### PR TITLE
fix(glam): Compute power of 2 buckets the same way Glean does

### DIFF
--- a/sql/mozfun/glam/histogram_generate_functional_buckets/udf.sql
+++ b/sql/mozfun/glam/histogram_generate_functional_buckets/udf.sql
@@ -10,19 +10,27 @@ RETURNS ARRAY<FLOAT64> AS (
       -- Generate all bucket indexes
       -- https://github.com/mozilla/glean/blob/main/glean-core/src/histogram/functional.rs
       SELECT
+        -- Glean precomputes this exponent once and raises it to the bucket index; the
+        -- rounding of this intermediate value is what makes the bucket minimums match.
+        -- Must not be "simplified" to POW(log_base, idx / buckets_per_magnitude).
+        -- See https://github.com/mozilla/glam/issues/3537 for more details.
+        POW(log_base, 1 / buckets_per_magnitude) AS exponent,
         GENERATE_ARRAY(0, CEIL(LOG(range_max + 1, log_base) * buckets_per_magnitude)) AS indexes
     ),
-    buckets AS (
-      -- The evaluation order below is deliberate and must not be "simplified" to
-      -- POW(log_base, idx / buckets_per_magnitude).
-      -- See https://github.com/mozilla/glam/issues/3537 for more details.
+    all_buckets AS (
       SELECT
-        FLOOR(POW(POW(log_base, 1 / buckets_per_magnitude), idx)) AS bucket
+        FLOOR(POW(exponent, idx)) AS bucket
       FROM
         bucket_indexes,
         UNNEST(indexes) AS idx
+    ),
+    buckets AS (
+      SELECT
+        bucket
+      FROM
+        all_buckets
       WHERE
-        FLOOR(POW(POW(log_base, 1 / buckets_per_magnitude), idx)) <= range_max
+        bucket <= range_max
     )
     SELECT
       ARRAY_CONCAT([0.0], ARRAY_AGG(DISTINCT(bucket) ORDER BY bucket))
@@ -63,9 +71,10 @@ SELECT
         expect = actual
     )
   ),
-  -- Bucket minimums at powers of two must match Glean, which truncates them to
-  -- 2^n - 1. Emitting 2^n instead makes downstream bucket fills drop every
-  -- sample that lands on a power-of-two bucket minimum.
+  -- At buckets_per_magnitude = 16 every power-of-two bucket minimum evaluates to just
+  -- under 2^n, so Glean reports 2^n - 1 and emitting 2^n makes downstream fills drop
+  -- those samples. Specific to this magnitude: at 8 they are exact for every value
+  -- Glean can record, hence the 16, 32, 64 ... expected by the (2, 8, 305) case above.
   assert.array_equals(
     [31, 1023, 32767, 65535, 268435455],
     ARRAY(

--- a/sql/mozfun/glam/histogram_generate_functional_buckets/udf.sql
+++ b/sql/mozfun/glam/histogram_generate_functional_buckets/udf.sql
@@ -13,13 +13,16 @@ RETURNS ARRAY<FLOAT64> AS (
         GENERATE_ARRAY(0, CEIL(LOG(range_max + 1, log_base) * buckets_per_magnitude)) AS indexes
     ),
     buckets AS (
+      -- The evaluation order below is deliberate and must not be "simplified" to
+      -- POW(log_base, idx / buckets_per_magnitude).
+      -- See https://github.com/mozilla/glam/issues/3537 for more details.
       SELECT
-        FLOOR(POW(log_base, (idx) / buckets_per_magnitude)) AS bucket
+        FLOOR(POW(POW(log_base, 1 / buckets_per_magnitude), idx)) AS bucket
       FROM
         bucket_indexes,
         UNNEST(indexes) AS idx
       WHERE
-        FLOOR(POW(log_base, (idx) / buckets_per_magnitude)) <= range_max
+        FLOOR(POW(POW(log_base, 1 / buckets_per_magnitude), idx)) <= range_max
     )
     SELECT
       ARRAY_CONCAT([0.0], ARRAY_AGG(DISTINCT(bucket) ORDER BY bucket))
@@ -58,5 +61,21 @@ SELECT
         UNNEST(glam.histogram_generate_functional_buckets(2, 16, 774282 + 1)) actual
       WHERE
         expect = actual
+    )
+  ),
+  -- Bucket minimums at powers of two must match Glean, which truncates them to
+  -- 2^n - 1. Emitting 2^n instead makes downstream bucket fills drop every
+  -- sample that lands on a power-of-two bucket minimum.
+  assert.array_equals(
+    [31, 1023, 32767, 65535, 268435455],
+    ARRAY(
+      SELECT
+        bucket
+      FROM
+        UNNEST(glam.histogram_generate_functional_buckets(2, 16, 536870911)) AS bucket
+      WHERE
+        bucket IN (31, 32, 1023, 1024, 32767, 32768, 65535, 65536, 268435455, 268435456)
+      ORDER BY
+        bucket
     )
   )


### PR DESCRIPTION
## Description

fixes https://github.com/mozilla/glam/issues/3537

Fixes the BQ implementation of functional bucket calculation to match the Glean one for bucket labels that are power of 2.


## Related Tickets & Documents
* DENG-11449

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
