### PR TITLE
feat(sumo_metrics): extend kb_quality_metrics_article_v1 history back to 2024-01-01

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/metadata.yaml
@@ -5,11 +5,15 @@ description: |
 
   Grain: Day x Article (document_id)
 
-  For each in-scope en-US article and each day in the trailing 1-year window:
+  Covers all available history: the date spine starts at the earliest signal in
+  the sources (first approved revision or first vote) and runs through yesterday.
+  An article's first row is the date of its first approved revision.
+
+  For each in-scope en-US article and each day in that range:
   - days_since_last_revision / fresh_ind: freshness vs. a 365-day window
   - helpful_votes / total_votes: votes cast that day
-  - running_helpful_votes / running_total_votes: cumulative votes (seeded with
-    pre-window totals)
+  - running_helpful_votes / running_total_votes: cumulative votes over all
+    history
 
   Article scope (matching the KB quality dashboard query):
   - parent_id IS NULL (original, non-translated), is_archived = FALSE
@@ -17,7 +21,14 @@ description: |
   - products NOT LIKE '%thunderbird%', locale = 'en-US'
   - product (via mozfun.customer_experience.normalize_product) != 'Other'
 
-  Recomputed in full each run (relative-date window, no date partition).
+  Recomputed in full each run (no date partition parameter).
+
+  Caveat — survivorship bias: the article population is a *current* snapshot
+  (is_archived = FALSE, today's category/products/product mapping). Historical
+  event_dates therefore only include articles that still exist and are
+  unarchived today, so article counts trend upward over time partly for this
+  reason. fresh_ind itself is a valid point-in-time measure (computed against
+  each event_date, not today); only the population is biased.
 
   Used by:
   - kb_quality_metrics_daily_v1 (day-level aggregation + moving averages)
@@ -30,6 +41,11 @@ labels:
   application: sumo
   type: base_metrics
   schedule: daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: event_date
+    require_partition_filter: false
 scheduling:
   dag_name: bqetl_sumo_metrics
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/metadata.yaml
@@ -5,15 +5,14 @@ description: |
 
   Grain: Day x Article (document_id)
 
-  Covers all available history: the date spine starts at the earliest signal in
-  the sources (first approved revision or first vote) and runs through yesterday.
-  An article's first row is the date of its first approved revision.
+  Covers 2024-01-01 through yesterday. An article's first row is the later of
+  2024-01-01 and the date of its first approved revision.
 
   For each in-scope en-US article and each day in that range:
   - days_since_last_revision / fresh_ind: freshness vs. a 365-day window
   - helpful_votes / total_votes: votes cast that day
-  - running_helpful_votes / running_total_votes: cumulative votes over all
-    history
+  - running_helpful_votes / running_total_votes: all-time cumulative votes
+    (in-window votes on top of a pre-2024 seed)
 
   Article scope (matching the KB quality dashboard query):
   - parent_id IS NULL (original, non-translated), is_archived = FALSE
@@ -23,15 +22,14 @@ description: |
 
   Recomputed in full each run (no date partition parameter).
 
-  Caveat — helpfulness has a later start than freshness: the source table
-  metrics_kb_votes_details only holds votes from 2023-01-01 onward, so on
-  earlier event_dates helpful_votes / total_votes are NULL and the running
-  totals are 0. Freshness columns go back to the first approved revision of the
-  oldest in-scope article (2009-07-17 as of 2026-08). Downstream
-  helpful_percentage_14_ma is therefore NULL before 2023.
+  The 2024-01-01 start is a deliberate floor, not a data limit. Freshness could
+  extend back to 2009 and votes (metrics_kb_votes_details) to 2023-01-01, but
+  the window is capped to keep the table small enough that it needs no
+  partitioning. Pre-2024 votes are not lost — they are folded into the running
+  totals via the seed.
 
   Caveat — survivorship bias: the article population is a *current* snapshot
-  (is_archived = FALSE, today's category/products/product mapping). Historical
+  (is_archived = FALSE, today's category/products/product mapping). Earlier
   event_dates therefore only include articles that still exist and are
   unarchived today, so article counts trend upward over time partly for this
   reason. fresh_ind itself is a valid point-in-time measure (computed against
@@ -48,11 +46,6 @@ labels:
   application: sumo
   type: base_metrics
   schedule: daily
-bigquery:
-  time_partitioning:
-    type: day
-    field: event_date
-    require_partition_filter: false
 scheduling:
   dag_name: bqetl_sumo_metrics
   date_partition_parameter: null

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/metadata.yaml
@@ -23,6 +23,13 @@ description: |
 
   Recomputed in full each run (no date partition parameter).
 
+  Caveat — helpfulness has a later start than freshness: the source table
+  metrics_kb_votes_details only holds votes from 2023-01-01 onward, so on
+  earlier event_dates helpful_votes / total_votes are NULL and the running
+  totals are 0. Freshness columns go back to the first approved revision of the
+  oldest in-scope article (2009-07-17 as of 2026-08). Downstream
+  helpful_percentage_14_ma is therefore NULL before 2023.
+
   Caveat — survivorship bias: the article population is a *current* snapshot
   (is_archived = FALSE, today's category/products/product mapping). Historical
   event_dates therefore only include articles that still exist and are

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/query.sql
@@ -7,11 +7,11 @@
 --   html NOT LIKE '%REDIRECT%' -- exclude decommissioned redirect articles
 --   products NOT LIKE '%thunderbird%' -- Thunderbird support handled separately
 --
--- Full recompute over all available history each run (no date partition parameter).
--- The date spine starts at the earliest signal in the sources (first approved
--- revision or first vote); days before an article's own first approved revision
+-- Full recompute each run over a fixed window starting 2024-01-01 (no date
+-- partition parameter). Days before an article's own first approved revision
 -- produce no row, because `daily_freshness_per_article` requires
--- reviewed_date <= event_date.
+-- reviewed_date <= event_date. Votes cast before the window start are folded
+-- into `historical_helpfulness` so the running totals stay all-time cumulative.
 WITH articles AS (
   SELECT
     *
@@ -41,27 +41,28 @@ daily_votes AS (
     url,
     locale
 ),
--- Earliest date with any signal: first approved revision or first vote.
--- MIN ignores NULLs, so this survives either source being empty.
+-- First event_date in the table. Single source of truth for the spine start and
+-- the pre-window vote seed below.
 window_start AS (
   SELECT
-    MIN(d) AS start_date
-  FROM
-    UNNEST(
-      [
-        (SELECT MIN(vote_date) FROM daily_votes),
-        (
-          SELECT
-            MIN(DATE(reviewed))
-          FROM
-            `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_revision`
-          WHERE
-            is_approved
-        )
-      ]
-    ) AS d
+    DATE '2024-01-01' AS start_date
 ),
--- Daily date spine x each article, covering all history.
+-- Vote totals accrued before the window start, used to seed running totals so
+-- they remain all-time cumulative. Derived from `daily_votes` to avoid a second
+-- scan of the source table.
+historical_helpfulness AS (
+  SELECT
+    document_id,
+    SUM(helpful_votes) AS historical_helpful_votes,
+    SUM(total_votes) AS historical_total_votes
+  FROM
+    daily_votes
+  WHERE
+    vote_date < (SELECT start_date FROM window_start)
+  GROUP BY
+    document_id
+),
+-- Daily date spine x each article, from the window start through yesterday.
 dates AS (
   SELECT
     document_id,
@@ -125,8 +126,8 @@ daily_freshness_per_article AS (
     )
 ),
 -- For each day, the daily and running cumulative helpfulness votes per article.
--- The spine starts at or before the first vote, so the running totals are
--- cumulative over all history without needing a pre-window seed.
+-- Running totals are all-time: in-window votes accumulate on top of the
+-- pre-window seed.
 daily_helpfulness_per_article AS (
   SELECT
     dates.event_date,
@@ -135,13 +136,13 @@ daily_helpfulness_per_article AS (
     help.locale,
     help.helpful_votes,
     help.total_votes,
-    SUM(COALESCE(help.helpful_votes, 0)) OVER (
+    COALESCE(hh.historical_helpful_votes, 0) + SUM(COALESCE(help.helpful_votes, 0)) OVER (
       PARTITION BY
         dates.document_id
       ORDER BY
         dates.event_date
     ) AS running_helpful_votes,
-    SUM(COALESCE(help.total_votes, 0)) OVER (
+    COALESCE(hh.historical_total_votes, 0) + SUM(COALESCE(help.total_votes, 0)) OVER (
       PARTITION BY
         dates.document_id
       ORDER BY
@@ -153,6 +154,9 @@ daily_helpfulness_per_article AS (
     daily_votes help
     ON dates.event_date = help.vote_date
     AND dates.document_id = help.document_id
+  LEFT JOIN
+    historical_helpfulness hh
+    ON dates.document_id = hh.document_id
 ),
 -- Article-level daily metrics with product mapping applied.
 main AS (

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/query.sql
@@ -7,7 +7,11 @@
 --   html NOT LIKE '%REDIRECT%' -- exclude decommissioned redirect articles
 --   products NOT LIKE '%thunderbird%' -- Thunderbird support handled separately
 --
--- Full recompute over a trailing 1-year window each run (no date partition).
+-- Full recompute over all available history each run (no date partition parameter).
+-- The date spine starts at the earliest signal in the sources (first approved
+-- revision or first vote); days before an article's own first approved revision
+-- produce no row, because `daily_freshness_per_article` requires
+-- reviewed_date <= event_date.
 WITH articles AS (
   SELECT
     *
@@ -20,7 +24,44 @@ WITH articles AS (
     AND html NOT LIKE '%REDIRECT%'
     AND products NOT LIKE '%thunderbird%'
 ),
--- Daily date spine x each article, covering the trailing year.
+-- All-time daily vote totals per article (no date bound).
+daily_votes AS (
+  SELECT
+    DATE(vote_created_date) AS vote_date,
+    document_id,
+    url,
+    locale,
+    SUM(CAST(helpful AS INT64)) AS helpful_votes,
+    COUNT(*) AS total_votes
+  FROM
+    `moz-fx-data-shared-prod.sumo_syndicate.metrics_kb_votes_details`
+  GROUP BY
+    vote_date,
+    document_id,
+    url,
+    locale
+),
+-- Earliest date with any signal: first approved revision or first vote.
+-- MIN ignores NULLs, so this survives either source being empty.
+window_start AS (
+  SELECT
+    MIN(d) AS start_date
+  FROM
+    UNNEST(
+      [
+        (SELECT MIN(vote_date) FROM daily_votes),
+        (
+          SELECT
+            MIN(DATE(reviewed))
+          FROM
+            `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_revision`
+          WHERE
+            is_approved
+        )
+      ]
+    ) AS d
+),
+-- Daily date spine x each article, covering all history.
 dates AS (
   SELECT
     document_id,
@@ -30,7 +71,7 @@ dates AS (
   CROSS JOIN
     UNNEST(
       GENERATE_DATE_ARRAY(
-        DATE(CURRENT_DATE - INTERVAL 1 YEAR),
+        (SELECT start_date FROM window_start),
         DATE(CURRENT_DATE - INTERVAL 1 DAY),
         INTERVAL 1 DAY
       )
@@ -83,20 +124,9 @@ daily_freshness_per_article AS (
         r.locale
     )
 ),
--- Vote totals accrued before the trailing-year window, used to seed running totals.
-historical_helpfulness AS (
-  SELECT
-    document_id,
-    SUM(CAST(helpful AS INT64)) AS historical_helpful_votes,
-    COUNT(*) AS historical_total_votes
-  FROM
-    `moz-fx-data-shared-prod.sumo_syndicate.metrics_kb_votes_details`
-  WHERE
-    DATE(vote_created_date) < DATE(CURRENT_DATE - INTERVAL 1 YEAR)
-  GROUP BY
-    document_id
-),
 -- For each day, the daily and running cumulative helpfulness votes per article.
+-- The spine starts at or before the first vote, so the running totals are
+-- cumulative over all history without needing a pre-window seed.
 daily_helpfulness_per_article AS (
   SELECT
     dates.event_date,
@@ -105,13 +135,13 @@ daily_helpfulness_per_article AS (
     help.locale,
     help.helpful_votes,
     help.total_votes,
-    COALESCE(hh.historical_helpful_votes, 0) + SUM(COALESCE(help.helpful_votes, 0)) OVER (
+    SUM(COALESCE(help.helpful_votes, 0)) OVER (
       PARTITION BY
         dates.document_id
       ORDER BY
         dates.event_date
     ) AS running_helpful_votes,
-    COALESCE(hh.historical_total_votes, 0) + SUM(COALESCE(help.total_votes, 0)) OVER (
+    SUM(COALESCE(help.total_votes, 0)) OVER (
       PARTITION BY
         dates.document_id
       ORDER BY
@@ -120,29 +150,9 @@ daily_helpfulness_per_article AS (
   FROM
     dates
   LEFT JOIN
-    (
-      SELECT
-        DATE(vote_created_date) AS vote_created_date,
-        document_id,
-        url,
-        locale,
-        SUM(CAST(helpful AS INT64)) AS helpful_votes,
-        COUNT(*) AS total_votes
-      FROM
-        `moz-fx-data-shared-prod.sumo_syndicate.metrics_kb_votes_details`
-      WHERE
-        DATE(vote_created_date) >= DATE(CURRENT_DATE - INTERVAL 1 YEAR)
-      GROUP BY
-        vote_created_date,
-        document_id,
-        url,
-        locale
-    ) help
-    ON dates.event_date = help.vote_created_date
+    daily_votes help
+    ON dates.event_date = help.vote_date
     AND dates.document_id = help.document_id
-  LEFT JOIN
-    historical_helpfulness hh
-    ON dates.document_id = hh.document_id
 ),
 -- Article-level daily metrics with product mapping applied.
 main AS (

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/schema.yaml
@@ -2,7 +2,7 @@ fields:
 - name: event_date
   type: DATE
   mode: NULLABLE
-  description: Observation date (point-in-time snapshot; covers all available history)
+  description: Observation date (point-in-time snapshot; 2024-01-01 onward)
 - name: document_id
   type: INTEGER
   mode: NULLABLE
@@ -56,8 +56,8 @@ fields:
 - name: running_helpful_votes
   type: INTEGER
   mode: NULLABLE
-  description: Cumulative helpful votes through `event_date` across all history
+  description: All-time cumulative helpful votes through `event_date` (seeded with pre-2024 totals)
 - name: running_total_votes
   type: INTEGER
   mode: NULLABLE
-  description: Cumulative total votes through `event_date` across all history
+  description: All-time cumulative total votes through `event_date` (seeded with pre-2024 totals)

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_quality_metrics_article_v1/schema.yaml
@@ -2,7 +2,7 @@ fields:
 - name: event_date
   type: DATE
   mode: NULLABLE
-  description: Observation date (point-in-time snapshot within the trailing 1-year window)
+  description: Observation date (point-in-time snapshot; covers all available history)
 - name: document_id
   type: INTEGER
   mode: NULLABLE
@@ -56,8 +56,8 @@ fields:
 - name: running_helpful_votes
   type: INTEGER
   mode: NULLABLE
-  description: Cumulative helpful votes through `event_date`, seeded with pre-window totals
+  description: Cumulative helpful votes through `event_date` across all history
 - name: running_total_votes
   type: INTEGER
   mode: NULLABLE
-  description: Cumulative total votes through `event_date`, seeded with pre-window totals
+  description: Cumulative total votes through `event_date` across all history


### PR DESCRIPTION
## What

`kb_quality_metrics_article_v1` built its `event_date` spine from `CURRENT_DATE - 1 YEAR`, so the table only ever held a trailing year of article × day rows and historical daily vote counts / freshness weren't available. This anchors the window at a fixed **2024-01-01** instead, giving ~2.6× the history.

The floor is deliberate rather than a data limit: freshness could go back to 2009 and votes to 2023-01-01, but capping the window keeps the table at ~150 MB, which means **no partitioning is needed** and the existing unpartitioned prod table doesn't have to be recreated.

## Changes — `query.sql`

- `window_start` CTE holds `DATE '2024-01-01'` as the single source of truth for both the spine start and the seed cutoff, replacing the relative `CURRENT_DATE - INTERVAL 1 YEAR`.
- New `daily_votes` CTE aggregates `metrics_kb_votes_details` with **no date filter**, replacing the trailing-year inline subquery. `historical_helpfulness` is now derived from `daily_votes` rather than re-reading the source, so votes are scanned **once instead of twice**.
- `running_helpful_votes` / `running_total_votes` remain **all-time cumulative** — in-window votes accumulate on top of the pre-2024 seed. Without the seed they'd silently become "cumulative since 2024", a semantic regression vs. today's table.

`metadata.yaml` / `schema.yaml`: descriptions updated for the new window, plus notes on the 2024 floor and the survivorship-bias caveat below.

`kb_quality_metrics_daily_v1` needs no change; its 14-day moving averages and lagged comparisons extend automatically.

## Verification (against prod, read-only)

- `./bqetl query validate` → OK for both `kb_quality_metrics_article_v1` and `kb_quality_metrics_daily_v1`.
- Full run of the new query: **857,516 rows**, `event_date` 2024-01-01 → 2026-08-02, 1,008 documents (vs. 352,995 rows / 62 MB in prod today → projects to ~150 MB).
- **Running totals reconcile exactly.** On the latest `event_date`, `running_total_votes` / `running_helpful_votes` per `document_id` vs. all-time counts in `metrics_kb_votes_details`: **0 mismatches across all 1,008 docs**, 1,916,780 votes on both sides. This is the check that the seed still carries every pre-2024 vote.

## Notes for reviewers

- **No destructive deploy.** No partitioning is added, so this is a normal schema/description update; the daily full recompute repopulates the wider window on the next run.
- **Sizing rationale.** At ~150 MB, day-partitioning would create ~945 partitions of ~170 KB each — well below the ~1 GB-per-partition point where partitioning pays off, and small enough that metadata overhead would outweigh any scan savings.
- **An article's first row** is the later of 2024-01-01 and its first approved revision: `daily_freshness_per_article` inner-joins on `reviewed_date <= event_date`, and `main` builds off that CTE.
- **Survivorship bias** (documented in `metadata.yaml`, not fixed here): the article population is a *current* snapshot (`is_archived = FALSE`, today's `category`/`products`/product mapping), so earlier `event_date`s only include articles that still exist unarchived today, and article counts trend upward partly for that reason. `fresh_ind` remains a valid point-in-time measure, computed against each `event_date`. Fixing this would need historical document snapshots.