### PR TITLE
Bug 2054553 - Drop avg_dns_failure_time from internet_outages not_null checks

### DIFF
--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v1/checks.sql
@@ -13,6 +13,12 @@
 
   "avg_tls_handshake_time"
   "count_dns_failure"
+
+  Same reason, see bug 2054553: `avg_dns_failure_time` is LEFT JOINed
+  from the `dns_failure_time` CTE, which filters `key > 0` and requires
+  more than 50 rows per group, so it is NULL for sparse city/hour cells.
+
+  "avg_dns_failure_time"
 */
 {{ not_null(columns=[
   "datetime",
@@ -26,7 +32,6 @@
   "proportion_channel_open",
   "avg_dns_success_time",
   "missing_dns_success",
-  "avg_dns_failure_time",
   "missing_dns_failure",
   "ssl_error_prop",
 

--- a/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v2/checks.sql
+++ b/sql/moz-fx-data-shared-prod/internet_outages/global_outages_v2/checks.sql
@@ -15,6 +15,12 @@
 
   "avg_tls_handshake_time"
   "count_dns_failure"
+
+  Same reason, see bug 2054553: `avg_dns_failure_time` is LEFT JOINed
+  from the `dns_failure_time` CTE, which filters `key > 0` and requires
+  more than 50 rows per group, so it is NULL for sparse city/hour cells.
+
+  "avg_dns_failure_time"
 */
 {{ not_null(columns=[
   "country",
@@ -28,7 +34,6 @@
   "proportion_channel_open",
   "avg_dns_success_time",
   "missing_dns_success",
-  "avg_dns_failure_time",
   "missing_dns_failure",
   "ssl_error_prop",
 


### PR DESCRIPTION
`avg_dns_failure_time` comes from the `dns_failure_time` CTE, which is LEFT JOINed onto the DAU spine and internally filters `key > 0` with `HAVING COUNT(*) > 50`. Any (country, city, hour) cell that has DAUs but too few positive DNS-failure histogram rows gets no match, so the column is NULL by construction. Asserting not_null on it is unsatisfiable whenever the data is sparse; the check has failed continuously since the 2026-07-12 run.

This is the same class of problem #4706 fixed for bug 1868674, which removed count_dns_failure and avg_tls_handshake_time from this list. count_dns_failure reads the same dns_failure_src CTE as dns_failure_time, so removing one and keeping the other was an incomplete fix.

v1 and v2 carry identical lists (v2 was copied from v1 in #5952), which is why both tasks fail in lockstep.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=2054553