### PR TITLE
fix(glam): fail generation on errors instead of treating them as `no-probes`

### DIFF
--- a/bigquery_etl/glam/clients_daily_histogram_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_histogram_aggregates.py
@@ -1,7 +1,6 @@
 """clients_daily_histogram_aggregates query generator."""
 
 import argparse
-import sys
 from collections import defaultdict
 from typing import Dict, List, Optional
 
@@ -11,7 +10,12 @@ from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.probe_filters import get_etl_excluded_probes_quickfix
 
 from .client_side_sampled_metrics import get as get_sampled_metrics
-from .utils import get_schema, is_static_labeled_counter, ping_type_from_table
+from .utils import (
+    emit_query,
+    get_schema,
+    is_static_labeled_counter,
+    ping_type_from_table,
+)
 
 ATTRIBUTES = ",".join(
     [
@@ -138,7 +142,7 @@ def get_metrics_sql(metrics: Dict[str, List[str]]) -> dict[str, str]:
 
 
 def main():
-    """Print a clients_daily_scalar_aggregates query to stdout."""
+    """Generate a clients_daily_histogram_aggregates query."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--no-parameterize",
@@ -155,6 +159,15 @@ def main():
         "--product",
         type=str,
         default="org_mozilla_fenix",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to write query.sql into. Created when the ping has probes "
+            "and removed when it has none. Defaults to writing to stdout."
+        ),
     )
     args = parser.parse_args()
 
@@ -180,10 +193,9 @@ def main():
     if args.product == "firefox_desktop":
         client_sampled_metrics_sql = get_metrics_sql(client_sampled_distributions)
     if not metrics_sql["labeled"] and not metrics_sql["unlabeled"]:
-        print(header)
-        print("-- Empty query: no probes found!")
-        sys.exit(1)
-    print(
+        emit_query(None, args.output_dir, args.source_table)
+        return
+    emit_query(
         render_main(
             header=header,
             source_table=args.source_table,
@@ -197,7 +209,9 @@ def main():
             client_sampled_channel=CLIENT_SAMPLED_CHANNEL,
             client_sampled_os=CLIENT_SAMPLED_OS,
             client_sampled_max_sample_id=CLIENT_SAMPLED_MAX_SAMPLE_ID,
-        )
+        ),
+        args.output_dir,
+        args.source_table,
     )
 
 

--- a/bigquery_etl/glam/clients_daily_scalar_aggregates.py
+++ b/bigquery_etl/glam/clients_daily_scalar_aggregates.py
@@ -2,7 +2,6 @@
 """clients_daily_scalar_aggregates query generator."""
 
 import argparse
-import sys
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
@@ -12,7 +11,12 @@ from bigquery_etl.format_sql.formatter import reformat
 from bigquery_etl.util.probe_filters import get_etl_excluded_probes_quickfix
 
 from .client_side_sampled_metrics import get as get_sampled_metrics
-from .utils import get_schema, is_static_labeled_counter, ping_type_from_table
+from .utils import (
+    emit_query,
+    get_schema,
+    is_static_labeled_counter,
+    ping_type_from_table,
+)
 
 ATTRIBUTES = ",".join(
     [
@@ -153,7 +157,7 @@ def get_scalar_metrics(
 
 
 def main():
-    """Print a clients_daily_scalar_aggregates query to stdout."""
+    """Generate a clients_daily_scalar_aggregates query."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--no-parameterize",
@@ -165,6 +169,15 @@ def main():
         "--product",
         type=str,
         default="org_mozilla_fenix",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help=(
+            "Directory to write query.sql into. Created when the ping has probes "
+            "and removed when it has none. Defaults to writing to stdout."
+        ),
     )
     args = parser.parse_args()
 
@@ -206,10 +219,9 @@ def main():
             unlabeled_sampled_metric_names
         ).strip()
     if not unlabeled_metrics and not labeled_metrics:
-        print(header)
-        print("-- Empty query: no probes found!")
-        sys.exit(1)
-    print(
+        emit_query(None, args.output_dir, args.source_table)
+        return
+    emit_query(
         render_main(
             header=header,
             source_table=args.source_table,
@@ -224,7 +236,9 @@ def main():
             client_sampled_channel=CLIENT_SAMPLED_CHANNEL,
             client_sampled_os=CLIENT_SAMPLED_OS,
             client_sampled_max_sample_id=CLIENT_SAMPLED_MAX_SAMPLE_ID,
-        )
+        ),
+        args.output_dir,
+        args.source_table,
     )
 
 

--- a/bigquery_etl/glam/utils.py
+++ b/bigquery_etl/glam/utils.py
@@ -1,9 +1,13 @@
 """Utilities for the GLAM module."""
 
 import json
+import shutil
 import subprocess
+import sys
+import time
 from collections import namedtuple
 from itertools import combinations
+from pathlib import Path
 from typing import List, Optional, Tuple
 
 import requests
@@ -34,6 +38,14 @@ _PRODUCT_TO_APP_NAME = {
 # field names look up directly. The Dictionary uses the same app names as
 # Experimenter, so the product -> app mapping uses _PRODUCT_TO_APP_NAME.
 GLEAN_DICTIONARY_DATA_URL = "https://dictionary.telemetry.mozilla.org/data"
+GLEAN_DICTIONARY_TIMEOUT = 30
+# Retries beyond the first attempt, with 2**attempt seconds between them.
+GLEAN_DICTIONARY_RETRIES = 4
+GLEAN_DICTIONARY_RETRY_STATUS = frozenset({429, 500, 502, 503, 504})
+_TRANSIENT_ERRORS = (
+    requests.exceptions.Timeout,
+    requests.exceptions.ConnectionError,
+)
 
 _glean_metric_metadata_cache: dict = {}
 
@@ -112,6 +124,40 @@ def get_custom_distribution_metadata(product_name) -> List[CustomDistributionMet
     return custom
 
 
+def _get_with_retries(url: str) -> requests.Response:
+    """GET `url`, retrying transient timeouts."""
+    for attempt in range(GLEAN_DICTIONARY_RETRIES):
+        try:
+            resp = requests.get(url, timeout=GLEAN_DICTIONARY_TIMEOUT)
+            if resp.status_code not in GLEAN_DICTIONARY_RETRY_STATUS:
+                return resp
+        except _TRANSIENT_ERRORS:
+            pass
+        time.sleep(2**attempt)
+    return requests.get(url, timeout=GLEAN_DICTIONARY_TIMEOUT)
+
+
+def emit_query(
+    sql: Optional[str], output_dir: Optional[str], source_table: str
+) -> None:
+    """Write a generated query, or skip the ping when it has no probes."""
+    if sql is None:
+        print(f"skipping {source_table}: no probes found", file=sys.stderr)
+        if output_dir is not None:
+            shutil.rmtree(output_dir, ignore_errors=True)
+        return
+
+    if output_dir is None:
+        print(sql)
+        return
+
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    query_path = path / "query.sql"
+    query_path.write_text(sql.rstrip("\n") + "\n")
+    print(f"generated {query_path}", file=sys.stderr)
+
+
 def get_glean_metric_metadata(
     product: Optional[str], probe_name: str
 ) -> Optional[dict]:
@@ -134,11 +180,10 @@ def get_glean_metric_metadata(
         return None
 
     url = f"{GLEAN_DICTIONARY_DATA_URL}/{app}/metrics/data_{probe_name}.json"
-    resp = requests.get(url, timeout=10)
+    resp = _get_with_retries(url)
     if resp.status_code == 404:
         meta = None
     else:
-        # Anything other than 404 must fail loudly, not be treated as absent.
         resp.raise_for_status()
         info = resp.json()
         meta = {"type": info.get("type"), "labels": info.get("labels") or []}

--- a/bigquery_etl/glam/utils.py
+++ b/bigquery_etl/glam/utils.py
@@ -124,17 +124,29 @@ def get_custom_distribution_metadata(product_name) -> List[CustomDistributionMet
     return custom
 
 
-def _get_with_retries(url: str) -> requests.Response:
-    """GET `url`, retrying transient timeouts."""
-    for attempt in range(GLEAN_DICTIONARY_RETRIES):
+def _get_with_retries(url: str) -> requests.Response:  # type: ignore[return]
+    """GET `url`, retrying transient errors and GLEAN_DICTIONARY_RETRY_STATUS.
+
+    The last attempt always returns or raises, which mypy cannot infer,
+    hence the type: ignore[return].
+    """
+    for attempt in range(GLEAN_DICTIONARY_RETRIES + 1):
+        last = attempt == GLEAN_DICTIONARY_RETRIES
         try:
             resp = requests.get(url, timeout=GLEAN_DICTIONARY_TIMEOUT)
-            if resp.status_code not in GLEAN_DICTIONARY_RETRY_STATUS:
+            if last or resp.status_code not in GLEAN_DICTIONARY_RETRY_STATUS:
                 return resp
-        except _TRANSIENT_ERRORS:
-            pass
+            reason = f"HTTP {resp.status_code}"
+        except _TRANSIENT_ERRORS as e:
+            if last:
+                raise
+            reason = type(e).__name__
+        print(
+            f"retrying {url} after {reason} "
+            f"(attempt {attempt + 1}/{GLEAN_DICTIONARY_RETRIES + 1})",
+            file=sys.stderr,
+        )
         time.sleep(2**attempt)
-    return requests.get(url, timeout=GLEAN_DICTIONARY_TIMEOUT)
 
 
 def emit_query(
@@ -143,8 +155,11 @@ def emit_query(
     """Write a generated query, or skip the ping when it has no probes."""
     if sql is None:
         print(f"skipping {source_table}: no probes found", file=sys.stderr)
-        if output_dir is not None:
-            shutil.rmtree(output_dir, ignore_errors=True)
+        if output_dir is None:
+            print("-- Empty query: no probes found!")
+        # Not ignore_errors: a stale query.sql must not survive a failed removal.
+        elif Path(output_dir).exists():
+            shutil.rmtree(output_dir)
         return
 
     if output_dir is None:

--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -2,6 +2,11 @@
 
 set -ex
 
+# The generators own their output directory: they write query.sql when the ping
+# has probes and remove the directory when it has none, both exiting 0. Any
+# non-zero exit is therefore a real failure and must fail this script -- it used
+# to be indistinguishable from "no probes found", so a Glean Dictionary timeout
+# could silently drop a ping's query and leave the Airflow task green.
 function write_scalars {
     local product=$1
     local dataset=$2
@@ -9,16 +14,10 @@ function write_scalars {
     local dst_project=$4
     local sql_dir=$5
     local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_scalar_aggregates_${table}"
-    mkdir -p "$directory"
-    if ! python3 -m bigquery_etl.glam.clients_daily_scalar_aggregates \
+    python3 -m bigquery_etl.glam.clients_daily_scalar_aggregates \
         --source-table "$dataset.$table" \
         --product "$product" \
-        > "$directory/query.sql"; then
-            echo "skipping $directory/query.sql: no probes found"
-            rm -r "$directory"
-    else
-        echo "generated $directory/query.sql"
-    fi
+        --output-dir "$directory"
 }
 
 function write_histograms {
@@ -28,16 +27,20 @@ function write_histograms {
     local dst_project=$4
     local sql_dir=$5
     local directory="${sql_dir}/${dst_project}/glam_etl/${product}__clients_daily_histogram_aggregates_${table}"
-    mkdir -p "$directory"
-    if ! python3 -m bigquery_etl.glam.clients_daily_histogram_aggregates \
+    python3 -m bigquery_etl.glam.clients_daily_histogram_aggregates \
         --source-table "$dataset.$table" \
         --product "$product" \
-        > "$directory/query.sql"; then
-            echo "skipping $directory/query.sql: no probes found"
-            rm -r "$directory"
-    else
-        echo "generated $directory/query.sql"
-    fi
+        --output-dir "$directory"
+}
+
+function wait_for_pids {
+    # Wait on each pid individually so a failing generator fails this script. A
+    # bare `wait` always returns 0, so backgrounded failures were invisible even
+    # though the functions above run under `set -e`.
+    local pid
+    for pid in "$@"; do
+        wait "$pid"
+    done
 }
 
 function write_clients_daily_aggregates {
@@ -80,16 +83,20 @@ function write_clients_daily_aggregates {
         select(.tableReference.tableId | test($exclude_pattern) | not) |
         "\(.tableReference.tableId)"')
 
-    # generate schemas in parallel
+    # generate schemas in parallel, 2 tables at a time to limit concurrent
+    # python processes
+    local pids=()
     for table in $tables; do
-        # 2 tables at a time to limit concurrent python processes
-        i=$((i % 2))
-        ((i++==0)) && wait
         write_scalars "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
+        pids+=("$!")
         write_histograms "$product" "$dataset" "$table" "$dst_project" "$sql_dir" &
+        pids+=("$!")
+        if ((${#pids[@]} >= 4)); then
+            wait_for_pids "${pids[@]}"
+            pids=()
+        fi
     done
-
-    wait
+    wait_for_pids "${pids[@]}"
 }
 
 cd "$(dirname "$0")/../.."

--- a/script/glam/generate_glean_sql
+++ b/script/glam/generate_glean_sql
@@ -2,11 +2,9 @@
 
 set -ex
 
-# The generators own their output directory: they write query.sql when the ping
-# has probes and remove the directory when it has none, both exiting 0. Any
-# non-zero exit is therefore a real failure and must fail this script -- it used
-# to be indistinguishable from "no probes found", so a Glean Dictionary timeout
-# could silently drop a ping's query and leave the Airflow task green.
+# Generators write query.sql when the ping has probes and remove the directory
+# when it has none, both exiting 0. Any non-zero exit is therefore a real failure
+# and must fail this script.
 function write_scalars {
     local product=$1
     local dataset=$2

--- a/tests/glam/test_labeled_counter_categorical.py
+++ b/tests/glam/test_labeled_counter_categorical.py
@@ -210,6 +210,21 @@ class TestGleanDictionaryRetries:
                 utils.is_static_labeled_counter("org_mozilla_fenix", "m")
         assert get.call_count == utils.GLEAN_DICTIONARY_RETRIES + 1
 
+    def test_retries_are_reported(self, capsys):
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            side_effect=[
+                requests.exceptions.ReadTimeout("timed out"),
+                _resp(status_code=503),
+                _resp({"type": "labeled_counter", "labels": ["a"]}),
+            ],
+        ):
+            utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+        err = capsys.readouterr().err
+        assert "after ReadTimeout (attempt 1/5)" in err
+        assert "after HTTP 503 (attempt 2/5)" in err
+
     def test_404_is_not_retried(self):
         with mock.patch.object(
             utils.requests, "get", return_value=_resp(status_code=404)
@@ -243,14 +258,24 @@ class TestEmitQuery:
         utils.emit_query(None, str(out), "d.some_ping_v1")
         assert not out.exists()
 
+    def test_failed_removal_propagates(self, tmp_path):
+        out = tmp_path / "some_ping"
+        out.mkdir()
+        (out / "query.sql").write_text("SELECT 1\n")
+        with mock.patch.object(
+            utils.shutil, "rmtree", side_effect=OSError("permission denied")
+        ):
+            with pytest.raises(OSError):
+                utils.emit_query(None, str(out), "d.some_ping_v1")
+
     def test_stdout_mode_writes_sql(self, capsys):
         utils.emit_query("SELECT 1", None, "d.some_ping_v1")
         assert capsys.readouterr().out.strip() == "SELECT 1"
 
-    def test_stdout_mode_emits_nothing_when_no_probes(self, capsys):
+    def test_stdout_mode_marks_empty_query_when_no_probes(self, capsys):
         utils.emit_query(None, None, "d.some_ping_v1")
         captured = capsys.readouterr()
-        assert captured.out == ""
+        assert captured.out.strip() == "-- Empty query: no probes found!"
         assert "no probes found" in captured.err
 
 

--- a/tests/glam/test_labeled_counter_categorical.py
+++ b/tests/glam/test_labeled_counter_categorical.py
@@ -1,0 +1,307 @@
+"""Tests for processing static labeled_counters as categorical histograms.
+
+A labeled_counter with a predefined `labels` list (per the Glean Dictionary) is
+the Glean replacement for a Legacy Telemetry categorical histogram. These live in
+the histogram pipeline; dynamic (open-ended) labeled_counters stay in the scalar
+pipeline.
+"""
+
+import sys
+from unittest import mock
+
+import pytest
+import requests
+
+from bigquery_etl.glam import clients_daily_histogram_aggregates as histograms
+from bigquery_etl.glam import clients_daily_scalar_aggregates as scalars
+from bigquery_etl.glam import utils
+
+
+@pytest.fixture(autouse=True)
+def no_retry_sleep(monkeypatch):
+    """Keep the retry backoff from actually sleeping during tests."""
+    monkeypatch.setattr(utils.time, "sleep", lambda _: None)
+
+
+def _resp(payload=None, status_code=200):
+    """Build a stand-in for a requests.Response returning `payload` from json()."""
+    resp = mock.Mock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+class TestGleanDictionaryLookup:
+    def setup_method(self):
+        utils._glean_metric_metadata_cache.clear()
+
+    def test_static_labeled_counter_detected(self):
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            return_value=_resp(
+                {"type": "labeled_counter", "labels": ["not_used", "succeeded"]}
+            ),
+        ) as get:
+            assert utils.is_static_labeled_counter(
+                "org_mozilla_fenix", "dns_trr_http3_0rtt_state"
+            )
+        # Fenix maps to the "fenix" dictionary app; file name == BQ column form.
+        url = get.call_args.args[0]
+        assert "/fenix/metrics/data_dns_trr_http3_0rtt_state.json" in url
+
+    def test_dynamic_labeled_counter_not_static(self):
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            return_value=_resp({"type": "labeled_counter", "labels": None}),
+        ):
+            assert not utils.is_static_labeled_counter("org_mozilla_fenix", "dynamic")
+
+    def test_non_labeled_counter_not_static(self):
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            return_value=_resp({"type": "timing_distribution", "labels": []}),
+        ):
+            assert not utils.is_static_labeled_counter("org_mozilla_fenix", "perf_load")
+
+    def test_absent_metric_404_is_not_static(self):
+        # A genuine 404 is the only "expected" miss -> not static.
+        with mock.patch.object(
+            utils.requests, "get", return_value=_resp(status_code=404)
+        ) as get:
+            assert not utils.is_static_labeled_counter("org_mozilla_fenix", "missing")
+        get.assert_called_once()
+
+    def test_network_error_propagates(self):
+        # A transient failure must fail loudly, not be treated as "not static".
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            side_effect=requests.exceptions.ConnectionError("boom"),
+        ):
+            with pytest.raises(requests.exceptions.ConnectionError):
+                utils.is_static_labeled_counter("org_mozilla_fenix", "x")
+
+    def test_non_404_http_error_propagates(self):
+        resp = _resp(status_code=500)
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError("500")
+        with mock.patch.object(utils.requests, "get", return_value=resp):
+            with pytest.raises(requests.exceptions.HTTPError):
+                utils.is_static_labeled_counter("org_mozilla_fenix", "x")
+
+    def test_unknown_product_skips_request(self):
+        with mock.patch.object(utils.requests, "get") as get:
+            assert not utils.is_static_labeled_counter("not_a_product", "x")
+        get.assert_not_called()
+
+    def test_result_is_cached(self):
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            return_value=_resp({"type": "labeled_counter", "labels": ["a"]}),
+        ) as get:
+            utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+            utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+        get.assert_called_once()
+
+
+SCHEMA = [
+    {
+        "name": "metrics",
+        "fields": [
+            {
+                "name": "labeled_counter",
+                "fields": [
+                    {"name": "dns_trr_http3_0rtt_state"},  # static
+                    {"name": "some_dynamic_counter"},  # dynamic
+                ],
+            },
+            {"name": "counter", "fields": [{"name": "plain_counter"}]},
+            {"name": "timing_distribution", "fields": [{"name": "perf_load"}]},
+        ],
+    }
+]
+
+
+def _fake_is_static(product, probe_name):
+    return probe_name == "dns_trr_http3_0rtt_state"
+
+
+class TestHistogramRouting:
+    def test_static_labeled_counter_routed_to_histogram(self, monkeypatch):
+        monkeypatch.setattr(histograms, "is_static_labeled_counter", _fake_is_static)
+        monkeypatch.setattr(histograms, "get_sampled_metrics", lambda *a, **k: {})
+        metrics, _ = histograms.get_distribution_metrics(
+            SCHEMA, product="org_mozilla_fenix"
+        )
+        assert metrics["labeled_counter"] == ["dns_trr_http3_0rtt_state"]
+        assert metrics["timing_distribution"] == ["perf_load"]
+
+    def test_categorical_snippet_uses_bare_metric_path(self):
+        # The metric's key/value array IS the categorical histogram, so it is fed
+        # in directly (no `.values`) as an unlabeled histogram.
+        sql = histograms.get_metrics_sql(
+            {"labeled_counter": ["dns_trr_http3_0rtt_state"]}
+        )
+        assert (
+            '(\'\', "dns_trr_http3_0rtt_state", "labeled_counter", '
+            "metrics.labeled_counter.dns_trr_http3_0rtt_state)" in sql["unlabeled"]
+        )
+        assert sql["labeled"] == ""
+
+    def test_distribution_snippet_still_uses_values(self):
+        sql = histograms.get_metrics_sql({"timing_distribution": ["perf_load"]})
+        assert "metrics.timing_distribution.perf_load.values" in sql["unlabeled"]
+
+
+class TestScalarExclusion:
+    def test_static_labeled_counter_excluded_from_scalar(self, monkeypatch):
+        monkeypatch.setattr(scalars, "is_static_labeled_counter", _fake_is_static)
+        monkeypatch.setattr(scalars, "get_sampled_metrics", lambda *a, **k: {})
+        result, _ = scalars.get_scalar_metrics(
+            SCHEMA, "labeled", product="org_mozilla_fenix"
+        )
+        # Dynamic stays in scalar; static moved to the histogram pipeline.
+        assert result["labeled_counter"] == ["some_dynamic_counter"]
+
+
+class TestGleanDictionaryRetries:
+    """A transient Dictionary failure took out a whole ping's query (2026-08-03)."""
+
+    def setup_method(self):
+        utils._glean_metric_metadata_cache.clear()
+
+    def test_read_timeout_is_retried_then_succeeds(self):
+        payload = {"type": "labeled_counter", "labels": ["a"]}
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            side_effect=[
+                requests.exceptions.ReadTimeout("timed out"),
+                _resp(payload),
+            ],
+        ) as get:
+            assert utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+        assert get.call_count == 2
+
+    def test_retryable_status_is_retried_then_succeeds(self):
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            side_effect=[
+                _resp(status_code=503),
+                _resp({"type": "labeled_counter", "labels": ["a"]}),
+            ],
+        ) as get:
+            assert utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+        assert get.call_count == 2
+
+    def test_persistent_timeout_still_raises(self):
+        # Retries must not turn a real outage into a silent success.
+        with mock.patch.object(
+            utils.requests,
+            "get",
+            side_effect=requests.exceptions.ReadTimeout("timed out"),
+        ) as get:
+            with pytest.raises(requests.exceptions.ReadTimeout):
+                utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+        assert get.call_count == utils.GLEAN_DICTIONARY_RETRIES + 1
+
+    def test_404_is_not_retried(self):
+        with mock.patch.object(
+            utils.requests, "get", return_value=_resp(status_code=404)
+        ) as get:
+            assert not utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+        get.assert_called_once()
+
+    def test_timeout_is_generous(self):
+        with mock.patch.object(
+            utils.requests, "get", return_value=_resp(status_code=404)
+        ) as get:
+            utils.is_static_labeled_counter("org_mozilla_fenix", "m")
+        assert get.call_args.kwargs["timeout"] == utils.GLEAN_DICTIONARY_TIMEOUT
+
+
+class TestEmitQuery:
+    def test_writes_query_to_output_dir(self, tmp_path):
+        out = tmp_path / "some_ping"
+        utils.emit_query("SELECT 1", str(out), "d.some_ping_v1")
+        assert (out / "query.sql").read_text() == "SELECT 1\n"
+
+    def test_no_probes_removes_stale_directory(self, tmp_path):
+        out = tmp_path / "some_ping"
+        out.mkdir()
+        (out / "query.sql").write_text("SELECT 1\n")
+        utils.emit_query(None, str(out), "d.some_ping_v1")
+        assert not out.exists()
+
+    def test_no_probes_without_existing_directory(self, tmp_path):
+        out = tmp_path / "some_ping"
+        utils.emit_query(None, str(out), "d.some_ping_v1")
+        assert not out.exists()
+
+    def test_stdout_mode_writes_sql(self, capsys):
+        utils.emit_query("SELECT 1", None, "d.some_ping_v1")
+        assert capsys.readouterr().out.strip() == "SELECT 1"
+
+    def test_stdout_mode_emits_nothing_when_no_probes(self, capsys):
+        utils.emit_query(None, None, "d.some_ping_v1")
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "no probes found" in captured.err
+
+
+EMPTY_SCHEMA: list = []
+
+
+class TestGeneratorOutputContract:
+    """exit 0 means handled; any non-zero exit means something broke."""
+
+    def setup_method(self):
+        utils._glean_metric_metadata_cache.clear()
+
+    def _run(self, module, tmp_path, monkeypatch, schema, out_name="out"):
+        out = tmp_path / out_name
+        monkeypatch.setattr(module, "get_schema", lambda *a, **k: schema)
+        monkeypatch.setattr(module, "get_sampled_metrics", lambda *a, **k: {})
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "prog",
+                "--source-table",
+                "org_mozilla_fenix_stable.metrics_v1",
+                "--product",
+                "org_mozilla_fenix",
+                "--output-dir",
+                str(out),
+            ],
+        )
+        module.main()
+        return out
+
+    @pytest.mark.parametrize("module", [histograms, scalars])
+    def test_no_probes_leaves_no_directory(self, module, tmp_path, monkeypatch):
+        out = self._run(module, tmp_path, monkeypatch, EMPTY_SCHEMA)
+        assert not out.exists()
+
+    @pytest.mark.parametrize("module", [histograms, scalars])
+    def test_probes_produce_query_file(self, module, tmp_path, monkeypatch):
+        monkeypatch.setattr(module, "is_static_labeled_counter", _fake_is_static)
+        out = self._run(module, tmp_path, monkeypatch, SCHEMA)
+        assert (out / "query.sql").read_text().startswith("-- Query generated by:")
+
+    @pytest.mark.parametrize("module", [histograms, scalars])
+    def test_dictionary_failure_propagates(self, module, tmp_path, monkeypatch):
+        # The regression: this used to exit 1, indistinguishable from "no probes",
+        # so the caller deleted the query and the Airflow task stayed green.
+        def boom(*args, **kwargs):
+            raise requests.exceptions.ReadTimeout("timed out")
+
+        monkeypatch.setattr(module, "is_static_labeled_counter", boom)
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            self._run(module, tmp_path, monkeypatch, SCHEMA)
+        assert not (tmp_path / "out").exists()


### PR DESCRIPTION
## Description

A Glean Dictionary timeout made the generator exit 1 the same code as the legitimate "no probes found" case, so the query was deleted and the pod still exited 0. 
This PR makes generators now take `--output-dir` and exit 0 only when handled, `wait_for_pids` replaces a bare `wait` that always returned 0, and the Dictionary lookup retries with backoff.

## Related Tickets & Documents
* DENG-11467

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
