### PR TITLE
fix(bug-2060144): resolve google play store bad request error

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -101,7 +101,7 @@ bqetl_google_play_store:
   description: Schedules daily level google play store export data
   schedule_interval: 10 18 * * *
   tags:
-    - impact/tier_2
+    - impact/tier_3
 
 bqetl_fxa_events:
   schedule_interval: 30 1 * * *

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/metadata.yaml
@@ -15,7 +15,9 @@ labels:
   owner1: kik
 scheduling:
   dag_name: bqetl_google_play_store
-  arguments: ["--date", "{{ds}}"]
+  arguments:
+  - --date={{macros.ds_add(ds, -7)}}
+  date_partition_offset: -7
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO
     key: bqetl_google_play_store_developer_reporting_api_data_boxwood

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
@@ -104,8 +104,7 @@ def main():
     logical_dag_date_string = logical_dag_date.strftime("%Y-%m-%d")
     print("logical_dag_date_string: ", logical_dag_date_string)
 
-    # Get 2 days prior - we always will pull data for the previous day
-    data_pull_date = logical_dag_date - timedelta(days=1)
+    data_pull_date = logical_dag_date
     data_pull_date_string = data_pull_date.strftime("%Y-%m-%d")
 
     print(

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
@@ -11,7 +11,6 @@ from google.auth.transport.requests import Request
 from google.cloud import bigquery
 from google.oauth2 import service_account
 
-# Set variables
 TARGET_PROJECT = "moz-fx-data-shared-prod"
 TARGET_TABLE = "moz-fx-data-shared-prod.google_play_store_derived.slow_startup_events_by_startup_type_and_version_v1"
 GCS_BUCKET = "gs://moz-fx-data-prod-external-data/"
@@ -83,7 +82,14 @@ def get_slow_start_rates_by_app_and_date_and_version(
         api_url, headers=headers, json=request_payload, timeout=timeout_seconds
     )
 
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
+        print(error_message)
+
+        raise requests.exceptions.HTTPError(error_message) from None
+
     return response.json()
 
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_and_version_v1/query.py
@@ -84,11 +84,10 @@ def get_slow_start_rates_by_app_and_date_and_version(
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
-        print(error_message)
-
-        raise requests.exceptions.HTTPError(error_message) from None
+    except requests.exceptions.HTTPError as err:
+        raise requests.exceptions.HTTPError(
+            f"Request to: {response.url} failed with status {response.status_code}: {response.text}"
+        ) from err
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/metadata.yaml
@@ -15,7 +15,9 @@ labels:
   owner1: kik
 scheduling:
   dag_name: bqetl_google_play_store
-  arguments: ["--date", "{{ds}}"]
+  arguments:
+  - --date={{macros.ds_add(ds, -7)}}
+  date_partition_offset: -7
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO
     key: bqetl_google_play_store_developer_reporting_api_data_boxwood

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
@@ -106,8 +106,7 @@ def main():
     logical_dag_date_string = logical_dag_date.strftime("%Y-%m-%d")
     print("logical_dag_date_string: ", logical_dag_date_string)
 
-    # Get 2 days prior - we always will pull data for the previous day
-    data_pull_date = logical_dag_date - timedelta(days=1)
+    data_pull_date = logical_dag_date
     data_pull_date_string = data_pull_date.strftime("%Y-%m-%d")
     print("data_pull_date")
     print(data_pull_date)

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
@@ -11,7 +11,6 @@ from google.auth.transport.requests import Request
 from google.cloud import bigquery
 from google.oauth2 import service_account
 
-# Set variables
 TARGET_PROJECT = "moz-fx-data-shared-prod"
 TARGET_TABLE = "moz-fx-data-shared-prod.google_play_store_derived.slow_startup_events_by_startup_type_v1"
 GCS_BUCKET = "gs://moz-fx-data-prod-external-data/"
@@ -82,7 +81,14 @@ def get_slow_start_rates_by_app_and_date(
         api_url, headers=headers, json=request_payload, timeout=timeout_seconds
     )
 
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
+        print(error_message)
+
+        raise requests.exceptions.HTTPError(error_message) from None
+
     return response.json()
 
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_v1/query.py
@@ -83,11 +83,10 @@ def get_slow_start_rates_by_app_and_date(
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
-        print(error_message)
-
-        raise requests.exceptions.HTTPError(error_message) from None
+    except requests.exceptions.HTTPError as err:
+        raise requests.exceptions.HTTPError(
+            f"Request to: {response.url} failed with status {response.status_code}: {response.text}"
+        ) from err
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/metadata.yaml
@@ -9,7 +9,9 @@ labels:
   owner1: kik
 scheduling:
   dag_name: bqetl_google_play_store
-  arguments: ["--date", "{{ds}}"]
+  arguments:
+  - --date={{macros.ds_add(ds, -7)}}
+  date_partition_offset: -7
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO
     key: bqetl_google_play_store_developer_reporting_api_data_boxwood

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
@@ -35,7 +35,7 @@ def create_request_payload_using_logical_dag_date(date_to_pull_data_for):
     date_to_pull_data_for_month = date_to_pull_data_for.month
     date_to_pull_data_for_day = date_to_pull_data_for.day
 
-    end_date = date_to_pull_data_for
+    end_date = date_to_pull_data_for + timedelta(days=1)
 
     day_after_date_to_pull_data_for_yr = end_date.year
     day_after_date_to_pull_data_for_month = end_date.month
@@ -89,11 +89,10 @@ def get_slow_start_rates_by_app_and_date(
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
-        print(error_message)
-
-        raise requests.exceptions.HTTPError(error_message) from None
+    except requests.exceptions.HTTPError as err:
+        raise requests.exceptions.HTTPError(
+            f"Request to: {response.url} failed with status {response.status_code}: {response.text}"
+        ) from err
 
     return response.json()
 
@@ -112,8 +111,7 @@ def main():
     logical_dag_date_string = logical_dag_date.strftime("%Y-%m-%d")
     print("logical_dag_date_string: ", logical_dag_date_string)
 
-    # Get 2 days prior - we always will pull data for the previous day
-    data_pull_date = logical_dag_date - timedelta(days=1)
+    data_pull_date = logical_dag_date
     data_pull_date_string = data_pull_date.strftime("%Y-%m-%d")
     print("data_pull_date")
     print(data_pull_date)

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
@@ -35,8 +35,7 @@ def create_request_payload_using_logical_dag_date(date_to_pull_data_for):
     date_to_pull_data_for_month = date_to_pull_data_for.month
     date_to_pull_data_for_day = date_to_pull_data_for.day
 
-    # Add 1 day to date to pull data for
-    end_date = date_to_pull_data_for + timedelta(days=1)
+    end_date = date_to_pull_data_for
 
     day_after_date_to_pull_data_for_yr = end_date.year
     day_after_date_to_pull_data_for_month = end_date.month

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/slow_startup_events_by_startup_type_version_and_device_v1/query.py
@@ -88,7 +88,14 @@ def get_slow_start_rates_by_app_and_date(
         api_url, headers=headers, json=request_payload, timeout=timeout_seconds
     )
 
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
+        print(error_message)
+
+        raise requests.exceptions.HTTPError(error_message) from None
+
     return response.json()
 
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_anr_rate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_anr_rate_v1/metadata.yaml
@@ -18,8 +18,8 @@ labels:
 scheduling:
   dag_name: bqetl_google_play_store
   arguments:
-  - --date={{macros.ds_add(ds, -1)}}
-  date_partition_offset: -1
+  - --date={{macros.ds_add(ds, -7)}}
+  date_partition_offset: -7
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO
     key: bqetl_google_play_store_developer_reporting_api_data_boxwood

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_anr_rate_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_anr_rate_v1/query.py
@@ -157,11 +157,10 @@ def fetch_data(
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
-        print(error_message)
-
-        raise requests.exceptions.HTTPError(error_message) from None
+    except requests.exceptions.HTTPError as err:
+        raise requests.exceptions.HTTPError(
+            f"Request to: {response.url} failed with status {response.status_code}: {response.text}"
+        ) from err
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_anr_rate_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_anr_rate_v1/query.py
@@ -154,7 +154,14 @@ def fetch_data(
         json=request_payload,
         timeout=timeout_seconds,
     )
-    response.raise_for_status()
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
+        print(error_message)
+
+        raise requests.exceptions.HTTPError(error_message) from None
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_crash_rate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_crash_rate_v1/metadata.yaml
@@ -18,8 +18,8 @@ labels:
 scheduling:
   dag_name: bqetl_google_play_store
   arguments:
-  - --date={{macros.ds_add(ds, -1)}}
-  date_partition_offset: -1
+  - --date={{macros.ds_add(ds, -7)}}
+  date_partition_offset: -7
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO
     key: bqetl_google_play_store_developer_reporting_api_data_boxwood

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_crash_rate_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_crash_rate_v1/query.py
@@ -153,7 +153,14 @@ def fetch_data(
         json=request_payload,
         timeout=timeout_seconds,
     )
-    response.raise_for_status()
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
+        print(error_message)
+
+        raise requests.exceptions.HTTPError(error_message) from None
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_crash_rate_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_crash_rate_v1/query.py
@@ -156,11 +156,10 @@ def fetch_data(
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
-        print(error_message)
-
-        raise requests.exceptions.HTTPError(error_message) from None
+    except requests.exceptions.HTTPError as err:
+        raise requests.exceptions.HTTPError(
+            f"Request to: {response.url} failed with status {response.status_code}: {response.text}"
+        ) from err
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_error_count_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_error_count_v1/metadata.yaml
@@ -18,8 +18,8 @@ labels:
 scheduling:
   dag_name: bqetl_google_play_store
   arguments:
-  - --date={{macros.ds_add(ds, -1)}}
-  date_partition_offset: -1
+  - --date={{macros.ds_add(ds, -7)}}
+  date_partition_offset: -7
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO
     key: bqetl_google_play_store_developer_reporting_api_data_boxwood

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_error_count_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_error_count_v1/query.py
@@ -141,7 +141,14 @@ def fetch_data(
         json=request_payload,
         timeout=timeout_seconds,
     )
-    response.raise_for_status()
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
+        print(error_message)
+
+        raise requests.exceptions.HTTPError(error_message) from None
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_error_count_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_error_count_v1/query.py
@@ -144,11 +144,10 @@ def fetch_data(
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
-        print(error_message)
-
-        raise requests.exceptions.HTTPError(error_message) from None
+    except requests.exceptions.HTTPError as err:
+        raise requests.exceptions.HTTPError(
+            f"Request to: {response.url} failed with status {response.status_code}: {response.text}"
+        ) from err
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_lmk_rate_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_lmk_rate_v1/metadata.yaml
@@ -18,8 +18,8 @@ labels:
 scheduling:
   dag_name: bqetl_google_play_store
   arguments:
-  - --date={{macros.ds_add(ds, -1)}}
-  date_partition_offset: -1
+  - --date={{macros.ds_add(ds, -7)}}
+  date_partition_offset: -7
   secrets:
   - deploy_target: GOOGLE_PLAY_STORE_SRVC_ACCT_INFO
     key: bqetl_google_play_store_developer_reporting_api_data_boxwood

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_lmk_rate_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_lmk_rate_v1/query.py
@@ -155,11 +155,10 @@ def fetch_data(
 
     try:
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
-        print(error_message)
-
-        raise requests.exceptions.HTTPError(error_message) from None
+    except requests.exceptions.HTTPError as err:
+        raise requests.exceptions.HTTPError(
+            f"Request to: {response.url} failed with status {response.status_code}: {response.text}"
+        ) from err
 
     return response.json()
 

--- a/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_lmk_rate_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/google_play_store_derived/vitals_lmk_rate_v1/query.py
@@ -152,7 +152,14 @@ def fetch_data(
         json=request_payload,
         timeout=timeout_seconds,
     )
-    response.raise_for_status()
+
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError:
+        error_message = f"Request to: {response.url} failed with the following error: {response.json()}"
+        print(error_message)
+
+        raise requests.exceptions.HTTPError(error_message) from None
 
     return response.json()
 


### PR DESCRIPTION
# fix(bug-2060144): resolve google play store bad request error

## Description

This makes the following three changes:

1. Improve logging of the HTTP error response to make it easier to understand why a request failed.
2. Use a 7 day lag for this job, it appears there is a latency on Google side in making this data available (as of writing the earliest date available is 30th of July).
3. Change the tier tag from `tier_2` to `tier_3`.