### PR TITLE
feat(sumo_metrics): anchor zendesk_ticket_sla_v1 window at 2024-01-01

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_ticket_sla_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_ticket_sla_v1/metadata.yaml
@@ -2,7 +2,8 @@ friendly_name: Zendesk Ticket SLA (Per-Ticket)
 description: |
   Ticket-level SLA snapshot for SUMO Zendesk support tickets.
 
-  Grain: One row per ticket (rolling 13-month window keyed on ticket_created_date).
+  Grain: One row per ticket, for tickets created 2024-01-01 onward
+  (keyed on ticket_created_date).
 
   Single source of truth for:
   - First Reply Time (TTFR) — calendar and business minutes
@@ -17,8 +18,15 @@ description: |
 
   Late-arriving updates: full_resolution_at, rating_category, and reopen_count can
   change weeks after a ticket is created (status flips, late survey responses).
-  This table is rebuilt non-incrementally over a rolling 13-month window so those
-  changes flow through without manual partition rewrites.
+  This table is rebuilt non-incrementally over the full 2024-01-01-onward window so
+  those changes flow through without manual partition rewrites.
+
+  Caveat — CSAT starts later than the window: ticket_csat_survey only holds
+  surveys for tickets created 2025-06-17 onward, so survey_responded is FALSE and
+  rating_category is NULL for every earlier ticket. That is missing source data,
+  not a 0% response rate — CSAT rates must not be trended across the window
+  start. TTFR / FRT / FCR / reopen metrics are unaffected: ticket_comment and
+  ticket_field_history go back to 2019 along with ticket.
 
   Filter dimensions:
   - product (mapped via mozfun.customer_experience.normalize_product)

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_ticket_sla_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/zendesk_ticket_sla_v1/query.sql
@@ -3,7 +3,7 @@
 -- Business minutes computed against "Mozilla Support Hours" with holiday subtraction,
 -- mirroring the calculation Zendesk surfaces in its UI.
 --
--- Rebuilt over a rolling 13-month window so late-arriving updates
+-- Rebuilt in full over a fixed window starting 2024-01-01 so late-arriving updates
 -- (full_resolution status flips, CSAT survey responses, reopens) flow through.
 WITH tickets_in_window AS (
   SELECT
@@ -19,7 +19,7 @@ WITH tickets_in_window AS (
     `moz-fx-data-shared-prod.zendesk_syndicate.ticket` AS t
   WHERE
     DATE(t.created_at)
-    BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL 13 MONTH)
+    BETWEEN DATE '2024-01-01'
     AND CURRENT_DATE()
     AND t.status != 'deleted'
 ),


### PR DESCRIPTION
## What

`zendesk_ticket_sla_v1` scoped `tickets_in_window` to a rolling 13-month window (`DATE_SUB(CURRENT_DATE(), INTERVAL 13 MONTH)`), so older tickets silently dropped out of the table as time moved forward. This pins the window to a fixed **2024-01-01** floor instead.

Companion to #9754, which does the same for `kb_quality_metrics_article_v1`.

## Changes

- `query.sql`: `tickets_in_window` filters `DATE(t.created_at) BETWEEN DATE '2024-01-01' AND CURRENT_DATE()`. One-line change — every downstream CTE is already scoped by joining to `tickets_in_window`.
- `metadata.yaml`: grain/rebuild wording updated, plus the CSAT caveat below.

No seeding or cumulative-metric concerns here: every metric is self-contained per ticket, unlike the running vote totals in #9754.

## Verification (against prod, read-only)

- `./bqetl query validate sumo_metrics_derived.zendesk_ticket_sla_v1` → OK.
- Full run: **302,593 rows**, `ticket_created_date` 2024-01-01 → 2026-08-03. `COUNT(*) = COUNT(DISTINCT ticket_id)`, so the wider window introduces no fan-out.
- Prod today is 155,249 rows / 27.5 MB, so this is ~1.95× → roughly 55 MB. Already partitioned on `ticket_created_date` and clustered on `product` / `automation_category`, so **no destructive deploy** and downstream partition pruning still applies.
- Per-quarter sanity check of the newly-added period — resolution rate, reply rate, reopens, and median business-minutes TTFR are all consistent with the previously-covered months, confirming `ticket_comment` and `ticket_field_history` genuinely retain data back to 2024:

| quarter | tickets | % resolved | % replied | reopened | median TTFR (biz min) | CSAT n |
|---|---|---|---|---|---|---|
| 2024-Q1 | 15,919 | 100.0 | 20.5 | 2,130 | 431.0 | **0** |
| 2024-Q3 | 14,200 | 100.0 | 25.9 | 1,712 | 293.0 | **0** |
| 2025-Q1 | 37,686 | 100.0 | 25.4 | 2,601 | 324.2 | **0** |
| 2025-Q3 | 36,991 | 100.0 | 25.8 | 2,521 | 132.0 | 1,050 |
| 2026-Q2 | 40,021 | 99.6 | 17.0 | 1,591 | 144.9 | 909 |

## Reviewers: one caveat worth knowing about

**CSAT does not extend back over the new window.** All 4,503 rows in `ticket_csat_survey` belong to tickets created **2025-06-17 or later**, so `survey_responded` is FALSE and `rating_category` is NULL for every 2024 and early-2025 ticket. That's missing source data, not a 0% response rate — CSAT rates must not be trended across the window start or they'll show a phantom collapse before mid-2025. Documented in `metadata.yaml`.

TTFR / FRT / FCR / reopen metrics are unaffected: `ticket_comment` and `ticket_field_history` both start 2019-04-04, same as `ticket`. The 2024-01-01 floor is therefore a deliberate choice rather than a data limit for those metrics — happy to push it back further if that's useful.