### PR TITLE
Fix geckoview_version_v1 nightly branch after geckoview_version field removal

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/query.sql
@@ -16,7 +16,9 @@ WITH extracted AS (
   SELECT
     submission_timestamp,
     client_info.app_build,
-    COALESCE(metrics.string.gecko_version, metrics.string.geckoview_version) AS gecko_version,
+    -- geckoview_version was dropped from the nightly ping schema; gecko_version
+    -- is the only field still present for this channel.
+    metrics.string.gecko_version AS gecko_version,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_fenix_nightly.metrics` AS t1
   UNION ALL


### PR DESCRIPTION
## Summary
- `org_mozilla_fenix_derived.geckoview_version_v1` started failing (`bqetl_org_mozilla_fenix_derived` DAG) because the `geckoview_version` field was dropped from `org_mozilla_fenix_nightly`'s ping schema (schema update applied 2026-08-11 06:29 UTC). The nightly branch's `COALESCE(gecko_version, geckoview_version)` fallback referenced a now-nonexistent struct field, which BigQuery rejects outright.
- Release and aurora channels still have `geckoview_version` in their schemas and aren't affected, so this only touches the nightly branch.
- Fix: select `gecko_version` directly in the nightly branch instead of falling back to the dropped field.

## Test plan
- [x] `./bqetl query validate org_mozilla_fenix_derived.geckoview_version_v1` passes
- [ ] Existing unit test (`tests/sql/.../geckoview_version_v1/test_aggregation`) — couldn't run it locally (my account lacks `bigquery.datasets.create` on `moz-fx-data-shared-prod`), deferring to CI