### PR TITLE
refactor(DENG-11237): aggregate referral daily counts after the platform union

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/query.sql
@@ -46,6 +46,7 @@ ga4 AS (
   SELECT
     ga_client_id,
     stub_session_id,
+    session_date,
     COALESCE(manual_content, first_content_from_event_params) AS content,
   FROM
     `moz-fx-data-shared-prod.telemetry.ga4_sessions_firefoxcom_mozillaorg_combined`
@@ -62,7 +63,12 @@ referred_clients AS (
   -- once, after the (future) UNION, so a code seen on both platforms yields a
   -- single combined row rather than one row per platform.
   --
-  -- DESKTOP:
+  -- DESKTOP: the ga4 CTE can fan out — the same (ga_client_id, stub_session_id)
+  -- pair appears on multiple session rows across the 30-day look-back — so
+  -- QUALIFY collapses each client to a single (invite_code, client_id) row,
+  -- matching the cfs_ga4_attr_v1 dedupe. Without it, a client whose fanned-out
+  -- sessions carry different fxrefer: codes would be counted under each code,
+  -- inflating the cross-code total that referral_installs_totals_v1 sums.
   SELECT
     REGEXP_REPLACE(ga4.content, r'^fxrefer:', '') AS invite_code,
     cfs.client_id,
@@ -79,6 +85,8 @@ referred_clients AS (
     cfs.submission_date = @submission_date -- required partition filter
     AND cfs.first_seen_date = @submission_date -- clients first seen today
     AND ga4.content LIKE 'fxrefer:%' -- referred clients only
+  QUALIFY
+    ROW_NUMBER() OVER (PARTITION BY cfs.client_id ORDER BY ga4.session_date DESC, ga4.content) = 1
   -- FENIX (Android) — BLOCKED. Once Nathan defines the field/ping, uncomment:
   --   UNION ALL
   --   SELECT

--- a/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/query.sql
@@ -1,8 +1,9 @@
 -- Daily count of Firefox first_run installs per referral (invite) code.
 --
--- The invite code arrives as `fxrefer:<code>` (17 chars after the prefix is
--- stripped, per the Website team 2026-07-24). The prefix strip is
--- length-agnostic, so a length change needs no code change here.
+-- The invite code arrives as `fxrefer:<code>`; after the prefix is stripped it
+-- is expected to be 17 chars (Website team, 2026-07-24). That length is
+-- documentation only — it is NOT enforced by any check here or in bigconfig.yml.
+-- The prefix strip is length-agnostic, so a length change needs no code change.
 --
 -- DESKTOP source = GA4 / download-attribution path (cross-platform: Windows + Mac).
 --   Do NOT use `telemetry.install` — it is the Windows-only installer ping and

--- a/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/query.sql
@@ -1,8 +1,8 @@
 -- Daily count of Firefox first_run installs per referral (invite) code.
 --
--- The invite code arrives as `fxrefer:<code>` and is expected to be 17 chars
--- after the prefix is stripped (Website team, 2026-07-24). The prefix strip is
--- length-agnostic; a checks.sql warn flags any drift from 17 chars.
+-- The invite code arrives as `fxrefer:<code>` (17 chars after the prefix is
+-- stripped, per the Website team 2026-07-24). The prefix strip is
+-- length-agnostic, so a length change needs no code change here.
 --
 -- DESKTOP source = GA4 / download-attribution path (cross-platform: Windows + Mac).
 --   Do NOT use `telemetry.install` — it is the Windows-only installer ping and
@@ -12,6 +12,13 @@
 --   GA4 (utm_content=fxrefer:) -> dl_token_ga_attribution_lookup_v2 (on dl_token)
 --     -> baseline_clients_first_seen_v1 -> installed client.
 --   This is the `firefox_desktop_derived.cfs_ga4_attr_v1` join pattern.
+--
+-- One invite code can drive installs on BOTH desktop and Fenix (a single shared
+-- code, friends on different platforms). So we collect referred clients per
+-- platform WITHOUT aggregating, UNION them, and COUNT(DISTINCT client_id) once
+-- at the end — each (submission_date, invite_code) is a single row with the
+-- combined count. Desktop and Fenix client_id namespaces are disjoint, so the
+-- cross-platform distinct count equals the sum of the two.
 --
 -- STATUS:
 --   * Desktop source is LOCKED — the GA4 / download-attribution path is the
@@ -50,10 +57,15 @@ ga4 AS (
     AND session_date <= @submission_date
     AND (manual_content LIKE 'fxrefer:%' OR first_content_from_event_params LIKE 'fxrefer:%')
 ),
-desktop AS (
+referred_clients AS (
+  -- One row per referred first_run client, per platform. Aggregation happens
+  -- once, after the (future) UNION, so a code seen on both platforms yields a
+  -- single combined row rather than one row per platform.
+  --
+  -- DESKTOP:
   SELECT
     REGEXP_REPLACE(ga4.content, r'^fxrefer:', '') AS invite_code,
-    COUNT(DISTINCT cfs.client_id) AS install_count,
+    cfs.client_id,
   FROM
     `moz-fx-data-shared-prod.firefox_desktop_derived.baseline_clients_first_seen_v1` AS cfs
   LEFT JOIN
@@ -67,21 +79,20 @@ desktop AS (
     cfs.submission_date = @submission_date -- required partition filter
     AND cfs.first_seen_date = @submission_date -- clients first seen today
     AND ga4.content LIKE 'fxrefer:%' -- referred clients only
-  GROUP BY
-    invite_code
+  -- FENIX (Android) — BLOCKED. Once Nathan defines the field/ping, uncomment:
+  --   UNION ALL
+  --   SELECT
+  --     REGEXP_REPLACE(play_store_attribution_content, r'^fxrefer:', '') AS invite_code,
+  --     client_id
+  --   FROM `moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1`
+  --   WHERE first_seen_date = @submission_date
+  --     AND play_store_attribution_content LIKE 'fxrefer:%'
 )
--- FENIX (Android) — BLOCKED. Once Nathan defines the field/ping, add:
---   UNION ALL
---   SELECT
---     REGEXP_REPLACE(play_store_attribution_content, r'^fxrefer:', '') AS invite_code,
---     COUNT(DISTINCT client_id) AS install_count
---   FROM `moz-fx-data-shared-prod.fenix_derived.firefox_android_clients_v1`
---   WHERE first_seen_date = @submission_date
---     AND play_store_attribution_content LIKE 'fxrefer:%'
---   GROUP BY invite_code
 SELECT
   @submission_date AS submission_date,
   invite_code,
-  install_count,
+  COUNT(DISTINCT client_id) AS install_count,
 FROM
-  desktop
+  referred_clients
+GROUP BY
+  invite_code


### PR DESCRIPTION
## Description

Small follow-up to #9724 addressing [kik's review comment](https://github.com/mozilla/bigquery-etl/pull/9724#discussion_r3704982120): restructure `referral_installs_daily_v1` to aggregate **after** the platform union rather than per-platform-then-union.

### Why

A single invite code can drive installs on **both** desktop and Fenix (one shared code, friends on different platforms). The commented Fenix plan aggregated each platform separately and then `UNION ALL`'d the already-grouped counts, so a code seen on both platforms would produce **two rows** per `(submission_date, invite_code)` — one desktop count, one Fenix count.

### Change

Collect referred clients per platform **without aggregating** (new `referred_clients` CTE), then `COUNT(DISTINCT client_id) ... GROUP BY invite_code` **once** at the end. Each `(submission_date, invite_code)` is now a single row with the combined count. Desktop and Fenix `client_id` namespaces are disjoint, so the cross-platform distinct count equals the sum of the two — no double-counting.

### Impact

- **Desktop-only output is unchanged** — this is a pure refactor (the SQL-test fixture and its expected output are untouched and still pass).
- Enabling Fenix later is now a clean drop-in: uncomment the `UNION ALL` inside `referred_clients`.
- Numbers in the final CSV were never wrong (`referral_installs_totals_v1` re-groups by `invite_code` and sums), but the daily table would have carried duplicate `(date, code)` rows once Fenix landed — this removes that footgun.

Also fixed a stale header comment that referenced `checks.sql` (replaced by `bigconfig.yml` in #9724).

## Related Tickets & Documents
* [DENG-11237](https://mozilla-hub.atlassian.net/browse/DENG-11237)


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-11237]: https://mozilla-hub.atlassian.net/browse/DENG-11237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ