### PR TITLE
feat: add new analysis results monitoring table

### DIFF
--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
@@ -10,12 +10,10 @@ description: |-
   (e.g. a NULL `metric` means the whole experiment/period run failed before
   any specific metric was attempted) -- see view.sql in
   jetstream_analysis_errors for which log sites produce which NULLs.
-
-  Not safely backfillable -- see query.py's docstring.
 owners:
   - mwilliams@mozilla.com
 labels:
-  incremental: false
+  incremental: true
   schedule: daily
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
@@ -2,19 +2,20 @@ friendly_name: Analysis Results Monitoring
 description: |-
   Daily rollup of experiment analysis metrics with success/failure status, at
   (experiment, analysis_period, analysis_basis, segment, metric) grain. Each
-  row records whether that cell was successfully computed (found in the
-  experiment's `statistics_*` tables) or failed (found in
-  `jetstream_analysis_errors`, with its `error_category`). Used to measure
-  experiment- and metric-level analysis success rates. A NULL in
-  `analysis_period`, `analysis_basis`, `segment`, or `metric` on a failed row
-  means the failure was broader than a single cell (e.g. a NULL `metric`
-  means the whole experiment/period run failed before any specific metric was
-  attempted) -- see view.sql in jetstream_analysis_errors for which log sites
-  produce which NULLs.
+  row's status is succeeded, failed, or partial (both a logged failure and
+  output exist for that cell -- see query.py), with `error_category` set for
+  failed/partial rows. Used to measure experiment- and metric-level analysis
+  success rates. A NULL in `analysis_period`, `analysis_basis`, `segment`, or
+  `metric` on a failed row means the failure was broader than a single cell
+  (e.g. a NULL `metric` means the whole experiment/period run failed before
+  any specific metric was attempted) -- see view.sql in
+  jetstream_analysis_errors for which log sites produce which NULLs.
+
+  Not safely backfillable -- see query.py's docstring.
 owners:
   - mwilliams@mozilla.com
 labels:
-  incremental: true
+  incremental: false
   schedule: daily
 bigquery:
   time_partitioning:
@@ -25,6 +26,9 @@ scheduling:
   dag_name: bqetl_experiments_daily
   arguments:
     - --date={{ds}}
+  referenced_tables:
+    - ['moz-fx-data-experiments', 'monitoring', 'logs']
   depends_on:
     - task_id: jetstream_run
       dag_name: jetstream
+      execution_delta: -1h

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
@@ -1,0 +1,30 @@
+friendly_name: Analysis Results Monitoring
+description: |-
+  Daily rollup of experiment analysis metrics with success/failure status, at
+  (experiment, analysis_period, analysis_basis, segment, metric) grain. Each
+  row records whether that cell was successfully computed (found in the
+  experiment's `statistics_*` tables) or failed (found in
+  `jetstream_analysis_errors`, with its `error_category`). Used to measure
+  experiment- and metric-level analysis success rates. A NULL in
+  `analysis_period`, `analysis_basis`, `segment`, or `metric` on a failed row
+  means the failure was broader than a single cell (e.g. a NULL `metric`
+  means the whole experiment/period run failed before any specific metric was
+  attempted) -- see view.sql in jetstream_analysis_errors for which log sites
+  produce which NULLs.
+owners:
+  - mwilliams@mozilla.com
+labels:
+  incremental: true
+  schedule: daily
+bigquery:
+  time_partitioning:
+    type: day
+    field: analysis_date
+    require_partition_filter: false
+scheduling:
+  dag_name: bqetl_experiments_daily
+  arguments:
+    - --date={{ds}}
+  depends_on:
+    - task_id: jetstream_run
+      dag_name: jetstream

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/metadata.yaml
@@ -1,15 +1,16 @@
 friendly_name: Analysis Results Monitoring
 description: |-
   Daily rollup of experiment analysis metrics with success/failure status, at
-  (experiment, analysis_period, analysis_basis, segment, metric) grain. Each
-  row's status is succeeded, failed, or partial (both a logged failure and
-  output exist for that cell -- see query.py), with `error_category` set for
-  failed/partial rows. Used to measure experiment- and metric-level analysis
-  success rates. A NULL in `analysis_period`, `analysis_basis`, `segment`, or
-  `metric` on a failed row means the failure was broader than a single cell
-  (e.g. a NULL `metric` means the whole experiment/period run failed before
-  any specific metric was attempted) -- see view.sql in
-  jetstream_analysis_errors for which log sites produce which NULLs.
+  (experiment, analysis_period, window_index, analysis_basis, segment,
+  metric) grain. Each row's status is succeeded, failed, or partial (both a
+  logged failure and output exist for that cell -- see query.py), with
+  `error_category` set for failed/partial rows. Used to measure experiment-
+  and metric-level analysis success rates. A NULL in `analysis_period`,
+  `window_index`, `analysis_basis`, `segment`, or `metric` on a failed row
+  means the failure was broader than a single cell (e.g. a NULL `metric`
+  means the whole experiment/period run failed before any specific metric
+  was attempted) -- see view.sql in jetstream_analysis_errors for which log
+  sites produce which NULLs.
 owners:
   - mwilliams@mozilla.com
 labels:
@@ -26,6 +27,7 @@ scheduling:
     - --date={{ds}}
   referenced_tables:
     - ['moz-fx-data-experiments', 'monitoring', 'logs']
+    - ['moz-fx-data-experiments', 'monitoring', 'experimenter_experiments_v1']
   depends_on:
     - task_id: jetstream_run
       dag_name: jetstream

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
@@ -3,15 +3,18 @@
 """Build the daily jetstream analysis success/failure rollup.
 
 For a given date, records one row per (experiment, analysis_period,
-analysis_basis, segment, metric) cell that jetstream either successfully
-computed (found in that experiment's `statistics_*` tables) or failed to
-compute (found in `monitoring.jetstream_analysis_errors`).
+window_index, analysis_basis, segment, metric) cell that jetstream either
+successfully computed (found in that experiment's `statistics_*` tables) or
+failed to compute (found in `monitoring.jetstream_analysis_errors`).
+`window_index` is NULL when the failure that produced a row didn't identify
+a specific window (most failures don't -- see FAILED_SQL).
 
 Table names under `mozanalysis` don't map 1:1 to a single experiment slug
 without normalizing hyphens to underscores (`jetstream.bq_normalize_name`),
 so the set of tables written on the target date is discovered via
 `INFORMATION_SCHEMA.TABLE_STORAGE_TIMELINE`, matched back to experiment
-slugs via each table's description, and unioned into a single query
+slugs primarily via each table's description (falling back to matching the
+table name when a description is missing), and unioned into a single query
 alongside the failure view.
 
 `--date` is jetstream's analysis date, matching its own `--date={{ds}}`
@@ -37,6 +40,11 @@ PROJECT = "moz-fx-data-experiments"
 DATASET = "monitoring"
 STATS_DATASET = "mozanalysis"
 DESTINATION_TABLE = "analysis_results_monitoring_v1"
+
+# Safety margin below BigQuery's 1,000-referenced-resource-per-query cap,
+# which build_final_sql approaches as one reference per discovered table.
+# Peak observed over 180 days is 314.
+MAX_DISCOVERED_TABLES = 900
 
 # error_category values (see jetstream_analysis_errors/view.sql) that represent
 # an actual failure to compute something. Excludes `skipped` (the experiment
@@ -74,31 +82,61 @@ table_experiments AS (
   FROM `{PROJECT}.{STATS_DATASET}.INFORMATION_SCHEMA.TABLE_OPTIONS`
   WHERE option_name = 'description'
 ),
+-- A table can lack a description (https://github.com/mozilla/jetstream/issues/3299);
+-- those fall back to matching the table name against known experiment
+-- slugs, resolving ambiguous prefix matches (e.g. "foo" vs "foo-bar") by
+-- preferring the longest slug.
+normalized_experiments AS (
+  SELECT
+    normandy_slug AS experiment,
+    REGEXP_REPLACE(normandy_slug, r'[^a-zA-Z0-9_]', '_') AS normalized_slug
+  FROM `{PROJECT}.{DATASET}.experimenter_experiments_v1`
+  WHERE normandy_slug IS NOT NULL
+),
+fallback_matched AS (
+  SELECT
+    d.table_name,
+    e.experiment,
+    ROW_NUMBER() OVER (
+      PARTITION BY d.table_name ORDER BY LENGTH(e.normalized_slug) DESC
+    ) AS rn
+  FROM discovered_tables d
+  LEFT JOIN table_experiments t USING (table_name)
+  JOIN normalized_experiments e
+    ON STARTS_WITH(d.table_name, CONCAT('statistics_', e.normalized_slug, '_'))
+  WHERE t.experiment IS NULL
+),
+table_experiments_resolved AS (
+  SELECT table_name, experiment, 'description' AS matched_via FROM table_experiments
+  UNION ALL
+  SELECT table_name, experiment, 'fallback' AS matched_via FROM fallback_matched WHERE rn = 1
+),
 with_period_window AS (
   SELECT
     d.table_name,
     e.experiment,
+    e.matched_via,
     SUBSTR(
       d.table_name,
       LENGTH('statistics_' || REGEXP_REPLACE(e.experiment, r'[^a-zA-Z0-9_]', '_') || '_') + 1
     ) AS period_window
   FROM discovered_tables d
-  JOIN table_experiments e USING (table_name)
+  JOIN table_experiments_resolved e USING (table_name)
 )
 SELECT
   table_name,
   experiment,
-  REGEXP_REPLACE(period_window, r'_\\d+$', '') AS analysis_period
+  matched_via,
+  REGEXP_REPLACE(period_window, r'_\\d+$', '') AS analysis_period,
+  CAST(REGEXP_EXTRACT(period_window, r'_(\\d+)$') AS INT64) AS window_index
 FROM with_period_window
 WHERE REGEXP_CONTAINS(period_window, r'^({"|".join(PERIOD_TOKENS)})_\\d+$')
 """
 
 # `analysis_period` on failed rows is sometimes bare (e.g. "day", logged by
-# statistics.py) and sometimes period+window-count (e.g. "day_7", logged by
-# calculate_metrics/calculate_metric_for_ds). Window granularity isn't tracked
-# by this rollup (see plan-error-categorization.md), so both are normalized to
-# the bare period token to match the analysis_period produced by table
-# discovery above.
+# statistics.py -- window_index is then NULL, same "unattributed" semantics
+# as a NULL analysis_basis/segment/metric) and sometimes period+window-count
+# (e.g. "day_7", logged by calculate_metrics/calculate_metric_for_ds).
 FAILED_SQL = f"""
 SELECT
   * EXCEPT (timestamp)
@@ -107,6 +145,7 @@ FROM (
     @date AS analysis_date,
     experiment,
     REGEXP_REPLACE(analysis_period, r'_\\d+$', '') AS analysis_period,
+    CAST(REGEXP_EXTRACT(analysis_period, r'_(\\d+)$') AS INT64) AS window_index,
     analysis_basis,
     segment,
     metric,
@@ -120,20 +159,29 @@ FROM (
     AND error_category IN ({", ".join(f"'{c}'" for c in FAILURE_CATEGORIES)})
 )
 QUALIFY ROW_NUMBER() OVER (
-  PARTITION BY experiment, analysis_period, analysis_basis, segment, metric
+  PARTITION BY experiment, analysis_period, window_index, analysis_basis, segment, metric
   ORDER BY timestamp DESC
 ) = 1
 """
 
 
 def _escape(value: str) -> str:
-    return value.replace("'", "''")
+    return value.replace("\\", "\\\\").replace("'", "''")
 
 
 CURRENTLY_EXISTS_SQL = f"""
 SELECT table_name
 FROM `{PROJECT}.{STATS_DATASET}.INFORMATION_SCHEMA.TABLES`
 WHERE table_type = 'BASE TABLE' AND table_name IN UNNEST(@table_names)
+"""
+
+RAW_DISCOVERED_COUNT_SQL = f"""
+SELECT COUNT(DISTINCT table_name) AS n
+FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.TABLE_STORAGE_TIMELINE`
+WHERE table_schema = '{STATS_DATASET}'
+  AND table_type = 'BASE TABLE'
+  AND STARTS_WITH(table_name, 'statistics_')
+  AND DATE(creation_time) = DATE_ADD(@date, INTERVAL 1 DAY)
 """
 
 
@@ -155,6 +203,29 @@ def discover_statistics_tables(
         ),
     )
     tables = list(job.result())
+
+    raw_count = next(
+        iter(
+            client.query(
+                RAW_DISCOVERED_COUNT_SQL,
+                job_config=bigquery.QueryJobConfig(
+                    query_parameters=[
+                        bigquery.ScalarQueryParameter("date", "DATE", date)
+                    ]
+                ),
+            ).result()
+        )
+    ).n
+    unmatched = raw_count - len({row.table_name for row in tables})
+    if unmatched:
+        print(
+            f"{unmatched} table(s) matched neither a description nor a "
+            "known experiment slug -- excluded from this day's rollup"
+        )
+    fallback_count = sum(1 for row in tables if row.matched_via == "fallback")
+    if fallback_count:
+        print(f"{fallback_count} table(s) had no description; matched by name instead")
+
     if not tables:
         return tables
 
@@ -178,12 +249,17 @@ def discover_statistics_tables(
 
 
 def build_succeeded_sql(tables: list[bigquery.Row]) -> str:
-    """Build a UNION ALL over the discovered tables' (metric, segment, basis)."""
+    """Build a UNION ALL over the discovered tables' (metric, segment, basis).
+
+    Each table is exactly one (experiment, analysis_period, window_index) --
+    that's what its name encodes -- so window_index is a literal per subquery.
+    """
     if not tables:
         return """
         SELECT
           CAST(NULL AS STRING) AS experiment,
           CAST(NULL AS STRING) AS analysis_period,
+          CAST(NULL AS INT64) AS window_index,
           CAST(NULL AS STRING) AS analysis_basis,
           CAST(NULL AS STRING) AS segment,
           CAST(NULL AS STRING) AS metric
@@ -193,6 +269,7 @@ def build_succeeded_sql(tables: list[bigquery.Row]) -> str:
         SELECT DISTINCT
           '{_escape(row.experiment)}' AS experiment,
           '{_escape(row.analysis_period)}' AS analysis_period,
+          {row.window_index if row.window_index is not None else "CAST(NULL AS INT64)"} AS window_index,
           analysis_basis,
           segment,
           metric
@@ -217,6 +294,7 @@ def build_final_sql(tables: list[bigquery.Row]) -> str:
         @date AS analysis_date,
         experiment,
         analysis_period,
+        window_index,
         analysis_basis,
         segment,
         metric,
@@ -229,12 +307,13 @@ def build_final_sql(tables: list[bigquery.Row]) -> str:
       COALESCE(f.analysis_date, s.analysis_date) AS analysis_date,
       COALESCE(f.experiment, s.experiment) AS experiment,
       COALESCE(f.analysis_period, s.analysis_period) AS analysis_period,
+      COALESCE(f.window_index, s.window_index) AS window_index,
       COALESCE(f.analysis_basis, s.analysis_basis) AS analysis_basis,
       COALESCE(f.segment, s.segment) AS segment,
       COALESCE(f.metric, s.metric) AS metric,
       CASE
-        WHEN f.error_category IS NOT NULL AND s.status IS NOT NULL THEN 'partial'
-        WHEN f.error_category IS NOT NULL THEN 'failed'
+        WHEN f.status IS NOT NULL AND s.status IS NOT NULL THEN 'partial'
+        WHEN f.status IS NOT NULL THEN 'failed'
         ELSE 'succeeded'
       END AS status,
       f.error_category
@@ -242,6 +321,7 @@ def build_final_sql(tables: list[bigquery.Row]) -> str:
     FULL OUTER JOIN succeeded s
       ON f.experiment = s.experiment
       AND f.analysis_period = s.analysis_period
+      AND f.window_index = s.window_index
       AND f.analysis_basis = s.analysis_basis
       AND f.segment = s.segment
       AND f.metric = s.metric
@@ -263,6 +343,13 @@ def main():
 
     tables = discover_statistics_tables(client, args.date)
     print(f"Discovered {len(tables)} statistics tables")
+    if len(tables) > MAX_DISCOVERED_TABLES:
+        raise RuntimeError(
+            f"{len(tables)} tables discovered for {args.date}, over the "
+            f"{MAX_DISCOVERED_TABLES} safety margin -- query would likely hit "
+            "BigQuery's 1,000-referenced-resource limit. Suggested fix: "
+            "implement chunking."
+        )
     final_sql = build_final_sql(tables)
 
     destination = (

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
@@ -34,6 +34,7 @@ common case) aren't affected.
 """
 
 from argparse import ArgumentParser
+from datetime import UTC, date, datetime
 
 from google.cloud import bigquery
 
@@ -46,6 +47,12 @@ DESTINATION_TABLE = "analysis_results_monitoring_v1"
 # which build_final_sql approaches as one reference per discovered table.
 # Peak observed over 180 days is 314.
 MAX_DISCOVERED_TABLES = 900
+
+# JOBS_BY_PROJECT retains 180 days. Past that, table discovery silently
+# returns zero rows -- indistinguishable from "nothing was written that
+# day" -- so a backfill this old must fail loudly instead of reporting a
+# false 0% success rate.
+MAX_BACKFILL_AGE_DAYS = 180
 
 # error_category values (see jetstream_analysis_errors/view.sql) that represent
 # an actual failure to compute something. Excludes `skipped` (the experiment
@@ -64,6 +71,15 @@ PERIOD_TOKENS = [
     "day",
 ]
 
+# jetstream's DAG runs daily at 04:00 UTC, so a run for `@date` produces
+# rows between 04:00 UTC on `@date + 1` and 04:00 UTC on `@date + 2`.
+WINDOW_START = (
+    "TIMESTAMP_ADD(TIMESTAMP(DATE_ADD(@date, INTERVAL 1 DAY)), INTERVAL 4 HOUR)"
+)
+WINDOW_END = (
+    "TIMESTAMP_ADD(TIMESTAMP(DATE_ADD(@date, INTERVAL 2 DAY)), INTERVAL 4 HOUR)"
+)
+
 DISCOVER_TABLES_SQL = f"""
 WITH discovered_tables AS (
   -- JOBS_BY_PROJECT is a historical, per-job record (180-day retention),
@@ -77,11 +93,14 @@ WITH discovered_tables AS (
     AND STARTS_WITH(destination_table.table_id, 'statistics_')
     AND job_type = 'LOAD'
     AND error_result IS NULL
-    AND DATE(creation_time) = DATE_ADD(@date, INTERVAL 1 DAY)
+    AND creation_time >= {WINDOW_START}
+    AND creation_time < {WINDOW_END}
 ),
 -- jetstream sets each table's description to the exact experiment slug.
 table_experiments AS (
-  SELECT table_name, TRIM(option_value, '"') AS experiment
+  -- NULLIF: an empty (not missing) description must also fall through to
+  -- the name-matching fallback below, not resolve to experiment = ''.
+  SELECT table_name, NULLIF(TRIM(option_value, '"'), '') AS experiment
   FROM `{PROJECT}.{STATS_DATASET}.INFORMATION_SCHEMA.TABLE_OPTIONS`
   WHERE option_name = 'description'
 ),
@@ -138,7 +157,7 @@ WHERE REGEXP_CONTAINS(period_window, r'^({"|".join(PERIOD_TOKENS)})_\\d+$')
 
 # `analysis_period` on failed rows is sometimes bare (e.g. "day", logged by
 # statistics.py -- window_index is then NULL, same "unattributed" semantics
-# as a NULL analysis_basis/segment/metric) and sometimes period+window-count
+# as a NULL analysis_basis/segment/metric) and sometimes period+window-index
 # (e.g. "day_7", logged by calculate_metrics/calculate_metric_for_ds).
 FAILED_SQL = f"""
 SELECT
@@ -158,7 +177,8 @@ FROM (
   FROM `{PROJECT}.{DATASET}.jetstream_analysis_errors`
   WHERE source = 'jetstream'
     AND experiment IS NOT NULL
-    AND DATE(timestamp) = DATE_ADD(@date, INTERVAL 1 DAY)
+    AND timestamp >= {WINDOW_START}
+    AND timestamp < {WINDOW_END}
     AND error_category IN ({", ".join(f"'{c}'" for c in FAILURE_CATEGORIES)})
 )
 QUALIFY ROW_NUMBER() OVER (
@@ -186,7 +206,8 @@ WHERE destination_table.project_id = '{PROJECT}'
   AND STARTS_WITH(destination_table.table_id, 'statistics_')
   AND job_type = 'LOAD'
   AND error_result IS NULL
-  AND DATE(creation_time) = DATE_ADD(@date, INTERVAL 1 DAY)
+  AND creation_time >= {WINDOW_START}
+  AND creation_time < {WINDOW_END}
 """
 
 
@@ -343,6 +364,15 @@ def main():
         "--date", dest="date", required=True, help="Date to roll up (YYYY-MM-DD)"
     )
     args = parser.parse_args()
+
+    today = datetime.now(tz=UTC).date()
+    backfill_age_days = (today - date.fromisoformat(args.date)).days
+    if backfill_age_days > MAX_BACKFILL_AGE_DAYS:
+        raise RuntimeError(
+            f"--date={args.date} is {backfill_age_days} days old, past "
+            f"JOBS_BY_PROJECT's {MAX_BACKFILL_AGE_DAYS}-day retention -- "
+            "table discovery would silently find nothing."
+        )
 
     client = bigquery.Client(project=args.project)
 

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
@@ -12,9 +12,9 @@ a specific window (most failures don't -- see FAILED_SQL).
 Table names under `mozanalysis` don't map 1:1 to a single experiment slug
 without normalizing hyphens to underscores (`jetstream.bq_normalize_name`),
 so the set of tables written on the target date is discovered via
-`INFORMATION_SCHEMA.TABLE_STORAGE_TIMELINE`, matched back to experiment
-slugs primarily via each table's description (falling back to matching the
-table name when a description is missing), and unioned into a single query
+`INFORMATION_SCHEMA.JOBS_BY_PROJECT`, matched back to experiment slugs
+primarily via each table's description (falling back to matching the table
+name when a description is missing), and unioned into a single query
 alongside the failure view.
 
 `--date` is jetstream's analysis date, matching its own `--date={{ds}}`
@@ -24,12 +24,13 @@ timestamps are filtered on `date + 1`, not `date` itself.
 Scheduled to run after telemetry-airflow's `jetstream` DAG completes for the
 same analysis date (see metadata.yaml's `depends_on`).
 
-Backfillable, with one caveat: TABLE_STORAGE_TIMELINE is historical, so
-discovery is accurate for old dates, but if a table's content changes after
-the target date (e.g. an in-progress "overall" table, or an explicit rerun),
-a backfill reads today's content, not the target date's -- BigQuery has no
-way to recover the old rows past its few-day time-travel window. Tables
-written once and never touched again (the common case) aren't affected.
+Backfillable, with one caveat: JOBS_BY_PROJECT is historical, so discovery
+is accurate for old dates, but if a table's content changes after the
+target date (e.g. a `rerun`/`rerun-config-changed` recomputing an
+experiment's history), a backfill reads today's content, not the target
+date's -- BigQuery has no way to recover the old rows past its few-day
+time-travel window. Tables written once and never touched again (the
+common case) aren't affected.
 """
 
 from argparse import ArgumentParser
@@ -65,15 +66,17 @@ PERIOD_TOKENS = [
 
 DISCOVER_TABLES_SQL = f"""
 WITH discovered_tables AS (
-  -- `timestamp` is a periodic snapshot time (matches nearly every table
-  -- ever created); `creation_time` only changes when jetstream rewrites a
-  -- table, so it's the right filter for "written on this date". Views
-  -- aren't excluded automatically here, unlike TABLE_STORAGE.
-  SELECT DISTINCT table_name
-  FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.TABLE_STORAGE_TIMELINE`
-  WHERE table_schema = '{STATS_DATASET}'
-    AND table_type = 'BASE TABLE'
-    AND STARTS_WITH(table_name, 'statistics_')
+  -- JOBS_BY_PROJECT is a historical, per-job record (180-day retention),
+  -- unlike INFORMATION_SCHEMA.TABLES/TABLE_STORAGE, which only ever reflect
+  -- a table's current state -- querying those for a past date silently
+  -- misses any table rewritten since.
+  SELECT DISTINCT destination_table.table_id AS table_name
+  FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
+  WHERE destination_table.project_id = '{PROJECT}'
+    AND destination_table.dataset_id = '{STATS_DATASET}'
+    AND STARTS_WITH(destination_table.table_id, 'statistics_')
+    AND job_type = 'LOAD'
+    AND error_result IS NULL
     AND DATE(creation_time) = DATE_ADD(@date, INTERVAL 1 DAY)
 ),
 -- jetstream sets each table's description to the exact experiment slug.
@@ -176,11 +179,13 @@ WHERE table_type = 'BASE TABLE' AND table_name IN UNNEST(@table_names)
 """
 
 RAW_DISCOVERED_COUNT_SQL = f"""
-SELECT COUNT(DISTINCT table_name) AS n
-FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.TABLE_STORAGE_TIMELINE`
-WHERE table_schema = '{STATS_DATASET}'
-  AND table_type = 'BASE TABLE'
-  AND STARTS_WITH(table_name, 'statistics_')
+SELECT COUNT(DISTINCT destination_table.table_id) AS n
+FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.JOBS_BY_PROJECT`
+WHERE destination_table.project_id = '{PROJECT}'
+  AND destination_table.dataset_id = '{STATS_DATASET}'
+  AND STARTS_WITH(destination_table.table_id, 'statistics_')
+  AND job_type = 'LOAD'
+  AND error_result IS NULL
   AND DATE(creation_time) = DATE_ADD(@date, INTERVAL 1 DAY)
 """
 
@@ -190,8 +195,8 @@ def discover_statistics_tables(
 ) -> list[bigquery.Row]:
     """Find the statistics_* tables written on `date`, matched to experiments.
 
-    A table found via TABLE_STORAGE_TIMELINE may have since been deleted (it's
-    a historical record, so this is expected for old-enough backfills, not a
+    A table found via JOBS_BY_PROJECT may have since been deleted (it's a
+    historical record, so this is expected for old-enough backfills, not a
     bug), which would otherwise crash the whole day's query with "Not found"
     when build_succeeded_sql tries to read it. Tables missing today are
     dropped and reported rather than silently skipped.

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
@@ -7,11 +7,12 @@ analysis_basis, segment, metric) cell that jetstream either successfully
 computed (found in that experiment's `statistics_*` tables) or failed to
 compute (found in `monitoring.jetstream_analysis_errors`).
 
-Table names under `mozanalysis` don't encode analysis_basis, and don't map
-1:1 to a single experiment slug without normalizing hyphens to underscores
-(`jetstream.bq_normalize_name`), so the set of tables written on the target
-date is discovered via `INFORMATION_SCHEMA.TABLE_STORAGE`, matched back to
-experiment slugs, and unioned into a single query alongside the failure view.
+Table names under `mozanalysis` don't map 1:1 to a single experiment slug
+without normalizing hyphens to underscores (`jetstream.bq_normalize_name`),
+so the set of tables written on the target date is discovered via
+`INFORMATION_SCHEMA.TABLE_STORAGE_TIMELINE`, matched back to experiment
+slugs via each table's description, and unioned into a single query
+alongside the failure view.
 
 `--date` is jetstream's analysis date, matching its own `--date={{ds}}`
 argument. Both it and this task actually run a day later, so table/log
@@ -20,10 +21,12 @@ timestamps are filtered on `date + 1`, not `date` itself.
 Scheduled to run after telemetry-airflow's `jetstream` DAG completes for the
 same analysis date (see metadata.yaml's `depends_on`).
 
-Not safely backfillable: `TABLE_STORAGE` only records a table's most recent
-write, so re-running this for an older date after a later rerun will find
-none of that date's tables and silently overwrite its partition. Only run
-for the current date.
+Backfillable, with one caveat: TABLE_STORAGE_TIMELINE is historical, so
+discovery is accurate for old dates, but if a table's content changes after
+the target date (e.g. an in-progress "overall" table, or an explicit rerun),
+a backfill reads today's content, not the target date's -- BigQuery has no
+way to recover the old rows past its few-day time-travel window. Tables
+written once and never touched again (the common case) aren't affected.
 """
 
 from argparse import ArgumentParser
@@ -54,16 +57,16 @@ PERIOD_TOKENS = [
 
 DISCOVER_TABLES_SQL = f"""
 WITH discovered_tables AS (
-  -- TABLE_STORAGE can lag behind deletions, so cross-check against TABLES.
-  SELECT ts.table_name
-  FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.TABLE_STORAGE` ts
-  JOIN `{PROJECT}.{STATS_DATASET}.INFORMATION_SCHEMA.TABLES` t
-    ON ts.table_name = t.table_name
-  WHERE ts.table_schema = '{STATS_DATASET}'
-    AND ts.table_type = 'BASE TABLE'
-    AND t.table_type = 'BASE TABLE'
-    AND STARTS_WITH(ts.table_name, 'statistics_')
-    AND DATE(ts.storage_last_modified_time) = DATE_ADD(@date, INTERVAL 1 DAY)
+  -- `timestamp` is a periodic snapshot time (matches nearly every table
+  -- ever created); `creation_time` only changes when jetstream rewrites a
+  -- table, so it's the right filter for "written on this date". Views
+  -- aren't excluded automatically here, unlike TABLE_STORAGE.
+  SELECT DISTINCT table_name
+  FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.TABLE_STORAGE_TIMELINE`
+  WHERE table_schema = '{STATS_DATASET}'
+    AND table_type = 'BASE TABLE'
+    AND STARTS_WITH(table_name, 'statistics_')
+    AND DATE(creation_time) = DATE_ADD(@date, INTERVAL 1 DAY)
 ),
 -- jetstream sets each table's description to the exact experiment slug.
 table_experiments AS (
@@ -127,17 +130,51 @@ def _escape(value: str) -> str:
     return value.replace("'", "''")
 
 
+CURRENTLY_EXISTS_SQL = f"""
+SELECT table_name
+FROM `{PROJECT}.{STATS_DATASET}.INFORMATION_SCHEMA.TABLES`
+WHERE table_type = 'BASE TABLE' AND table_name IN UNNEST(@table_names)
+"""
+
+
 def discover_statistics_tables(
     client: bigquery.Client, date: str
 ) -> list[bigquery.Row]:
-    """Find the statistics_* tables written on `date`, matched to experiments."""
+    """Find the statistics_* tables written on `date`, matched to experiments.
+
+    A table found via TABLE_STORAGE_TIMELINE may have since been deleted (it's
+    a historical record, so this is expected for old-enough backfills, not a
+    bug), which would otherwise crash the whole day's query with "Not found"
+    when build_succeeded_sql tries to read it. Tables missing today are
+    dropped and reported rather than silently skipped.
+    """
     job = client.query(
         DISCOVER_TABLES_SQL,
         job_config=bigquery.QueryJobConfig(
             query_parameters=[bigquery.ScalarQueryParameter("date", "DATE", date)]
         ),
     )
-    return list(job.result())
+    tables = list(job.result())
+    if not tables:
+        return tables
+
+    exists_job = client.query(
+        CURRENTLY_EXISTS_SQL,
+        job_config=bigquery.QueryJobConfig(
+            query_parameters=[
+                bigquery.ArrayQueryParameter(
+                    "table_names", "STRING", [row.table_name for row in tables]
+                )
+            ]
+        ),
+    )
+    existing_names = {row.table_name for row in exists_job.result()}
+
+    missing = [row.table_name for row in tables if row.table_name not in existing_names]
+    if missing:
+        print(f"Skipping {len(missing)} table(s) no longer present: {missing}")
+
+    return [row for row in tables if row.table_name in existing_names]
 
 
 def build_succeeded_sql(tables: list[bigquery.Row]) -> str:

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
@@ -13,9 +13,17 @@ Table names under `mozanalysis` don't encode analysis_basis, and don't map
 date is discovered via `INFORMATION_SCHEMA.TABLE_STORAGE`, matched back to
 experiment slugs, and unioned into a single query alongside the failure view.
 
+`--date` is jetstream's analysis date, matching its own `--date={{ds}}`
+argument. Both it and this task actually run a day later, so table/log
+timestamps are filtered on `date + 1`, not `date` itself.
+
 Scheduled to run after telemetry-airflow's `jetstream` DAG completes for the
-same date (see metadata.yaml's `depends_on`), since jetstream's own run isn't
-part of this DAG and this rollup would otherwise see a partial day.
+same analysis date (see metadata.yaml's `depends_on`).
+
+Not safely backfillable: `TABLE_STORAGE` only records a table's most recent
+write, so re-running this for an older date after a later rerun will find
+none of that date's tables and silently overwrite its partition. Only run
+for the current date.
 """
 
 from argparse import ArgumentParser
@@ -34,8 +42,7 @@ DESTINATION_TABLE = "analysis_results_monitoring_v1"
 # (ambiguous by construction -- see that view's comments).
 FAILURE_CATEGORIES = ["resources", "data", "configuration", "jetstream_failure"]
 
-# ordered longest-first so a shorter token (e.g. "day") can't partially shadow
-# a longer one (e.g. "days28") in the REGEXP_CONTAINS alternation below.
+# valid jetstream.AnalysisPeriod values, as they appear in table name suffixes.
 PERIOD_TOKENS = [
     "preenrollment_week",
     "preenrollment_days28",
@@ -56,43 +63,31 @@ WITH discovered_tables AS (
     AND ts.table_type = 'BASE TABLE'
     AND t.table_type = 'BASE TABLE'
     AND STARTS_WITH(ts.table_name, 'statistics_')
-    AND DATE(ts.storage_last_modified_time) = @date
+    AND DATE(ts.storage_last_modified_time) = DATE_ADD(@date, INTERVAL 1 DAY)
 ),
-normalized_experiments AS (
-  SELECT
-    normandy_slug AS experiment,
-    REGEXP_REPLACE(normandy_slug, r'[^a-zA-Z0-9_]', '_') AS normalized_slug
-  FROM `{PROJECT}.{DATASET}.experimenter_experiments_v1`
-  WHERE normandy_slug IS NOT NULL
+-- jetstream sets each table's description to the exact experiment slug.
+table_experiments AS (
+  SELECT table_name, TRIM(option_value, '"') AS experiment
+  FROM `{PROJECT}.{STATS_DATASET}.INFORMATION_SCHEMA.TABLE_OPTIONS`
+  WHERE option_name = 'description'
 ),
-matched AS (
-  -- a table can prefix-match more than one experiment's normalized slug
-  -- (e.g. "ios-worldcup-feature" is a prefix of "ios-worldcup-feature-1512");
-  -- resolved by preferring the longest (most specific) slug below.
+with_period_window AS (
   SELECT
-    t.table_name,
+    d.table_name,
     e.experiment,
-    e.normalized_slug,
-    SUBSTR(t.table_name, LENGTH('statistics_' || e.normalized_slug || '_') + 1) AS period_window
-  FROM discovered_tables t
-  JOIN normalized_experiments e
-    ON STARTS_WITH(t.table_name, CONCAT('statistics_', e.normalized_slug, '_'))
-),
-ranked AS (
-  SELECT
-    table_name,
-    experiment,
-    period_window,
-    ROW_NUMBER() OVER (PARTITION BY table_name ORDER BY LENGTH(normalized_slug) DESC) AS rn
-  FROM matched
+    SUBSTR(
+      d.table_name,
+      LENGTH('statistics_' || REGEXP_REPLACE(e.experiment, r'[^a-zA-Z0-9_]', '_') || '_') + 1
+    ) AS period_window
+  FROM discovered_tables d
+  JOIN table_experiments e USING (table_name)
 )
 SELECT
   table_name,
   experiment,
   REGEXP_REPLACE(period_window, r'_\\d+$', '') AS analysis_period
-FROM ranked
-WHERE rn = 1
-  AND REGEXP_CONTAINS(period_window, r'^({"|".join(PERIOD_TOKENS)})_\\d+$')
+FROM with_period_window
+WHERE REGEXP_CONTAINS(period_window, r'^({"|".join(PERIOD_TOKENS)})_\\d+$')
 """
 
 # `analysis_period` on failed rows is sometimes bare (e.g. "day", logged by
@@ -103,19 +98,24 @@ WHERE rn = 1
 # discovery above.
 FAILED_SQL = f"""
 SELECT
-  @date AS analysis_date,
-  experiment,
-  REGEXP_REPLACE(analysis_period, r'_\\d+$', '') AS analysis_period,
-  analysis_basis,
-  segment,
-  metric,
-  'failed' AS status,
-  error_category
-FROM `{PROJECT}.{DATASET}.jetstream_analysis_errors`
-WHERE source = 'jetstream'
-  AND experiment IS NOT NULL
-  AND DATE(timestamp) = @date
-  AND error_category IN ({", ".join(f"'{c}'" for c in FAILURE_CATEGORIES)})
+  * EXCEPT (timestamp)
+FROM (
+  SELECT
+    @date AS analysis_date,
+    experiment,
+    REGEXP_REPLACE(analysis_period, r'_\\d+$', '') AS analysis_period,
+    analysis_basis,
+    segment,
+    metric,
+    'failed' AS status,
+    error_category,
+    timestamp
+  FROM `{PROJECT}.{DATASET}.jetstream_analysis_errors`
+  WHERE source = 'jetstream'
+    AND experiment IS NOT NULL
+    AND DATE(timestamp) = DATE_ADD(@date, INTERVAL 1 DAY)
+    AND error_category IN ({", ".join(f"'{c}'" for c in FAILURE_CATEGORIES)})
+)
 QUALIFY ROW_NUMBER() OVER (
   PARTITION BY experiment, analysis_period, analysis_basis, segment, metric
   ORDER BY timestamp DESC
@@ -164,7 +164,12 @@ def build_succeeded_sql(tables: list[bigquery.Row]) -> str:
 
 
 def build_final_sql(tables: list[bigquery.Row]) -> str:
-    """Combine failed and succeeded into one table."""
+    """Combine failed and succeeded into one table, one row per cell.
+
+    A cell can have both a failure logged and output in the statistics table
+    (e.g. one statistic/reference-branch errored, another didn't) -- such
+    cells are labelled "partial" rather than picking a side.
+    """
     succeeded_sql = build_succeeded_sql(tables)
     return f"""
     WITH failed AS (
@@ -178,15 +183,31 @@ def build_final_sql(tables: list[bigquery.Row]) -> str:
         analysis_basis,
         segment,
         metric,
-        'succeeded' AS status,
-        CAST(NULL AS STRING) AS error_category
+        'succeeded' AS status
       FROM (
         {succeeded_sql}
       )
     )
-    SELECT * FROM failed
-    UNION ALL
-    SELECT * FROM succeeded
+    SELECT
+      COALESCE(f.analysis_date, s.analysis_date) AS analysis_date,
+      COALESCE(f.experiment, s.experiment) AS experiment,
+      COALESCE(f.analysis_period, s.analysis_period) AS analysis_period,
+      COALESCE(f.analysis_basis, s.analysis_basis) AS analysis_basis,
+      COALESCE(f.segment, s.segment) AS segment,
+      COALESCE(f.metric, s.metric) AS metric,
+      CASE
+        WHEN f.error_category IS NOT NULL AND s.status IS NOT NULL THEN 'partial'
+        WHEN f.error_category IS NOT NULL THEN 'failed'
+        ELSE 'succeeded'
+      END AS status,
+      f.error_category
+    FROM failed f
+    FULL OUTER JOIN succeeded s
+      ON f.experiment = s.experiment
+      AND f.analysis_period = s.analysis_period
+      AND f.analysis_basis = s.analysis_basis
+      AND f.segment = s.segment
+      AND f.metric = s.metric
     """
 
 
@@ -204,6 +225,7 @@ def main():
     client = bigquery.Client(project=args.project)
 
     tables = discover_statistics_tables(client, args.date)
+    print(f"Discovered {len(tables)} statistics tables")
     final_sql = build_final_sql(tables)
 
     destination = (
@@ -221,10 +243,8 @@ def main():
             ),
         ),
     )
-    job.result()
-    print(
-        f"Wrote {job.output_rows} rows to {destination} ({len(tables)} tables discovered)"
-    )
+    result = job.result()
+    print(f"Wrote {result.total_rows} rows to {destination}")
 
 
 if __name__ == "__main__":

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+
+"""Build the daily jetstream analysis success/failure rollup.
+
+For a given date, records one row per (experiment, analysis_period,
+analysis_basis, segment, metric) cell that jetstream either successfully
+computed (found in that experiment's `statistics_*` tables) or failed to
+compute (found in `monitoring.jetstream_analysis_errors`).
+
+Table names under `mozanalysis` don't encode analysis_basis, and don't map
+1:1 to a single experiment slug without normalizing hyphens to underscores
+(`jetstream.bq_normalize_name`), so the set of tables written on the target
+date is discovered via `INFORMATION_SCHEMA.TABLE_STORAGE`, matched back to
+experiment slugs, and unioned into a single query alongside the failure view.
+
+Scheduled to run after telemetry-airflow's `jetstream` DAG completes for the
+same date (see metadata.yaml's `depends_on`), since jetstream's own run isn't
+part of this DAG and this rollup would otherwise see a partial day.
+"""
+
+from argparse import ArgumentParser
+
+from google.cloud import bigquery
+
+PROJECT = "moz-fx-data-experiments"
+DATASET = "monitoring"
+STATS_DATASET = "mozanalysis"
+DESTINATION_TABLE = "analysis_results_monitoring_v1"
+
+# error_category values (see jetstream_analysis_errors/view.sql) that represent
+# an actual failure to compute something. Excludes `skipped` (the experiment
+# was intentionally not analyzed), `valid_degradation`/`library_warning`
+# (benign; the metric was still computed), `informational`, and `uncategorized`
+# (ambiguous by construction -- see that view's comments).
+FAILURE_CATEGORIES = ["resources", "data", "configuration", "jetstream_failure"]
+
+# ordered longest-first so a shorter token (e.g. "day") can't partially shadow
+# a longer one (e.g. "days28") in the REGEXP_CONTAINS alternation below.
+PERIOD_TOKENS = [
+    "preenrollment_week",
+    "preenrollment_days28",
+    "days28",
+    "week",
+    "overall",
+    "day",
+]
+
+DISCOVER_TABLES_SQL = f"""
+WITH discovered_tables AS (
+  -- TABLE_STORAGE can lag behind deletions, so cross-check against TABLES.
+  SELECT ts.table_name
+  FROM `{PROJECT}.region-us.INFORMATION_SCHEMA.TABLE_STORAGE` ts
+  JOIN `{PROJECT}.{STATS_DATASET}.INFORMATION_SCHEMA.TABLES` t
+    ON ts.table_name = t.table_name
+  WHERE ts.table_schema = '{STATS_DATASET}'
+    AND ts.table_type = 'BASE TABLE'
+    AND t.table_type = 'BASE TABLE'
+    AND STARTS_WITH(ts.table_name, 'statistics_')
+    AND DATE(ts.storage_last_modified_time) = @date
+),
+normalized_experiments AS (
+  SELECT
+    normandy_slug AS experiment,
+    REGEXP_REPLACE(normandy_slug, r'[^a-zA-Z0-9_]', '_') AS normalized_slug
+  FROM `{PROJECT}.{DATASET}.experimenter_experiments_v1`
+  WHERE normandy_slug IS NOT NULL
+),
+matched AS (
+  -- a table can prefix-match more than one experiment's normalized slug
+  -- (e.g. "ios-worldcup-feature" is a prefix of "ios-worldcup-feature-1512");
+  -- resolved by preferring the longest (most specific) slug below.
+  SELECT
+    t.table_name,
+    e.experiment,
+    e.normalized_slug,
+    SUBSTR(t.table_name, LENGTH('statistics_' || e.normalized_slug || '_') + 1) AS period_window
+  FROM discovered_tables t
+  JOIN normalized_experiments e
+    ON STARTS_WITH(t.table_name, CONCAT('statistics_', e.normalized_slug, '_'))
+),
+ranked AS (
+  SELECT
+    table_name,
+    experiment,
+    period_window,
+    ROW_NUMBER() OVER (PARTITION BY table_name ORDER BY LENGTH(normalized_slug) DESC) AS rn
+  FROM matched
+)
+SELECT
+  table_name,
+  experiment,
+  REGEXP_REPLACE(period_window, r'_\\d+$', '') AS analysis_period
+FROM ranked
+WHERE rn = 1
+  AND REGEXP_CONTAINS(period_window, r'^({"|".join(PERIOD_TOKENS)})_\\d+$')
+"""
+
+# `analysis_period` on failed rows is sometimes bare (e.g. "day", logged by
+# statistics.py) and sometimes period+window-count (e.g. "day_7", logged by
+# calculate_metrics/calculate_metric_for_ds). Window granularity isn't tracked
+# by this rollup (see plan-error-categorization.md), so both are normalized to
+# the bare period token to match the analysis_period produced by table
+# discovery above.
+FAILED_SQL = f"""
+SELECT
+  @date AS analysis_date,
+  experiment,
+  REGEXP_REPLACE(analysis_period, r'_\\d+$', '') AS analysis_period,
+  analysis_basis,
+  segment,
+  metric,
+  'failed' AS status,
+  error_category
+FROM `{PROJECT}.{DATASET}.jetstream_analysis_errors`
+WHERE source = 'jetstream'
+  AND experiment IS NOT NULL
+  AND DATE(timestamp) = @date
+  AND error_category IN ({", ".join(f"'{c}'" for c in FAILURE_CATEGORIES)})
+QUALIFY ROW_NUMBER() OVER (
+  PARTITION BY experiment, analysis_period, analysis_basis, segment, metric
+  ORDER BY timestamp DESC
+) = 1
+"""
+
+
+def _escape(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def discover_statistics_tables(
+    client: bigquery.Client, date: str
+) -> list[bigquery.Row]:
+    """Find the statistics_* tables written on `date`, matched to experiments."""
+    job = client.query(
+        DISCOVER_TABLES_SQL,
+        job_config=bigquery.QueryJobConfig(
+            query_parameters=[bigquery.ScalarQueryParameter("date", "DATE", date)]
+        ),
+    )
+    return list(job.result())
+
+
+def build_succeeded_sql(tables: list[bigquery.Row]) -> str:
+    """Build a UNION ALL over the discovered tables' (metric, segment, basis)."""
+    if not tables:
+        return """
+        SELECT
+          CAST(NULL AS STRING) AS experiment,
+          CAST(NULL AS STRING) AS analysis_period,
+          CAST(NULL AS STRING) AS analysis_basis,
+          CAST(NULL AS STRING) AS segment,
+          CAST(NULL AS STRING) AS metric
+        WHERE FALSE
+        """
+    return "\nUNION ALL\n".join(f"""
+        SELECT DISTINCT
+          '{_escape(row.experiment)}' AS experiment,
+          '{_escape(row.analysis_period)}' AS analysis_period,
+          analysis_basis,
+          segment,
+          metric
+        FROM `{PROJECT}.{STATS_DATASET}.{row.table_name}`
+        """ for row in tables)
+
+
+def build_final_sql(tables: list[bigquery.Row]) -> str:
+    """Combine failed and succeeded into one table."""
+    succeeded_sql = build_succeeded_sql(tables)
+    return f"""
+    WITH failed AS (
+      {FAILED_SQL}
+    ),
+    succeeded AS (
+      SELECT
+        @date AS analysis_date,
+        experiment,
+        analysis_period,
+        analysis_basis,
+        segment,
+        metric,
+        'succeeded' AS status,
+        CAST(NULL AS STRING) AS error_category
+      FROM (
+        {succeeded_sql}
+      )
+    )
+    SELECT * FROM failed
+    UNION ALL
+    SELECT * FROM succeeded
+    """
+
+
+def main():
+    """Run."""
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--project", default=PROJECT)
+    parser.add_argument("--destination_dataset", default=DATASET)
+    parser.add_argument("--destination_table", default=DESTINATION_TABLE)
+    parser.add_argument(
+        "--date", dest="date", required=True, help="Date to roll up (YYYY-MM-DD)"
+    )
+    args = parser.parse_args()
+
+    client = bigquery.Client(project=args.project)
+
+    tables = discover_statistics_tables(client, args.date)
+    final_sql = build_final_sql(tables)
+
+    destination = (
+        f"{args.project}.{args.destination_dataset}.{args.destination_table}"
+        f"${args.date.replace('-', '')}"
+    )
+    job = client.query(
+        final_sql,
+        job_config=bigquery.QueryJobConfig(
+            query_parameters=[bigquery.ScalarQueryParameter("date", "DATE", args.date)],
+            destination=destination,
+            write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+            time_partitioning=bigquery.TimePartitioning(
+                type_=bigquery.TimePartitioningType.DAY, field="analysis_date"
+            ),
+        ),
+    )
+    job.result()
+    print(
+        f"Wrote {job.output_rows} rows to {destination} ({len(tables)} tables discovered)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/schema.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/schema.yaml
@@ -14,6 +14,13 @@ fields:
     Analysis period (e.g., day, week, days28, overall). NULL on a failed row
     means the failure occurred before a specific period could be attributed
     (e.g., an unexpected task failure at the top of the analysis run).
+- name: window_index
+  type: INT64
+  mode: NULLABLE
+  description: |-
+    Which window of analysis_period this row is for (e.g., 7 for the
+    "day_7" table). NULL on most failed rows, since most failure log sites
+    don't record which window they were computing.
 - name: analysis_basis
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/schema.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/schema.yaml
@@ -1,0 +1,53 @@
+fields:
+- name: analysis_date
+  type: DATE
+  mode: NULLABLE
+  description: The date this row's success/failure status was observed.
+- name: experiment
+  type: STRING
+  mode: NULLABLE
+  description: Nimbus experiment (or rollout) normandy_slug.
+- name: analysis_period
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Analysis period (e.g., day, week, days28, overall). NULL on a failed row
+    means the failure occurred before a specific period could be attributed
+    (e.g., an unexpected task failure at the top of the analysis run).
+- name: analysis_basis
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Analysis basis (e.g., enrollments, exposures). NULL on a failed row means
+    the failure affected all bases for that experiment/period.
+- name: segment
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Segment slug, or "all" for the full population. NULL on a failed row
+    means the failure affected every segment for that experiment/metric
+    (e.g., a failure computing the underlying per-datasource metric table,
+    which all segments are derived from).
+- name: metric
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Metric slug. NULL on a failed row means the log record that produced it
+    doesn't identify a specific metric -- either because the failure occurred
+    before metric computation started (e.g., publishing the results view,
+    fetching the experiment definition), or because it was a single combined
+    query covering every metric for that period/basis at once (the legacy,
+    non-discrete metrics path). The affected metric set may still be knowable
+    from jetstream's own configuration, just not from the data sources this
+    rollup reads; these rows are excluded from metric-level success-rate
+    denominators for that experiment/period/basis as a result.
+- name: status
+  type: STRING
+  mode: NULLABLE
+  description: One of "succeeded" or "failed".
+- name: error_category
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Set only when status = "failed": resources, data, configuration, or
+    jetstream_failure. See jetstream_analysis_errors/view.sql for definitions.

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/schema.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/schema.yaml
@@ -2,7 +2,7 @@ fields:
 - name: analysis_date
   type: DATE
   mode: NULLABLE
-  description: The date this row's success/failure status was observed.
+  description: The jetstream analysis date this row's status pertains to.
 - name: experiment
   type: STRING
   mode: NULLABLE
@@ -44,10 +44,14 @@ fields:
 - name: status
   type: STRING
   mode: NULLABLE
-  description: One of "succeeded" or "failed".
+  description: |-
+    One of "succeeded", "failed", or "partial" (both a logged failure and
+    output in the statistics table exist for this cell, e.g. one statistic
+    or reference branch errored while another for the same metric didn't).
 - name: error_category
   type: STRING
   mode: NULLABLE
   description: |-
-    Set only when status = "failed": resources, data, configuration, or
-    jetstream_failure. See jetstream_analysis_errors/view.sql for definitions.
+    Set when status = "failed" or "partial": resources, data, configuration,
+    or jetstream_failure. See jetstream_analysis_errors/view.sql for
+    definitions.


### PR DESCRIPTION
## Description

Adds a new table that combines experiment analysis failures with successfully-computed metrics.

Some notes on current implementation:
- task is dependent on `jetstream_run`, so it should have the latest info (barring reruns triggered in other ways: like metric-hub, config changed)
- there is the possibility of a `partial` status in cases where some portion of a metric succeeded and another portion failed, or where the logs do not distinguish with enough granularity for us to say for sure
- we can plan to add metric config info to the `experimenter_experiments_v1` table so that we can track the full set of expected metrics based on the config instead of the joined set of success+failure

## Related Tickets & Documents


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
