### PR TITLE
feat(data_governance_metadata): add data_sensitivity, send_in_pings, and tags to probe definitions [DENG-11453]

### DIFF
--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/metadata.yaml
@@ -2,7 +2,8 @@ friendly_name: Probe Definitions
 description: |-
   Probe (Glean metric or Legacy Telemetry field) definitions for every distinct
   source ping listed in lineage_mapping_v1. Glean entries are fetched from the
-  Glean Dictionary JSON API; legacy entries are read from the closest
+  Glean Dictionary JSON API, with data_sensitivity and send_in_pings merged in
+  from probe-info; legacy entries are read from the closest
   upstream _stable table's DataHub schema. Consumed by the schema_enricher
   agent in data-shared-llm-agents to write column descriptions in bigquery-etl.
   Each run overwrites its own fetched_at date partition.

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/query.py
@@ -21,10 +21,10 @@ so this script depends only on ``google.cloud.bigquery`` + ``requests``.
 
 Behavioral parity with the agent's probe_fetcher:
 
-* ``fetch_legacy_probes`` is byte-equivalent to the agent's helper (same
-  GraphQL, same response mapping). ``fetch_glean_probes`` matches it for probe
-  name, description, and type, and adds the sensitivity fields above, which the
-  column classification pipeline needs.
+* ``fetch_legacy_probes`` matches the agent's helper on the GraphQL query and on
+  the probe name, description, and type mapping, and adds the sensitivity fields
+  below as empty. ``fetch_glean_probes`` matches on the same three and populates
+  them, which the column classification pipeline needs.
 * The 500-probe cap (``_MAX_UNFILTERED_PROBES``) and column-name fuzzy
   filtering from ``fetch_probe_definitions`` are intentionally **not**
   replicated. Those exist to keep LLM context small at agent read time; the
@@ -106,18 +106,22 @@ def _datahub_graphql(query: str, variables: dict, token: str) -> dict:
     return body["data"]
 
 
-def _get_json(url: str, description: str) -> Any:
-    """GET and parse JSON, returning None on 404, transport error, or bad body."""
+def _get_json(url: str, description: str, missing_ok: bool = False) -> Any:
+    """GET and parse JSON, returning None for a 404 when ``missing_ok``.
+
+    Every other failure raises. A timeout or 5xx is indistinguishable from an
+    empty result once it has been turned into one, and the run would go on to
+    write a partition whose fields are silently missing.
+    """
     try:
         response = requests.get(url, timeout=30)
-        if response.status_code == 404:
+        if missing_ok and response.status_code == 404:
             logger.warning(f"{description} not found: {url}")
             return None
         response.raise_for_status()
         return response.json()
     except (requests.RequestException, ValueError) as e:
-        logger.warning(f"Failed to fetch {description}: {e}")
-        return None
+        raise RuntimeError(f"Could not fetch {description} from {url}") from e
 
 
 _CATALOG_CACHE: dict[str, Any] = {}
@@ -128,7 +132,7 @@ def _fetch_catalog(url: str, description: str) -> list[dict[str, Any]]:
     if url not in _CATALOG_CACHE:
         data = _get_json(url, description)
         if not data:
-            raise RuntimeError(f"Could not fetch {description} from {url}")
+            raise RuntimeError(f"{description} is empty: {url}")
         _CATALOG_CACHE[url] = data
     return _CATALOG_CACHE[url]
 
@@ -137,11 +141,13 @@ def _fetch_catalog(url: str, description: str) -> list[dict[str, Any]]:
 def _fetch_metrics_map(slug: str) -> dict[str, dict[str, Any]]:
     """Fetch one probe-info metrics file, mapping metric name to latest history.
 
-    Yields an empty map for a missing slug or unreadable body, since one absent
-    metrics file is a data gap rather than an outage. Cached per slug so a shared
-    library is fetched once; treat the result as read-only.
+    A 404 yields an empty map, since a repository without a metrics file is a
+    data gap rather than an outage. Cached per slug so a shared library is
+    fetched once; treat the result as read-only.
     """
-    metrics = _get_json(_PROBE_INFO_URL.format(app=slug), f"probe-info {slug}")
+    metrics = _get_json(
+        _PROBE_INFO_URL.format(app=slug), f"probe-info {slug}", missing_ok=True
+    )
     if not metrics:
         return {}
 
@@ -157,7 +163,8 @@ def _repository_slugs(app: str) -> tuple[str, ...]:
     """Map a Glean Dictionary app name to its probe-info repository names.
 
     app-listings maps one ``app_name`` to a ``v1_name`` per channel and per
-    platform: ``mozilla_vpn`` has four, one each for desktop, Android and iOS.
+    platform: ``mozilla_vpn`` has one each for desktop, Android and iOS, plus the
+    iOS network extension.
     Metrics can be unique to one of them, so read all of them, as
     ``glean_usage`` does for its per-app artifacts. Release entries come first so
     their definitions win, treating an absent ``app_channel`` as release.

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/query.py
@@ -8,6 +8,10 @@ Reads the latest ``lineage_mapping_v1`` partition, groups by
 * the Glean Dictionary JSON API, for Glean pings, or
 * the closest upstream ``_stable`` table's DataHub schema, for Legacy Telemetry.
 
+Glean rows additionally carry ``data_sensitivity`` and ``send_in_pings``, merged
+in from probe-info (the app's own metrics plus its libraries'), and ``tags``,
+which the Dictionary response already provides.
+
 Writes one row per probe to ``probe_definitions_v1``, overwriting the run's
 ``fetched_at`` date partition.
 
@@ -17,8 +21,10 @@ so this script depends only on ``google.cloud.bigquery`` + ``requests``.
 
 Behavioral parity with the agent's probe_fetcher:
 
-* ``fetch_glean_probes`` and ``fetch_legacy_probes`` are byte-equivalent to
-  the agent's helpers (same URLs, same GraphQL, same response mapping).
+* ``fetch_legacy_probes`` is byte-equivalent to the agent's helper (same
+  GraphQL, same response mapping). ``fetch_glean_probes`` matches it for probe
+  name, description, and type, and adds the sensitivity fields above, which the
+  column classification pipeline needs.
 * The 500-probe cap (``_MAX_UNFILTERED_PROBES``) and column-name fuzzy
   filtering from ``fetch_probe_definitions`` are intentionally **not**
   replicated. Those exist to keep LLM context small at agent read time; the
@@ -29,8 +35,10 @@ Behavioral parity with the agent's probe_fetcher:
 
 Requires DATAHUB_GMS_TOKEN in the environment for the legacy-telemetry path.
 """
+
 import argparse
 import datetime
+import functools
 import logging
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -44,6 +52,13 @@ logger = logging.getLogger(__name__)
 _DATAHUB_URL = "https://mozilla.acryl.io/api/graphql"
 _GLEAN_DICT_URL = (
     "https://dictionary.telemetry.mozilla.org/data/{app}/pings/{ping}.json"
+)
+# probe-info carries data_sensitivity, which the Dictionary per-ping endpoint
+# omits. Slugs are dashed here and underscored in _GLEAN_DICT_URL.
+_PROBE_INFO_URL = "https://probeinfo.telemetry.mozilla.org/glean/{app}/metrics"
+_PROBE_INFO_REPOS_URL = "https://probeinfo.telemetry.mozilla.org/glean/repositories"
+_PROBE_INFO_APP_LISTINGS_URL = (
+    "https://probeinfo.telemetry.mozilla.org/v2/glean/app-listings"
 )
 
 _SCHEMA_FIELDS_QUERY = """
@@ -67,6 +82,9 @@ _PROBE_DEFINITIONS_SCHEMA = [
     bigquery.SchemaField("probe_description", "STRING", mode="NULLABLE"),
     bigquery.SchemaField("probe_type", "STRING", mode="NULLABLE"),
     bigquery.SchemaField("fetched_at", "DATE", mode="REQUIRED"),
+    bigquery.SchemaField("data_sensitivity", "STRING", mode="REPEATED"),
+    bigquery.SchemaField("send_in_pings", "STRING", mode="REPEATED"),
+    bigquery.SchemaField("tags", "STRING", mode="REPEATED"),
 ]
 
 
@@ -88,12 +106,134 @@ def _datahub_graphql(query: str, variables: dict, token: str) -> dict:
     return body["data"]
 
 
+def _get_json(url: str, description: str) -> Any:
+    """GET and parse JSON, returning None on 404, transport error, or bad body."""
+    try:
+        response = requests.get(url, timeout=30)
+        if response.status_code == 404:
+            logger.warning(f"{description} not found: {url}")
+            return None
+        response.raise_for_status()
+        return response.json()
+    except (requests.RequestException, ValueError) as e:
+        logger.warning(f"Failed to fetch {description}: {e}")
+        return None
+
+
+_CATALOG_CACHE: dict[str, Any] = {}
+
+
+def _fetch_catalog(url: str, description: str) -> list[dict[str, Any]]:
+    """Fetch a probe-info catalog endpoint, caching only successful results."""
+    if url not in _CATALOG_CACHE:
+        data = _get_json(url, description)
+        if not data:
+            raise RuntimeError(f"Could not fetch {description} from {url}")
+        _CATALOG_CACHE[url] = data
+    return _CATALOG_CACHE[url]
+
+
+@functools.lru_cache(maxsize=None)
+def _fetch_metrics_map(slug: str) -> dict[str, dict[str, Any]]:
+    """Fetch one probe-info metrics file, mapping metric name to latest history.
+
+    Yields an empty map for a missing slug or unreadable body, since one absent
+    metrics file is a data gap rather than an outage. Cached per slug so a shared
+    library is fetched once; treat the result as read-only.
+    """
+    metrics = _get_json(_PROBE_INFO_URL.format(app=slug), f"probe-info {slug}")
+    if not metrics:
+        return {}
+
+    result = {}
+    for name, definition in metrics.items():
+        history = (definition or {}).get("history") or []
+        if history:
+            result[name] = history[-1]
+    return result
+
+
+def _repository_slugs(app: str) -> tuple[str, ...]:
+    """Map a Glean Dictionary app name to its probe-info repository names.
+
+    app-listings maps one ``app_name`` to a ``v1_name`` per channel and per
+    platform: ``mozilla_vpn`` has four, one each for desktop, Android and iOS.
+    Metrics can be unique to one of them, so read all of them, as
+    ``glean_usage`` does for its per-app artifacts. Release entries come first so
+    their definitions win, treating an absent ``app_channel`` as release.
+    """
+    listings = [
+        listing
+        for listing in _fetch_catalog(
+            _PROBE_INFO_APP_LISTINGS_URL, "probe-info app listings"
+        )
+        if listing.get("app_name") == app and listing.get("v1_name")
+    ]
+    if not listings:
+        logger.warning(f"No probe-info app listing for Glean app {app!r}")
+        return (app.replace("_", "-"),)
+
+    slugs: list[str] = []
+    for listing in sorted(
+        listings, key=lambda entry: (entry.get("app_channel") or "release") != "release"
+    ):
+        if listing["v1_name"] not in slugs:
+            slugs.append(listing["v1_name"])
+    return tuple(slugs)
+
+
+def _metric_sources(app: str) -> tuple[str, ...]:
+    """Return the probe-info slugs to read for an app: the app plus its libraries."""
+    repositories = _fetch_catalog(_PROBE_INFO_REPOS_URL, "probe-info repositories")
+
+    by_name = {repo["name"]: repo for repo in repositories if repo.get("name")}
+    slug_by_library = {
+        library_name: name
+        for name, repo in by_name.items()
+        for library_name in repo.get("library_names") or []
+    }
+
+    sources: list[str] = []
+    queue = list(_repository_slugs(app))
+    while queue:
+        slug = queue.pop(0)
+        if slug in sources:
+            continue
+        sources.append(slug)
+        for dependency in (by_name.get(slug) or {}).get("dependencies") or []:
+            if dependency in slug_by_library:
+                queue.append(slug_by_library[dependency])
+            elif dependency in by_name:
+                queue.append(dependency)
+            else:
+                logger.warning(f"Unknown probe-info dependency {dependency!r}")
+    return tuple(sources)
+
+
+@functools.lru_cache(maxsize=None)
+def fetch_probe_info(app: str) -> dict[str, dict[str, Any]]:
+    """Fetch probe-info metric definitions for a Glean app, keyed by metric name.
+
+    ``app`` is the Glean Dictionary app name (e.g. ``firefox_desktop``). Merges
+    the app's own metrics with its libraries', app winning on conflict. Read-only.
+    """
+    merged: dict[str, dict[str, Any]] = {}
+    for slug in _metric_sources(app):
+        for name, definition in _fetch_metrics_map(slug).items():
+            merged.setdefault(name, definition)
+    return merged
+
+
 def fetch_glean_probes(source_ping: str) -> list[dict[str, Any]]:
     """Fetch probe definitions for a Glean ping from the Glean Dictionary.
 
     ``source_ping`` is expected in ``app.ping`` form (e.g. ``fenix.baseline``).
     Returns an empty list for 404s (typically: Glean Dictionary doesn't have an
     entry for that app/ping pair).
+
+    ``data_sensitivity`` and ``send_in_pings`` come from probe-info, matched on
+    the dotted metric name, falling back to the Dictionary's ``pings``; ``tags``
+    comes from the Dictionary.
     """
     if "." not in source_ping:
         logger.warning(
@@ -107,14 +247,21 @@ def fetch_glean_probes(source_ping: str) -> list[dict[str, Any]]:
         logger.warning(f"Glean Dictionary entry not found: {url}")
         return []
     response.raise_for_status()
-    return [
-        {
-            "probe_name": m.get("name"),
-            "probe_description": m.get("description"),
-            "probe_type": m.get("type"),
-        }
-        for m in response.json().get("metrics", [])
-    ]
+    probe_info = fetch_probe_info(app)
+    probes = []
+    for m in response.json().get("metrics", []):
+        info = probe_info.get(m.get("name")) or {}
+        probes.append(
+            {
+                "probe_name": m.get("name"),
+                "probe_description": m.get("description"),
+                "probe_type": m.get("type"),
+                "data_sensitivity": info.get("data_sensitivity") or [],
+                "send_in_pings": info.get("send_in_pings") or m.get("pings") or [],
+                "tags": m.get("tags") or [],
+            }
+        )
+    return probes
 
 
 def fetch_legacy_probes(stable_urn: str, token: str) -> list[dict[str, Any]]:
@@ -128,6 +275,9 @@ def fetch_legacy_probes(stable_urn: str, token: str) -> list[dict[str, Any]]:
             "probe_name": f.get("fieldPath"),
             "probe_description": f.get("description"),
             "probe_type": f.get("nativeDataType"),
+            "data_sensitivity": [],
+            "send_in_pings": [],
+            "tags": [],
         }
         for f in schema["fields"]
     ]
@@ -213,6 +363,10 @@ def fetch_for_ping(
             "probe_description": p.get("probe_description"),
             "probe_type": p.get("probe_type"),
             "fetched_at": fetched_at,
+            # REPEATED fields reject a JSON null, so always emit a list.
+            "data_sensitivity": p.get("data_sensitivity") or [],
+            "send_in_pings": p.get("send_in_pings") or [],
+            "tags": p.get("tags") or [],
         }
         for p in probes
     ]
@@ -331,6 +485,19 @@ def main() -> None:
         for ping in pings:
             logger.info(f"  would fetch {ping['ping_platform']}/{ping['source_ping']}")
         return
+
+    # Fill the probe-info caches one app at a time before fanning out. lru_cache
+    # does not coalesce in-flight calls, so concurrent workers on one app can race
+    # a transient failure against a success, giving two pings different
+    # sensitivity for the same probe and caching whichever finished last. Doing it
+    # here also fails a catalog outage before anything is written.
+    glean_apps = {
+        ping["source_ping"].split(".", 1)[0]
+        for ping in pings
+        if ping["ping_platform"] == "glean" and "." in ping["source_ping"]
+    }
+    for app in sorted(glean_apps):
+        fetch_probe_info(app)
 
     rows: list[dict[str, Any]] = []
     hard_failures = 0

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1/schema.yaml
@@ -29,3 +29,21 @@ fields:
   type: DATE
   mode: REQUIRED
   description: Run date of the probe-definition fetch job. This is the table's partition column.
+- name: data_sensitivity
+  type: STRING
+  mode: REPEATED
+  description: >-
+    Glean data_sensitivity labels declared on the metric (e.g. technical,
+    interaction, web_activity, highly_sensitive), from probe-info. Empty for
+    legacy telemetry, and for Glean metrics with no probe-info entry.
+- name: send_in_pings
+  type: STRING
+  mode: REPEATED
+  description: >-
+    Pings the Glean metric is sent in, from probe-info, falling back to the
+    Glean Dictionary's ping list. Empty for legacy telemetry.
+- name: tags
+  type: STRING
+  mode: REPEATED
+  description: >-
+    Glean metric tags from the Glean Dictionary. Empty for legacy telemetry.

--- a/tests/data_governance_metadata/test_probe_definitions_query.py
+++ b/tests/data_governance_metadata/test_probe_definitions_query.py
@@ -1,0 +1,385 @@
+"""Tests for probe_definitions_v1 query.py (Glean sensitivity signals)."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+# Import the query module from its file path.
+_repo_root = Path(__file__).resolve().parent.parent.parent
+_query_dir = (
+    _repo_root
+    / "sql/moz-fx-data-shared-prod/data_governance_metadata_derived/probe_definitions_v1"
+)
+_query_path = _query_dir / "query.py"
+
+# In CI the sql/ directory may be replaced with generated SQL,
+# which removes Python query files. Skip in that case.
+if not _query_path.exists():
+    pytest.skip("query.py not available (sql/ replaced in CI)", allow_module_level=True)
+
+spec = importlib.util.spec_from_file_location("probe_definitions_query", _query_path)
+assert spec is not None and spec.loader is not None
+query_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(query_mod)
+
+
+# A Glean Dictionary metric, shaped like the real per-ping response: tags and
+# pings are top level, there is no "metadata" key, and data_sensitivity is absent.
+AD_CLICKS = {
+    "name": "browser.search.ad_clicks",
+    "description": "Records clicks of adverts on SERP pages.",
+    "type": "labeled_counter",
+    "tags": ["Search"],
+    "pings": ["baseline", "metrics"],
+}
+DICTIONARY = {"metrics": [AD_CLICKS]}
+
+# probe-info keys metrics by dotted name; the last history entry is current.
+PROBE_INFO = {
+    "browser.search.ad_clicks": {
+        "history": [
+            {"data_sensitivity": ["technical"], "send_in_pings": ["metrics"]},
+            {
+                "data_sensitivity": ["interaction"],
+                "send_in_pings": ["baseline", "metrics"],
+            },
+        ]
+    }
+}
+
+REPOSITORIES = [
+    {
+        "name": "firefox-android-release",
+        "dependencies": ["org.mozilla.components:lib-gecko"],
+    },
+    {"name": "fenix", "dependencies": ["org.mozilla.components:lib-gecko"]},
+    {"name": "gecko", "library_names": ["org.mozilla.components:lib-gecko"]},
+    {"name": "firefox-ios-release"},
+]
+
+APP_LISTINGS = [
+    {"app_name": "fenix", "v1_name": "fenix", "app_channel": "nightly"},
+    {
+        "app_name": "fenix",
+        "v1_name": "firefox-android-release",
+        "app_channel": "release",
+    },
+    {"app_name": "firefox_ios", "v1_name": "firefox-ios-beta", "app_channel": "beta"},
+    {
+        "app_name": "firefox_ios",
+        "v1_name": "firefox-ios-release",
+        "app_channel": "release",
+    },
+    {"app_name": "firefox_desktop", "v1_name": "firefox-desktop"},
+    # One app_name, one release listing per platform.
+    {"app_name": "mozilla_vpn", "v1_name": "mozilla-vpn", "app_channel": "release"},
+    {
+        "app_name": "mozilla_vpn",
+        "v1_name": "mozilla-vpn-android",
+        "app_channel": "release",
+    },
+]
+
+CATALOG = {
+    "/glean/repositories": REPOSITORIES,
+    "/glean/app-listings": APP_LISTINGS,
+}
+
+FENIX_METRICS = "/glean/firefox-android-release/metrics"
+
+
+class FakeResponse:
+    """Minimal stand-in for a requests Response."""
+
+    def __init__(self, payload, status_code=200):
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self):
+        """Return the canned payload."""
+        return self.payload
+
+    def raise_for_status(self):
+        """Raise for 4xx/5xx, like requests does."""
+        if self.status_code >= 400:
+            raise query_mod.requests.HTTPError(f"status {self.status_code}")
+
+
+def stub_get(responses, urls=None):
+    """Build a requests.get stub routing on URL fragment.
+
+    Each value is a JSON payload or an exception to raise. An unmatched URL 404s,
+    which is how a slug with no probe-info entry behaves. Pass ``urls`` to record
+    the requested URLs.
+    """
+
+    def _get(url, **kwargs):
+        if urls is not None:
+            urls.append(url)
+        for fragment, payload in responses.items():
+            if fragment in url:
+                if isinstance(payload, Exception):
+                    raise payload
+                return FakeResponse(payload)
+        return FakeResponse({}, status_code=404)
+
+    return _get
+
+
+@pytest.fixture(autouse=True)
+def clear_probe_info_caches():
+    """Drop the probe-info caches so one test's stub cannot leak into the next."""
+
+    def _clear():
+        query_mod.fetch_probe_info.cache_clear()
+        query_mod._fetch_metrics_map.cache_clear()
+        query_mod._CATALOG_CACHE.clear()
+
+    _clear()
+    yield
+    _clear()
+
+
+class TestGleanFieldMerge:
+    def test_merges_probe_info_and_dictionary_fields(self):
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get(
+                {**CATALOG, "/pings/": DICTIONARY, FENIX_METRICS: PROBE_INFO},
+            ),
+        ):
+            probes = query_mod.fetch_glean_probes("fenix.baseline")
+
+        assert len(probes) == 1
+        probe = probes[0]
+        assert probe["probe_name"] == "browser.search.ad_clicks"
+        assert probe["probe_type"] == "labeled_counter"
+        # Latest history entry wins.
+        assert probe["data_sensitivity"] == ["interaction"]
+        assert probe["send_in_pings"] == ["baseline", "metrics"]
+        assert probe["tags"] == ["Search"]
+
+    def test_tags_come_from_the_dictionary_top_level_key(self):
+        metric = dict(AD_CLICKS, metadata={"tags": ["WrongSource"]})
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get({**CATALOG, "/pings/": {"metrics": [metric]}}),
+        ):
+            probes = query_mod.fetch_glean_probes("fenix.baseline")
+
+        assert probes[0]["tags"] == ["Search"]
+
+    def test_send_in_pings_falls_back_to_dictionary_pings(self):
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get({**CATALOG, "/pings/": DICTIONARY}),
+        ):
+            probes = query_mod.fetch_glean_probes("fenix.baseline")
+
+        assert probes[0]["send_in_pings"] == ["baseline", "metrics"]
+        assert probes[0]["data_sensitivity"] == []
+
+    def test_unreadable_metrics_file_leaves_sensitivity_empty(self):
+        # One repository's metrics file is a data gap, not an outage, so it does
+        # not propagate. An unreachable catalog does; see TestCatalogFailure.
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get(
+                {
+                    **CATALOG,
+                    "/pings/": DICTIONARY,
+                    FENIX_METRICS: query_mod.requests.ConnectionError("boom"),
+                },
+            ),
+        ):
+            probes = query_mod.fetch_glean_probes("fenix.baseline")
+
+        assert probes[0]["data_sensitivity"] == []
+        assert probes[0]["tags"] == ["Search"]
+
+
+class TestLibraryMetrics:
+    """Most metrics are defined in a library, not in the app's own metrics file."""
+
+    def test_library_definitions_fill_gaps(self):
+        metric = {"name": "a11y.backplate", "type": "boolean", "pings": ["metrics"]}
+        library = {"a11y.backplate": {"history": [{"data_sensitivity": ["technical"]}]}}
+        urls = []
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get(
+                {
+                    **CATALOG,
+                    "/pings/": {"metrics": [metric]},
+                    "/glean/gecko/metrics": library,
+                },
+                urls=urls,
+            ),
+        ):
+            probes = query_mod.fetch_glean_probes("fenix.metrics")
+
+        # Resolved the dependency's library name back to the gecko repository.
+        assert any(u.endswith("/glean/gecko/metrics") for u in urls)
+        assert probes[0]["data_sensitivity"] == ["technical"]
+
+    def test_app_definition_wins_over_library(self):
+        library = {
+            "browser.search.ad_clicks": {
+                "history": [{"data_sensitivity": ["stored_content"]}]
+            }
+        }
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get(
+                {
+                    **CATALOG,
+                    "/pings/": DICTIONARY,
+                    FENIX_METRICS: PROBE_INFO,
+                    "/glean/gecko/metrics": library,
+                },
+            ),
+        ):
+            probes = query_mod.fetch_glean_probes("fenix.baseline")
+
+        assert probes[0]["data_sensitivity"] == ["interaction"]
+
+    def test_transitive_dependencies_are_followed(self):
+        # probe-info publishes a flat graph today; this guards the traversal if
+        # a library ever declares dependencies of its own.
+        repositories = [
+            {"name": "app", "dependencies": ["lib-one"]},
+            {"name": "one", "library_names": ["lib-one"], "dependencies": ["lib-two"]},
+            {"name": "two", "library_names": ["lib-two"]},
+        ]
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get(
+                {
+                    "/glean/repositories": repositories,
+                    "/glean/app-listings": APP_LISTINGS,
+                }
+            ),
+        ):
+            assert query_mod._metric_sources("app") == ("app", "one", "two")
+
+    def test_dependency_cycle_does_not_hang(self):
+        repositories = [
+            {"name": "a", "library_names": ["lib-a"], "dependencies": ["lib-b"]},
+            {"name": "b", "library_names": ["lib-b"], "dependencies": ["lib-a"]},
+        ]
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get(
+                {
+                    "/glean/repositories": repositories,
+                    "/glean/app-listings": APP_LISTINGS,
+                }
+            ),
+        ):
+            assert query_mod._metric_sources("a") == ("a", "b")
+
+
+class TestAppSlugResolution:
+    """A Dictionary app name is not a probe-info repository name."""
+
+    def test_release_channel_is_read_before_other_channels(self):
+        # Regression guard: fenix is a repository, so a name-based lookup would
+        # resolve, but to the nightly channel. Release must be read first so its
+        # definitions win, and both are read so neither channel's are lost.
+        with patch.object(query_mod.requests, "get", stub_get(CATALOG)):
+            slugs = query_mod._repository_slugs("fenix")
+
+        assert slugs[0] == "firefox-android-release"
+        assert "fenix" in slugs
+
+    def test_app_with_no_repository_of_its_own_name_resolves(self):
+        # Regression guard: firefox_ios -> firefox-ios 404s, which left
+        # data_sensitivity empty for the whole app.
+        urls = []
+        with patch.object(
+            query_mod.requests,
+            "get",
+            stub_get(
+                {
+                    **CATALOG,
+                    "/pings/": DICTIONARY,
+                    "/glean/firefox-ios-release/metrics": PROBE_INFO,
+                },
+                urls,
+            ),
+        ):
+            probes = query_mod.fetch_glean_probes("firefox_ios.baseline")
+
+        assert any(u.endswith("/glean/firefox-ios-release/metrics") for u in urls)
+        assert not any(u.endswith("/glean/firefox-ios/metrics") for u in urls)
+        assert probes[0]["data_sensitivity"] == ["interaction"]
+
+    def test_every_platform_listing_is_read(self):
+        # mozilla_vpn has one release listing per platform, and metrics can be
+        # unique to one of them, so dropping any loses their sensitivity.
+        with patch.object(query_mod.requests, "get", stub_get(CATALOG)):
+            assert query_mod._repository_slugs("mozilla_vpn") == (
+                "mozilla-vpn",
+                "mozilla-vpn-android",
+            )
+
+    def test_absent_app_channel_means_release(self):
+        with patch.object(query_mod.requests, "get", stub_get(CATALOG)):
+            assert query_mod._repository_slugs("firefox_desktop") == (
+                "firefox-desktop",
+            )
+
+    def test_unlisted_app_falls_back_to_the_dashed_name(self):
+        with patch.object(query_mod.requests, "get", stub_get(CATALOG)):
+            assert query_mod._repository_slugs("mystery_app") == ("mystery-app",)
+
+
+class TestCatalogFailure:
+    def test_catalog_failure_raises_and_is_retried(self):
+        # Degrading instead of raising would write a partition whose
+        # data_sensitivity is silently incomplete, and cache that result for the
+        # app, so later pings never retry the catalog.
+        calls = []
+
+        def _get(url, **kwargs):
+            if "/glean/repositories" in url:
+                calls.append(url)
+                if len(calls) == 1:
+                    raise query_mod.requests.ConnectionError("boom")
+                return FakeResponse(REPOSITORIES)
+            if "/glean/app-listings" in url:
+                return FakeResponse(APP_LISTINGS)
+            return FakeResponse({}, status_code=404)
+
+        with patch.object(query_mod.requests, "get", _get):
+            with pytest.raises(RuntimeError, match="probe-info repositories"):
+                query_mod._metric_sources("fenix")
+            # Not remembered, so the retry sees the recovered catalog.
+            assert query_mod._metric_sources("fenix") == (
+                "firefox-android-release",
+                "fenix",
+                "gecko",
+            )
+
+        assert len(calls) == 2
+
+
+class TestSchema:
+    def test_schema_yaml_matches_the_load_job_schema(self):
+        # The load job schema and the deployed schema must agree, including the
+        # three fields declared after the partition column.
+        declared = yaml.safe_load((_query_dir / "schema.yaml").read_text())["fields"]
+        assert [(f["name"], f["type"], f["mode"]) for f in declared] == [
+            (f.name, f.field_type, f.mode) for f in query_mod._PROBE_DEFINITIONS_SCHEMA
+        ]

--- a/tests/data_governance_metadata/test_probe_definitions_query.py
+++ b/tests/data_governance_metadata/test_probe_definitions_query.py
@@ -185,9 +185,10 @@ class TestGleanFieldMerge:
         assert probes[0]["send_in_pings"] == ["baseline", "metrics"]
         assert probes[0]["data_sensitivity"] == []
 
-    def test_unreadable_metrics_file_leaves_sensitivity_empty(self):
-        # One repository's metrics file is a data gap, not an outage, so it does
-        # not propagate. An unreachable catalog does; see TestCatalogFailure.
+    def test_unreachable_metrics_file_raises(self):
+        # A 404 is a data gap and yields empty fields, but an outage must not be
+        # turned into one: the partition would be written with the whole app's
+        # sensitivity silently missing.
         with patch.object(
             query_mod.requests,
             "get",
@@ -199,10 +200,10 @@ class TestGleanFieldMerge:
                 },
             ),
         ):
-            probes = query_mod.fetch_glean_probes("fenix.baseline")
-
-        assert probes[0]["data_sensitivity"] == []
-        assert probes[0]["tags"] == ["Search"]
+            with pytest.raises(
+                RuntimeError, match="probe-info firefox-android-release"
+            ):
+                query_mod.fetch_glean_probes("fenix.baseline")
 
 
 class TestLibraryMetrics:


### PR DESCRIPTION
This is the first step required to productionize data classification pipeline.

data_sensitivity and send_in_pings come from probe-info-service, tags from the Glean Dictionary response, and send_in_pings falls back to the Dictionary's ping list when a metric has no probe-info entry. Legacy telemetry leaves all three empty.

## Related Tickets & Documents
* DENG-11453