### PR TITLE
feat(firefox_desktop): add hang_report_redacted view for the BHR aggregation job

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/hang_report_redacted/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/hang_report_redacted/metadata.yaml
@@ -1,0 +1,30 @@
+---
+friendly_name: Hang Report (redacted)
+description: |-
+  Narrow projection of `firefox_desktop_stable.hang_report_v1` for the
+  Background Hang Reporter aggregation job, which runs as a mozilla-central
+  TaskCluster cron (bug 2048276).
+
+  This is an allow-list: it exposes only the columns that job reads, and the
+  projection is itself the access control. The consumer is granted on this view
+  rather than on `firefox_desktop.hang_report`, so everything left out is
+  unreachable even if the job's credential is compromised. Not exposed:
+  session id, geo, ISP, attribution, experiments, user-agent data, and
+  IP-derived metadata.
+
+  Note this is stricter than the `stable_views_redacted` generator, which
+  removes only metrics tagged `highly_sensitive`. `hang_report` is not in that
+  generator's ping list; this view is checked in at the path the generator
+  would use, which it treats as a manual override.
+
+  `client_id` is exposed as-is. It is read only in memory, to build
+  HyperLogLog sketches for a distinct-affected-clients-per-hang-signature
+  metric. No identifier is written to any published artifact -- only aggregate
+  counts leave the job.
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  # https://mozilla-hub.atlassian.net/browse/DENG-11394
+  - workgroup:dataplatform/hang-report-collection
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/hang_report_redacted/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/hang_report_redacted/view.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.hang_report_redacted`
+AS
+SELECT
+  document_id,
+  submission_timestamp,
+  STRUCT(
+    client_info.os AS os,
+    client_info.os_version AS os_version,
+    client_info.architecture AS architecture,
+    client_info.app_build AS app_build,
+    client_info.client_id AS client_id
+  ) AS client_info,
+  STRUCT(
+    STRUCT(
+      metrics.object.hangs_modules AS hangs_modules,
+      metrics.object.hangs_reports AS hangs_reports
+    ) AS object
+  ) AS metrics
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_stable.hang_report_v1`


### PR DESCRIPTION
Jira: [DENG-11394](https://mozilla-hub.atlassian.net/browse/DENG-11394)

### What

Adds `firefox_desktop.hang_report_redacted`, a narrow allow-list projection of `firefox_desktop_stable.hang_report_v1`.

### Why

The Background Hang Reporter aggregation job was recently migrated out of `python_mozetl`/Airflow into mozilla-central, where it runs as a daily TaskCluster cron ([bug 2048276](https://bugzilla.mozilla.org/show_bug.cgi?id=2048276)) using a stored GCP service-account key. That credential is currently granted on `firefox_desktop.hang_report`, which exposes far more than the job needs — session id, geo, ISP, attribution, experiments, user-agent data and IP-derived metadata all come along for the ride.

The projection here *is* the access control: move the grant onto this view and those columns become unreachable even if the job's credential leaks.

### Columns, and why each one

The job's query is [`bhr_collection.py`](https://searchfox.org/mozilla-central/source/toolkit/components/backgroundhangmonitor/aggregation/bhr_collection.py). It reads exactly:

| Column | Used for |
|---|---|
| `document_id` | sampling, via `ABS(MOD(FARM_FINGERPRINT(document_id), 10000)) < N` |
| `submission_timestamp` | partition filter |
| `client_info.os`, `.os_version`, `.architecture` | per-platform breakdown |
| `client_info.app_build` | build-date window filter |
| `metrics.object.hangs_modules`, `.hangs_reports` | the hang payloads themselves |

The nested `STRUCT` shape is preserved deliberately so the job's SQL works against either view unchanged.

`client_id` is included ahead of its consumer. A distinct-affected-clients-per-signature metric is in review on the Firefox side; it reads `client_id` only in memory to build HyperLogLog sketches, and no identifier reaches any published artifact — only aggregate counts. Exposing it raw here was reviewed and agreed with Firefox operations security rather than using a salted hash. Happy to drop it from this PR and add it in a follow-up if you'd rather it land with its consumer.

### Notes for review

- **This is stricter than the `stable_views_redacted` generator**, which removes only metrics tagged `highly_sensitive`. `hang_report` is not in that generator's ping list (`bqetl_project.yaml` lists only `microsurvey` for `firefox_desktop`), and the files are checked in at the path the generator would use, which it treats as a manual override.
- **Reads the stable table, not `firefox_desktop.hang_report`.** The generated view is `SELECT * REPLACE(...)` plus derived columns (`app_version_*`, `is_bot_generated`); it adds columns but filters no rows, so the seven columns above are identical either way and repointing the job shifts no numbers.
- `is_bot_generated` is deliberately not carried over — it derives from `metadata.isp.name`, and the job doesn't use it. Easy to add as a plain boolean if that's preferable to leaving the capability out.

### Sequencing

Additive on purpose — nothing breaks when this merges. Revoking `workgroup_access` on `firefox_desktop.hang_report` is a **follow-up PR**, deliberately not bundled here: the cron reads `firefox_desktop.hang_report` today, so revoking before it has been repointed would break the running job.

1. This PR — add the view and grant.
2. mozilla-central — repoint the job at `hang_report_redacted`.
3. Follow-up PR — revoke the grant on `hang_report`.

[DENG-11394]: https://mozilla-hub.atlassian.net/browse/DENG-11394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ