### PR TITLE
chore: add example report read permissions

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozcloud/service_uptime/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud/service_uptime/metadata.yaml
@@ -7,3 +7,7 @@ description: |-
   error rate threshold.
 owners:
 - wstuckey@mozilla.com
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:cloud-engineering/quick-example-scheduled-report

--- a/sql/moz-fx-data-shared-prod/mozcloud_derived/service_uptime_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud_derived/service_uptime_v1/metadata.yaml
@@ -7,6 +7,10 @@ description: |-
   error rate threshold.
 owners:
 - wstuckey@mozilla.com
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:cloud-engineering/quick-example-scheduled-report
 labels:
   incremental: true
   schedule: daily


### PR DESCRIPTION
## Description

Third PR in a series that will be used as reference for the skills / docs for managing quick site report updates via scheduled github actions.

Note that this PR is querying non-sensitive (`workgroup:mozilla-confidential/data-viewers`) data even though Quick can access that data directly. This workflow is meant to demonstrate how one might generate a mozilla-confidential report from workgroup-confidential data without actually using any sensitive data.

## Related Tickets & Documents
* MZCLD-3461
* https://github.com/mozilla/webservices-infra/pull/12161
* https://github.com/mozilla/global-platform-admin/pull/7125

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
