### PR TITLE
fix(org_mozilla_fenix_derived): drop dead geckoview_version fallback

### DIFF
--- a/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/org_mozilla_fenix_derived/geckoview_version_v1/query.sql
@@ -16,7 +16,9 @@ WITH extracted AS (
   SELECT
     submission_timestamp,
     client_info.app_build,
-    COALESCE(metrics.string.gecko_version, metrics.string.geckoview_version) AS gecko_version,
+    -- geckoview_version was dropped from the nightly ping schema; gecko_version
+    -- is the only field still present for this channel.
+    metrics.string.gecko_version AS gecko_version,
   FROM
     `moz-fx-data-shared-prod.org_mozilla_fenix_nightly.metrics` AS t1
   UNION ALL


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
geckoview_version was dropped from org_mozilla_fenix_nightly's ping schema (schema update applied 2026-08-11), breaking the COALESCE fallback in geckoview_version_v1's nightly branch with "Field name geckoview_version does not exist in STRUCT<...>". gecko_version is the only field still present for that channel, so select it directly.

## Related Tickets & Documents
[Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=2062776)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
