### PR TITLE
feat(sumo_metrics_derived): add KB revision throughput and backlog metrics

### DIFF
--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/checks.sql
@@ -1,0 +1,119 @@
+-- Drift warnings for the `customer_experience.normalize_product` mapping this
+-- table depends on. `normalize_product` returns 'Other' for unknown inputs
+-- rather than leaking the raw value, so a new `products` path added in Kitsune
+-- changes the product breakdown silently. It also decides which revisions are
+-- excluded altogether, because the Thunderbird filter keys off the UDF's output,
+-- so a new Thunderbird-tagged path drops revisions from the table with no signal.
+--
+-- Both checks mirror kb_revisions_base_v1's own population filters so they only
+-- flag paths that actually reach the table. The table is a full recompute with no
+-- date partition, so these scan the whole window rather than @submission_date.
+
+#warn
+-- 1. Novel `products` paths that fall through to 'Other'.
+WITH scoped_documents AS (
+  SELECT
+    d.products,
+    COUNT(*) AS revisions
+  FROM
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_revision` AS r
+  JOIN
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_document_plus` AS d
+    ON d.id = r.document_id
+  WHERE
+    d.parent_id IS NULL
+    AND d.locale = 'en-US'
+    AND d.is_template = FALSE
+    AND d.is_archived = FALSE
+    AND LOWER(d.title) NOT LIKE 'forum response%'
+    AND DATE(r.created) >= DATE '2024-01-01'
+  GROUP BY
+    d.products
+),
+unmapped AS (
+  SELECT
+    products,
+    revisions
+  FROM
+    scoped_documents
+  WHERE
+    COALESCE(mozfun.customer_experience.normalize_product(products, 'GA4'), 'Other') = 'Other'
+    -- Paths the UDF intentionally maps to 'Other'. These mirror the GA4 'Other'
+    -- branches in normalize_product. Keep them in sync when the UDF changes.
+    -- Articles with no product assigned are a known state, not drift.
+    AND products IS NOT NULL
+    AND products != ''
+    AND products NOT IN ('/privacy-and-security/')
+    AND NOT REGEXP_CONTAINS(LOWER(products), r'/contributor/')
+    AND NOT REGEXP_CONTAINS(
+      LOWER(products),
+      r'/(firefox-os|firefox-lite|firefox-reality|firefox-lockwise|firefox-fire-tv|firefox-amazon-devices|firefox-send|firefox-windows-8-touch|firefox-preview|webmaker|pocket|hubs|screenshot-go|open-badges)/'
+    )
+)
+SELECT
+  IF(
+    (SELECT COUNT(*) FROM unmapped) > 0,
+    ERROR(
+      FORMAT(
+        'Unmapped KB product paths — add to normalize_product UDF: %t',
+        ARRAY(SELECT AS STRUCT products, revisions FROM unmapped ORDER BY revisions DESC)
+      )
+    ),
+    NULL
+  );
+
+#warn
+-- 2. Novel `products` paths excluded by the Thunderbird filter. The enumerated
+-- list is the set as of 2026-08-14. A new entry means revisions are being
+-- dropped from this table that were not dropped before, which is worth a look
+-- because multi-product paths carrying a Thunderbird tag are not necessarily
+-- Thunderbird-team content.
+WITH thunderbird_excluded AS (
+  SELECT
+    d.products,
+    COUNT(*) AS revisions
+  FROM
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_revision` AS r
+  JOIN
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_document_plus` AS d
+    ON d.id = r.document_id
+  WHERE
+    d.parent_id IS NULL
+    AND d.locale = 'en-US'
+    AND d.is_template = FALSE
+    AND d.is_archived = FALSE
+    AND LOWER(d.title) NOT LIKE 'forum response%'
+    AND DATE(r.created) >= DATE '2024-01-01'
+    AND mozfun.customer_experience.normalize_product(d.products, 'GA4') IN (
+      'Thunderbird',
+      'Thunderbird Android'
+    )
+    AND d.products NOT IN (
+      '/thunderbird/',
+      '/thunderbird-android/',
+      '/thunderbird/thunderbird-android/',
+      '/firefox/ios/mobile/thunderbird/',
+      '/firefox/thunderbird/'
+    )
+  GROUP BY
+    d.products
+)
+SELECT
+  IF(
+    (SELECT COUNT(*) FROM thunderbird_excluded) > 0,
+    ERROR(
+      FORMAT(
+        'New Thunderbird-mapped KB product paths are being excluded from kb_revisions_base_v1 — confirm they are Thunderbird-team content: %t',
+        ARRAY(
+          SELECT AS STRUCT
+            products,
+            revisions
+          FROM
+            thunderbird_excluded
+          ORDER BY
+            revisions DESC
+        )
+      )
+    ),
+    NULL
+  );

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/metadata.yaml
@@ -23,7 +23,7 @@ description: |
     mozfun.customer_experience.normalize_product(products, 'GA4')
 
   Recomputed in full each run over a fixed window starting 2024-01-01 (no date
-  partition). `latest_document_revision_date` and the `reviewed_date` backfill
+  partition). `latest_document_reviewed_date` and the `reviewed_date` backfill
   are computed over in-window revisions only.
 
   Used by:

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/metadata.yaml
@@ -22,9 +22,15 @@ description: |
   - product: canonical CX product name from
     mozfun.customer_experience.normalize_product(products, 'GA4')
 
-  Recomputed in full each run over a fixed window starting 2024-01-01 (no date
-  partition). `latest_document_reviewed_date` and the `reviewed_date` backfill
-  are computed over in-window revisions only.
+  Recomputed in full each run over a fixed window starting 2024-01-01 and ending
+  on the last complete day (no date partition). `latest_document_reviewed_date`
+  and the `reviewed_date` backfill are computed over in-window revisions only.
+
+  Known limitation: the window filters on creation date only, so a revision
+  created before 2024-01-01 but reviewed after it is absent entirely (21 to
+  date). Review counts derived from this table therefore understate throughput
+  for dates early in the window, decaying as the window ages — do not compare
+  early-2024 review throughput against later dates as if equivalent.
 
   Used by:
   - kb_revisions_daily_v1

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/metadata.yaml
@@ -1,0 +1,43 @@
+friendly_name: KB Revisions Base
+description: |
+  SUMO knowledge base revisions at the revision grain, with review dates,
+  reviewer population, and canonical product. Single source of truth for KB
+  revision throughput and review-backlog reporting.
+
+  Grain: Revision
+
+  Scope (en-US, original non-translated articles):
+  - parent_id IS NULL, locale = 'en-US', is_template = FALSE, is_archived = FALSE
+  - "forum response%" revisions excluded
+  - Thunderbird / Thunderbird Android excluded (maintained by another team)
+
+  Key columns:
+  - created_date: date the revision was created
+  - reviewed_date: date the revision was reviewed. Backfilled in two cases —
+    an approved revision with a NULL `reviewed` timestamp inherits its creation
+    date, and an unreviewed revision older than the document's most recent
+    review inherits that review date (all prior revisions are assumed covered
+    by the same review pass). NULL means still awaiting review.
+  - reviewer_type: 'Staff', 'Community', or 'Unreviewed' (no reviewer attached)
+  - product: canonical CX product name from
+    mozfun.customer_experience.normalize_product(products, 'GA4')
+
+  Recomputed in full each run over a fixed window starting 2024-01-01 (no date
+  partition). `latest_document_revision_date` and the `reviewed_date` backfill
+  are computed over in-window revisions only.
+
+  Used by:
+  - kb_revisions_daily_v1
+  - sumo_kb_revision_kpis
+owners:
+  - phlee@mozilla.com
+  - mozilla/customer_experience
+labels:
+  incremental: false
+  application: sumo
+  type: base_metrics
+  schedule: daily
+scheduling:
+  dag_name: bqetl_sumo_metrics
+  date_partition_parameter: null
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
@@ -16,6 +16,16 @@
 -- backfill below are computed over the in-window revisions only, so a document
 -- whose only reviewed revision predates the window start keeps a NULL
 -- reviewed_date.
+--
+-- The window filters on `r.created` only, so a revision created before the window
+-- start but reviewed inside it is absent entirely (21 revisions to date). That
+-- means `reviewed_revisions` / `approved_revisions` in kb_revisions_daily_v1
+-- understate review throughput for dates early in the window -- an early-2024
+-- pass that cleared a 2023 backlog is invisible -- and the understatement decays
+-- as the window ages. Do not compare early-2024 throughput against later dates as
+-- if they were on the same footing. Filtering on `created OR reviewed` would fix
+-- this, but it would also diverge from the upstream SUMO dashboard that this
+-- table was validated against, so it is left as a known limitation.
 WITH window_start AS (
   SELECT
     DATE '2024-01-01' AS start_date
@@ -86,9 +96,12 @@ revisions AS (
     AND d.is_template = FALSE
     AND d.is_archived = FALSE
     AND LOWER(d.title) NOT LIKE 'forum response%'
+    -- Ends at yesterday, not CURRENT_DATE: today is still accumulating, and a
+    -- partial day would bias the last point of every moving average downstream.
+    -- Matches kb_quality_metrics_article_v1's last-complete-day convention.
     AND DATE(r.created)
     BETWEEN (SELECT start_date FROM window_start)
-    AND CURRENT_DATE
+    AND DATE(CURRENT_DATE - INTERVAL 1 DAY)
 ),
 -- Assume every revision preceding a reviewed revision was covered by that same
 -- review pass, so an unreviewed revision older than the document's most recent

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
@@ -3,7 +3,8 @@
 -- KB revision throughput and review-backlog reporting.
 --
 -- Revision/article filters (matching the KB releases dashboard query):
---   d.parent_id IS NULL        -- original, non-translated articles
+--   d.parent_id IS NULL        -- original, non-translated articles (the join to
+--                              -- d is inner, so this cannot mean "no document")
 --   d.locale = 'en-US'         -- en-US articles only
 --   d.is_template = FALSE      -- exclude template revisions
 --   d.is_archived = FALSE      -- exclude archived articles
@@ -11,7 +12,7 @@
 --   product NOT IN ('Thunderbird', 'Thunderbird Android') -- handled by another team
 --
 -- Full recompute each run over a fixed window starting 2024-01-01 (no date
--- partition parameter). `latest_document_revision_date` and the `reviewed_date`
+-- partition parameter). `latest_document_reviewed_date` and the `reviewed_date`
 -- backfill below are computed over the in-window revisions only, so a document
 -- whose only reviewed revision predates the window start keeps a NULL
 -- reviewed_date.
@@ -67,9 +68,12 @@ revisions AS (
     END AS reviewer_type
   FROM
     `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_revision` r
-  LEFT JOIN
+  -- Inner join: a revision whose document is missing is out of scope, and the
+  -- d.* filters below would discard it anyway.
+  JOIN
     `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_document_plus` d
     ON d.id = r.document_id
+  -- These stay LEFT: reviewer_id is NULL for revisions awaiting review.
   LEFT JOIN
     `moz-fx-data-shared-prod.sumo_syndicate.kitsune_auth_user` creator
     ON r.creator_id = creator.id
@@ -92,7 +96,7 @@ revisions AS (
 with_document_latest AS (
   SELECT
     * EXCEPT (raw_reviewed_date),
-    MAX(raw_reviewed_date) OVER (PARTITION BY document_id) AS latest_document_revision_date,
+    MAX(raw_reviewed_date) OVER (PARTITION BY document_id) AS latest_document_reviewed_date,
     IF(
       raw_reviewed_date IS NULL
       AND created_date <= MAX(raw_reviewed_date) OVER (PARTITION BY document_id),
@@ -113,7 +117,7 @@ SELECT
   product,
   created_date,
   reviewed_date,
-  latest_document_revision_date,
+  latest_document_reviewed_date,
   is_approved,
   creator_id,
   creator_username,

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
@@ -1,0 +1,121 @@
+-- SUMO knowledge base revisions at the revision grain: when each revision was
+-- created, when it was reviewed, and who reviewed it. Single source of truth for
+-- KB revision throughput and review-backlog reporting.
+--
+-- Revision/article filters (matching the KB releases dashboard query):
+--   d.parent_id IS NULL        -- original, non-translated articles
+--   d.locale = 'en-US'         -- en-US articles only
+--   d.is_template = FALSE      -- exclude template revisions
+--   d.is_archived = FALSE      -- exclude archived articles
+--   title NOT LIKE 'forum response%' -- exclude forum-response revisions
+--   product NOT IN ('Thunderbird', 'Thunderbird Android') -- handled by another team
+--
+-- Full recompute each run over a fixed window starting 2024-01-01 (no date
+-- partition parameter). `latest_document_revision_date` and the `reviewed_date`
+-- backfill below are computed over the in-window revisions only, so a document
+-- whose only reviewed revision predates the window start keeps a NULL
+-- reviewed_date.
+WITH window_start AS (
+  SELECT
+    DATE '2024-01-01' AS start_date
+),
+revisions AS (
+  SELECT
+    r.id AS revision_id,
+    r.document_id,
+    d.title,
+    d.slug,
+    'https://support.mozilla.org/en-US/kb/' || d.slug AS article_link,
+    'https://support.mozilla.org/en-US/kb/' || d.slug || '/revision/' || r.id AS revision_link,
+    d.locale,
+    -- Canonical CX product name. `products` is a slash-delimited path, so the
+    -- 'GA4' rule set (which matches path-style inputs) applies. Unmapped paths
+    -- return 'Other'; a NULL path (the article has no product assigned) returns
+    -- NULL, which is folded into 'Other' so those revisions survive the
+    -- Thunderbird filter below and still count toward review throughput.
+    COALESCE(mozfun.customer_experience.normalize_product(d.products, 'GA4'), 'Other') AS product,
+    DATE(r.created) AS created_date,
+    -- Cover revisions that are approved but have a NULL `reviewed`; that happens
+    -- when several preceding revisions are ignored in one review pass.
+    IF(
+      r.reviewed IS NULL
+      AND r.is_approved,
+      DATE(r.created),
+      DATE(r.reviewed)
+    ) AS raw_reviewed_date,
+    r.is_approved,
+    r.creator_id,
+    creator.username AS creator_username,
+    creator.is_staff AS creator_is_staff,
+    r.reviewer_id,
+    reviewer.username AS reviewer_username,
+    -- Review population the revision belongs to. NULL `is_staff` means no
+    -- reviewer is attached yet, i.e. the revision is still awaiting review.
+    CASE
+      WHEN reviewer.is_staff
+        THEN 'Staff'
+      WHEN NOT reviewer.is_staff
+        THEN 'Community'
+      ELSE 'Unreviewed'
+    END AS reviewer_type
+  FROM
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_revision` r
+  LEFT JOIN
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_document_plus` d
+    ON d.id = r.document_id
+  LEFT JOIN
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_auth_user` creator
+    ON r.creator_id = creator.id
+  LEFT JOIN
+    `moz-fx-data-shared-prod.sumo_syndicate.kitsune_auth_user` reviewer
+    ON r.reviewer_id = reviewer.id
+  WHERE
+    d.parent_id IS NULL
+    AND d.locale = 'en-US'
+    AND d.is_template = FALSE
+    AND d.is_archived = FALSE
+    AND LOWER(d.title) NOT LIKE 'forum response%'
+    AND DATE(r.created)
+    BETWEEN (SELECT start_date FROM window_start)
+    AND CURRENT_DATE
+),
+-- Assume every revision preceding a reviewed revision was covered by that same
+-- review pass, so an unreviewed revision older than the document's most recent
+-- review inherits that review date.
+with_document_latest AS (
+  SELECT
+    * EXCEPT (raw_reviewed_date),
+    MAX(raw_reviewed_date) OVER (PARTITION BY document_id) AS latest_document_revision_date,
+    IF(
+      raw_reviewed_date IS NULL
+      AND created_date <= MAX(raw_reviewed_date) OVER (PARTITION BY document_id),
+      MAX(raw_reviewed_date) OVER (PARTITION BY document_id),
+      raw_reviewed_date
+    ) AS reviewed_date
+  FROM
+    revisions
+)
+SELECT
+  revision_id,
+  document_id,
+  title,
+  slug,
+  article_link,
+  revision_link,
+  locale,
+  product,
+  created_date,
+  reviewed_date,
+  latest_document_revision_date,
+  is_approved,
+  creator_id,
+  creator_username,
+  creator_is_staff,
+  reviewer_id,
+  reviewer_username,
+  reviewer_type
+FROM
+  with_document_latest
+-- Thunderbird KB articles are maintained by a separate team.
+WHERE
+  product NOT IN ('Thunderbird', 'Thunderbird Android')

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/query.sql
@@ -49,14 +49,21 @@ revisions AS (
     creator.is_staff AS creator_is_staff,
     r.reviewer_id,
     reviewer.username AS reviewer_username,
-    -- Review population the revision belongs to. NULL `is_staff` means no
-    -- reviewer is attached yet, i.e. the revision is still awaiting review.
+    -- Review population the revision belongs to. Keyed off `reviewer_id`, which
+    -- is what actually carries "nobody has picked this up yet" — a NULL
+    -- `reviewer.is_staff` cannot distinguish that from a reviewer_id whose user
+    -- row is missing from `kitsune_auth_user` (deleted or unsynced account), so
+    -- that case gets its own 'Unknown' label rather than being folded into
+    -- 'Unreviewed'. No revision is in that state today; the branch exists so a
+    -- future join miss shows up instead of inflating the unreviewed bucket.
     CASE
+      WHEN r.reviewer_id IS NULL
+        THEN 'Unreviewed'
       WHEN reviewer.is_staff
         THEN 'Staff'
       WHEN NOT reviewer.is_staff
         THEN 'Community'
-      ELSE 'Unreviewed'
+      ELSE 'Unknown'
     END AS reviewer_type
   FROM
     `moz-fx-data-shared-prod.sumo_syndicate.kitsune_wiki_revision` r

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/schema.yaml
@@ -47,7 +47,7 @@ fields:
     revision with a NULL `reviewed` timestamp inherits its creation date, and an
     unreviewed revision older than the document's most recent in-window review
     inherits that review date. NULL means the revision is still awaiting review.
-- name: latest_document_revision_date
+- name: latest_document_reviewed_date
   type: DATE
   mode: NULLABLE
   description: >

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/schema.yaml
@@ -1,0 +1,85 @@
+fields:
+- name: revision_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Kitsune revision ID (primary key of this table)
+- name: document_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Kitsune wiki document ID the revision belongs to
+- name: title
+  type: STRING
+  mode: NULLABLE
+  description: Title of the KB article
+- name: slug
+  type: STRING
+  mode: NULLABLE
+  description: URL slug of the KB article
+- name: article_link
+  type: STRING
+  mode: NULLABLE
+  description: Public support.mozilla.org URL of the KB article
+- name: revision_link
+  type: STRING
+  mode: NULLABLE
+  description: support.mozilla.org URL of this specific revision
+- name: locale
+  type: STRING
+  mode: NULLABLE
+  description: Article locale; always 'en-US' in this table
+- name: product
+  type: STRING
+  mode: NULLABLE
+  description: >
+    Canonical CX product name derived from the article's `products` path via
+    mozfun.customer_experience.normalize_product(products, 'GA4'). Unmapped
+    paths and articles with no product assigned are reported as 'Other';
+    Thunderbird products are excluded. Never NULL.
+- name: created_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the revision was created (UTC)
+- name: reviewed_date
+  type: DATE
+  mode: NULLABLE
+  description: >
+    Date the revision was reviewed (UTC). Backfilled in two cases: an approved
+    revision with a NULL `reviewed` timestamp inherits its creation date, and an
+    unreviewed revision older than the document's most recent in-window review
+    inherits that review date. NULL means the revision is still awaiting review.
+- name: latest_document_revision_date
+  type: DATE
+  mode: NULLABLE
+  description: >
+    Most recent review date across all in-window revisions of the same document.
+    NULL if no revision of the document has been reviewed within the window.
+- name: is_approved
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the revision was approved by its reviewer
+- name: creator_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Kitsune user ID of the revision author
+- name: creator_username
+  type: STRING
+  mode: NULLABLE
+  description: SUMO username of the revision author
+- name: creator_is_staff
+  type: BOOLEAN
+  mode: NULLABLE
+  description: Whether the revision author is Mozilla staff
+- name: reviewer_id
+  type: INTEGER
+  mode: NULLABLE
+  description: Kitsune user ID of the reviewer; NULL if not yet reviewed
+- name: reviewer_username
+  type: STRING
+  mode: NULLABLE
+  description: SUMO username of the reviewer; NULL if not yet reviewed
+- name: reviewer_type
+  type: STRING
+  mode: NULLABLE
+  description: >
+    Review population: 'Staff' or 'Community' based on the reviewer's staff flag,
+    or 'Unreviewed' when no reviewer is attached to the revision.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/schema.yaml
@@ -82,4 +82,9 @@ fields:
   mode: NULLABLE
   description: >
     Review population: 'Staff' or 'Community' based on the reviewer's staff flag,
-    or 'Unreviewed' when no reviewer is attached to the revision.
+    'Unreviewed' when `reviewer_id` is NULL, or 'Unknown' when `reviewer_id` is
+    set but has no matching row in `kitsune_auth_user` (no revision is in that
+    state today). Note that 'Unreviewed' does NOT imply `reviewed_date IS NULL`:
+    most 'Unreviewed' revisions inherit a `reviewed_date` from the document's
+    latest review, so they count toward `reviewed_revisions` downstream. See the
+    note on `reviewed_date`.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/metadata.yaml
@@ -12,8 +12,14 @@ description: |
   - reviewed_revisions: revisions reviewed that day
   - approved_revisions: revisions reviewed and approved that day
   - net_revisions: created minus reviewed — a daily *flow*, not a backlog level.
-    The cumulative backlog is exposed as `running_backlog` in
-    sumo_kb_revision_kpis.
+    The cumulative version is `backlog_change_since_window_start` in
+    sumo_kb_revision_kpis, which is a backlog trend rather than a pending count.
+
+  Note: the reviewer_type split of created_revisions (and net_revisions) means
+  "eventually reviewed by" and is retroactively mutable, because reviewer_type is
+  a property of the review and this table is fully recomputed each run. Day-level
+  totals are stable; the split of the recent tail is not. See the column
+  descriptions in schema.yaml.
 
   Recomputed in full each run (no date partition). Article scope and product
   mapping are defined upstream in kb_revisions_base_v1.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/metadata.yaml
@@ -1,0 +1,34 @@
+friendly_name: KB Revisions — Daily
+description: |
+  Day-level SUMO knowledge base revision activity, aggregated from
+  kb_revisions_base_v1.
+
+  Grain: Day x Product x Reviewer type
+
+  Built on a dense date spine (every day x every observed product x reviewer
+  type), so days with no activity report 0 rather than being absent.
+
+  - created_revisions: revisions created that day
+  - reviewed_revisions: revisions reviewed that day
+  - approved_revisions: revisions reviewed and approved that day
+  - net_revisions: created minus reviewed — a daily *flow*, not a backlog level.
+    The cumulative backlog is exposed as `running_backlog` in
+    sumo_kb_revision_kpis.
+
+  Recomputed in full each run (no date partition). Article scope and product
+  mapping are defined upstream in kb_revisions_base_v1.
+
+  Used by:
+  - sumo_kb_revision_kpis
+owners:
+  - phlee@mozilla.com
+  - mozilla/customer_experience
+labels:
+  incremental: false
+  application: sumo
+  type: aggregate
+  schedule: daily
+scheduling:
+  dag_name: bqetl_sumo_metrics
+  date_partition_parameter: null
+  depends_on_past: false

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/query.sql
@@ -40,8 +40,15 @@ dates AS (
   FROM
     (SELECT DISTINCT product, reviewer_type FROM base) AS columns
   CROSS JOIN
+    -- Ends at yesterday to match the upstream window: today is still
+    -- accumulating, and a partial final day would bias the last point of every
+    -- moving average in sumo_kb_revision_kpis.
     UNNEST(
-      GENERATE_DATE_ARRAY((SELECT start_date FROM window_start), CURRENT_DATE, INTERVAL 1 DAY)
+      GENERATE_DATE_ARRAY(
+        (SELECT start_date FROM window_start),
+        DATE(CURRENT_DATE - INTERVAL 1 DAY),
+        INTERVAL 1 DAY
+      )
     ) AS event_date
 ),
 created_revisions AS (

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/query.sql
@@ -6,8 +6,19 @@
 -- type), so days with no activity report 0 rather than being absent.
 --
 -- `net_revisions` is a daily *flow* (created minus reviewed), not a backlog
--- level; the cumulative backlog is exposed as `running_backlog` in
--- sumo_kb_revision_kpis.
+-- level; the cumulative version is `backlog_change_since_window_start` in
+-- sumo_kb_revision_kpis, which is also a trend rather than a pending count.
+--
+-- Caveat on the reviewer_type split of `created_revisions` (and therefore of
+-- `net_revisions`): reviewer_type is a property of the *review*, not of anything
+-- known when the revision was created, and this table is recomputed in full each
+-- run. So a revision created today counts under 'Unreviewed' for its creation
+-- date now, and moves to 'Staff'/'Community' for that same date once it is
+-- reviewed. The recent tail is materially affected — about 27% of revisions
+-- created in the last 30 days are still unreviewed — so a created-by-reviewer-
+-- type series redistributes between buckets on every run. Day-level totals are
+-- stable; only the split is retroactively mutable. Kept at this grain because
+-- the upstream SUMO dashboard groups creations the same way.
 WITH base AS (
   SELECT
     *

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/query.sql
@@ -1,0 +1,108 @@
+-- Day x product x reviewer-type counts of KB revisions created, reviewed, and
+-- approved, plus the daily net review flow. Derived from the revision-grain table
+-- so the population and product filters stay in one place.
+--
+-- Built on a dense date spine (every day x every observed product x reviewer
+-- type), so days with no activity report 0 rather than being absent.
+--
+-- `net_revisions` is a daily *flow* (created minus reviewed), not a backlog
+-- level; the cumulative backlog is exposed as `running_backlog` in
+-- sumo_kb_revision_kpis.
+WITH base AS (
+  SELECT
+    *
+  FROM
+    `moz-fx-data-shared-prod.sumo_metrics_derived.kb_revisions_base_v1`
+),
+window_start AS (
+  SELECT
+    MIN(created_date) AS start_date
+  FROM
+    base
+),
+-- Every combination of date, product, and reviewer type.
+dates AS (
+  SELECT
+    product,
+    reviewer_type,
+    event_date
+  FROM
+    (SELECT DISTINCT product, reviewer_type FROM base) AS columns
+  CROSS JOIN
+    UNNEST(
+      GENERATE_DATE_ARRAY((SELECT start_date FROM window_start), CURRENT_DATE, INTERVAL 1 DAY)
+    ) AS event_date
+),
+created_revisions AS (
+  SELECT
+    created_date,
+    product,
+    reviewer_type,
+    COUNT(*) AS created_revisions
+  FROM
+    base
+  GROUP BY
+    created_date,
+    product,
+    reviewer_type
+),
+reviewed_revisions AS (
+  SELECT
+    reviewed_date,
+    product,
+    reviewer_type,
+    COUNT(*) AS reviewed_revisions
+  FROM
+    base
+  WHERE
+    reviewed_date IS NOT NULL
+  GROUP BY
+    reviewed_date,
+    product,
+    reviewer_type
+),
+approved_revisions AS (
+  SELECT
+    reviewed_date AS approved_date,
+    product,
+    reviewer_type,
+    COUNT(*) AS approved_revisions
+  FROM
+    base
+  WHERE
+    reviewed_date IS NOT NULL
+    AND is_approved
+  GROUP BY
+    approved_date,
+    product,
+    reviewer_type
+)
+SELECT
+  dates.event_date,
+  DATE_TRUNC(dates.event_date, WEEK) AS week,
+  dates.product,
+  dates.reviewer_type,
+  COALESCE(created_revisions.created_revisions, 0) AS created_revisions,
+  COALESCE(reviewed_revisions.reviewed_revisions, 0) AS reviewed_revisions,
+  COALESCE(approved_revisions.approved_revisions, 0) AS approved_revisions,
+  COALESCE(created_revisions.created_revisions, 0) - COALESCE(
+    reviewed_revisions.reviewed_revisions,
+    0
+  ) AS net_revisions
+FROM
+  dates
+LEFT JOIN
+  created_revisions
+  ON dates.event_date = created_revisions.created_date
+  AND dates.product = created_revisions.product
+  AND dates.reviewer_type = created_revisions.reviewer_type
+LEFT JOIN
+  reviewed_revisions
+  ON dates.event_date = reviewed_revisions.reviewed_date
+  AND dates.product = reviewed_revisions.product
+  AND dates.reviewer_type = reviewed_revisions.reviewer_type
+LEFT JOIN
+  approved_revisions
+  ON dates.event_date = approved_revisions.approved_date
+  AND dates.product = approved_revisions.product
+  AND dates.reviewer_type = approved_revisions.reviewer_type

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/schema.yaml
@@ -14,7 +14,9 @@ fields:
 - name: reviewer_type
   type: STRING
   mode: NULLABLE
-  description: "Review population: 'Staff', 'Community', or 'Unreviewed'"
+  description: >
+    Review population: 'Staff', 'Community', 'Unreviewed' (no reviewer attached),
+    or 'Unknown' (reviewer not resolvable). See kb_revisions_base_v1.reviewer_type.
 - name: created_revisions
   type: INTEGER
   mode: NULLABLE
@@ -22,7 +24,14 @@ fields:
 - name: reviewed_revisions
   type: INTEGER
   mode: NULLABLE
-  description: Revisions reviewed on `event_date` for this product and reviewer type
+  description: >
+    Revisions reviewed on `event_date` for this product and reviewer type.
+    Non-zero for reviewer_type = 'Unreviewed': a revision with no reviewer
+    attached still inherits a `reviewed_date` from the document's latest review
+    upstream, and is counted here under 'Unreviewed'. Day-level totals are
+    correct, but do not read the 'Unreviewed' row as "reviewed by nobody" — sum
+    across reviewer types, or use sumo_kb_revision_kpis, when you want review
+    throughput.
 - name: approved_revisions
   type: INTEGER
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/schema.yaml
@@ -1,0 +1,38 @@
+fields:
+- name: event_date
+  type: DATE
+  mode: NULLABLE
+  description: Activity date (UTC)
+- name: week
+  type: DATE
+  mode: NULLABLE
+  description: Start of the week (Sunday) containing `event_date`
+- name: product
+  type: STRING
+  mode: NULLABLE
+  description: Canonical CX product name; see kb_revisions_base_v1.product
+- name: reviewer_type
+  type: STRING
+  mode: NULLABLE
+  description: "Review population: 'Staff', 'Community', or 'Unreviewed'"
+- name: created_revisions
+  type: INTEGER
+  mode: NULLABLE
+  description: Revisions created on `event_date` for this product and reviewer type
+- name: reviewed_revisions
+  type: INTEGER
+  mode: NULLABLE
+  description: Revisions reviewed on `event_date` for this product and reviewer type
+- name: approved_revisions
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Revisions reviewed and approved on `event_date` for this product and reviewer
+    type. A subset of `reviewed_revisions`.
+- name: net_revisions
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    `created_revisions` minus `reviewed_revisions` — the daily net review flow,
+    not a backlog level, and can be negative. For the cumulative backlog see
+    `running_backlog` in sumo_kb_revision_kpis.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_daily_v1/schema.yaml
@@ -20,7 +20,15 @@ fields:
 - name: created_revisions
   type: INTEGER
   mode: NULLABLE
-  description: Revisions created on `event_date` for this product and reviewer type
+  description: >
+    Revisions created on `event_date` for this product and reviewer type. The
+    reviewer_type split means "eventually reviewed by", not anything known at
+    creation time, and is retroactively mutable: this table is fully recomputed
+    each run, so a revision counted under 'Unreviewed' for its creation date
+    today moves to 'Staff'/'Community' for that same date once reviewed. About
+    27% of revisions created in the last 30 days are still unreviewed, so the
+    recent tail of a created-by-reviewer-type series will redistribute between
+    buckets on later runs. Sum across reviewer types for a stable creation count.
 - name: reviewed_revisions
   type: INTEGER
   mode: NULLABLE
@@ -43,5 +51,7 @@ fields:
   mode: NULLABLE
   description: >
     `created_revisions` minus `reviewed_revisions` — the daily net review flow,
-    not a backlog level, and can be negative. For the cumulative backlog see
-    `running_backlog` in sumo_kb_revision_kpis.
+    not a backlog level, and can be negative. Inherits the retroactive
+    mutability of `created_revisions` per reviewer type. For the cumulative
+    version see `backlog_change_since_window_start` in sumo_kb_revision_kpis,
+    which is a trend rather than a pending count.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: SUMO KB Revision KPIs
+description: >
+  Day-level SUMO knowledge base revision KPIs: total revisions created,
+  reviewed, and approved across all products and reviewer types, their 14-day
+  moving averages, the same moving averages lagged 14 days for
+  period-over-period comparison, and the cumulative review backlog
+  (`running_backlog`). `total_backlog` is the daily net flow (created minus
+  reviewed) and can be negative; `running_backlog` is the actual backlog level.
+  Rolled up from kb_revisions_daily_v1 so the population, product, and reviewer
+  definitions stay in one place — join back to that table on `event_date` to
+  break the totals down by product or reviewer type.
+owners:
+  - phlee@mozilla.com
+  - mozilla/customer_experience

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/metadata.yaml
@@ -2,10 +2,17 @@ friendly_name: SUMO KB Revision KPIs
 description: >
   Day-level SUMO knowledge base revision KPIs: total revisions created,
   reviewed, and approved across all products and reviewer types, their 14-day
-  moving averages, the same moving averages lagged 14 days for
-  period-over-period comparison, and the cumulative review backlog
-  (`running_backlog`). `total_backlog` is the daily net flow (created minus
-  reviewed) and can be negative; `running_backlog` is the actual backlog level.
+  moving averages, and the same moving averages lagged 14 days for
+  period-over-period comparison. `total_backlog` is the daily net flow (created
+  minus reviewed) and can be negative.
+
+  `backlog_change_since_window_start` is the cumulative net flow since the
+  upstream window start — it is NOT the pending-review count. Revisions created
+  before 2024-01-01 are outside kb_revisions_base_v1, so roughly 3,400 older
+  revisions that remain unreviewed are absent from the sum, and it can go
+  negative when cumulative reviews since the window start exceed cumulative
+  creations. Treat it as a backlog trend, not a level.
+
   Rolled up from kb_revisions_daily_v1 so the population, product, and reviewer
   definitions stay in one place — join back to that table on `event_date` to
   break the totals down by product or reviewer type.

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/view.sql
@@ -1,0 +1,73 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.sumo_metrics_derived.sumo_kb_revision_kpis`
+AS
+-- Day-level SUMO KB revision KPIs: total revisions created, reviewed, and
+-- approved across all products and reviewer types, their 14-day moving averages,
+-- the same moving averages lagged 14 days for period-over-period comparison, and
+-- the cumulative review backlog.
+--
+-- Rolled up from kb_revisions_daily_v1 so the population, product, and reviewer
+-- definitions stay in one place. Join back to kb_revisions_daily_v1 on
+-- `event_date` to break the totals down by product or reviewer type.
+--
+--   total_backlog   : daily net flow (created - reviewed) — can be negative
+--   running_backlog : cumulative net flow to date, i.e. the actual backlog level
+WITH day_level AS (
+  SELECT
+    event_date,
+    SUM(created_revisions) AS total_created_revisions,
+    SUM(reviewed_revisions) AS total_reviewed_revisions,
+    SUM(approved_revisions) AS total_approved_revisions
+  FROM
+    `moz-fx-data-shared-prod.sumo_metrics_derived.kb_revisions_daily_v1`
+  GROUP BY
+    event_date
+),
+moving_averages AS (
+  SELECT
+    *,
+    AVG(total_created_revisions) OVER (
+      ORDER BY
+        event_date
+      ROWS BETWEEN
+        13 PRECEDING
+        AND CURRENT ROW
+    ) AS total_created_revisions_14_ma,
+    AVG(total_reviewed_revisions) OVER (
+      ORDER BY
+        event_date
+      ROWS BETWEEN
+        13 PRECEDING
+        AND CURRENT ROW
+    ) AS total_reviewed_revisions_14_ma,
+    AVG(total_approved_revisions) OVER (
+      ORDER BY
+        event_date
+      ROWS BETWEEN
+        13 PRECEDING
+        AND CURRENT ROW
+    ) AS total_approved_revisions_14_ma
+  FROM
+    day_level
+)
+SELECT
+  *,
+  LAG(total_created_revisions_14_ma, 14) OVER (
+    ORDER BY
+      event_date
+  ) AS lagged_total_created_revisions_14_ma,
+  LAG(total_reviewed_revisions_14_ma, 14) OVER (
+    ORDER BY
+      event_date
+  ) AS lagged_total_reviewed_revisions_14_ma,
+  LAG(total_approved_revisions_14_ma, 14) OVER (
+    ORDER BY
+      event_date
+  ) AS lagged_total_approved_revisions_14_ma,
+  total_created_revisions - total_reviewed_revisions AS total_backlog,
+  SUM(total_created_revisions - total_reviewed_revisions) OVER (
+    ORDER BY
+      event_date
+  ) AS running_backlog
+FROM
+  moving_averages

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/view.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/sumo_kb_revision_kpis/view.sql
@@ -4,14 +4,23 @@ AS
 -- Day-level SUMO KB revision KPIs: total revisions created, reviewed, and
 -- approved across all products and reviewer types, their 14-day moving averages,
 -- the same moving averages lagged 14 days for period-over-period comparison, and
--- the cumulative review backlog.
+-- the cumulative change in review backlog since the upstream window start.
 --
 -- Rolled up from kb_revisions_daily_v1 so the population, product, and reviewer
 -- definitions stay in one place. Join back to kb_revisions_daily_v1 on
 -- `event_date` to break the totals down by product or reviewer type.
 --
---   total_backlog   : daily net flow (created - reviewed) — can be negative
---   running_backlog : cumulative net flow to date, i.e. the actual backlog level
+--   total_backlog : daily net flow (created - reviewed) — can be negative
+--   backlog_change_since_window_start : cumulative net flow since the upstream
+--     window start, NOT the pending-review count. kb_revisions_base_v1 only
+--     contains revisions created on or after 2024-01-01, so the ~3,400 older
+--     revisions that are still unreviewed are absent from this sum, and it can
+--     go negative on any date where cumulative reviews since the window start
+--     exceed cumulative creations. Read it as a trend, not a level. A true
+--     all-time level would require widening the upstream window to cover every
+--     revision rather than seeding a constant here, because pre-window
+--     revisions do still get reviewed inside the window (21 to date), so a
+--     fixed seed would never decay.
 WITH day_level AS (
   SELECT
     event_date,
@@ -68,6 +77,6 @@ SELECT
   SUM(total_created_revisions - total_reviewed_revisions) OVER (
     ORDER BY
       event_date
-  ) AS running_backlog
+  ) AS backlog_change_since_window_start
 FROM
   moving_averages


### PR DESCRIPTION
Productionizes the SUMO KB releases dashboard query ([`kb_releases_query.sql`](https://github.com/mozilla/bigquery-etl/blob/main/README.md) in `mzl-sumo-metrics/dashboard queries/`) as three scheduled layers in `sumo_metrics_derived`.

Ref [DENG-11504](https://mozilla-hub.atlassian.net/browse/DENG-11504).

## What's added

| Table | Grain | Purpose |
| --- | --- | --- |
| `kb_revisions_base_v1` | one row per revision | Population filters, product mapping, two-stage `reviewed_date` backfill |
| `kb_revisions_daily_v1` | day x product x reviewer_type | Counts of revisions created / reviewed / approved, on a dense date spine |
| `sumo_kb_revision_kpis` (view) | day | Totals, 14-day moving averages and lags, cumulative review backlog |

This mirrors the existing `kb_quality_metrics_article_v1` -> `kb_quality_metrics_daily_v1` -> `sumo_content_quality_kpis` layering, so the population and product definitions stay in one place. `bqetl dag generate bqetl_sumo_metrics` picks up both tasks with `kb_revisions_daily__v1` correctly downstream of the base; no `dags.yaml` change needed.

## Deliberate changes from the dashboard query

- **Product mapping.** The hardcoded 90-line `CASE` is replaced by `mozfun.customer_experience.normalize_product(products, 'GA4')`, matching how `kb_quality_metrics_article_v1` treats the same field. A `NULL` products path is folded into `'Other'` via `COALESCE` so those revisions still count toward throughput.
- **Window.** The rolling 1-year window becomes a fixed `2024-01-01` start so history doesn't roll off on each full recompute.
- **Naming.** `reviewer_is_staff` -> `reviewer_type` (it holds `'Staff'`/`'Community'`/`'Unreviewed'`, not a boolean); `backlog_revisions` -> `net_revisions` (it's a daily flow, not a level — the actual backlog is `running_backlog` in the view).
- **PII.** Dropped `creator_email` / `reviewer_email`; kept usernames and IDs.
- **Grain.** Day-level totals are no longer fanned across every product row. Consumers read `kb_revisions_daily_v1` for breakdowns and join `sumo_kb_revision_kpis` on `event_date` for totals.

## Validation

Full results are in a PR comment below. Summary, with date ranges matched to the dashboard's rolling year (2025-08-14 -> 2026-08-13):

- **Zero diffs** across all 16 shared columns on the 2,534 revisions present in both, including both stages of the `reviewed_date` backfill and `latest_document_revision_date`.
- **0 of 366** day-level cells and **0 of 1,098** day x reviewer-type cells differ, once the 5 revisions below are set aside.
- Product mapping is strictly 1:1 for every path the dashboard recognized. 142 revisions the dashboard bucketed as `other` are now correctly classified.

## Open Questions
Widen window to capture pre-window reviews — filter on created OR reviewed instead of created only. Adds 21 revisions, fixes understated early-2024 throughput; breaks dashboard parity. Currently: documented as a known limitation.

Widen window for a true backlog level — drop the 2024-01-01 start so backlog_change_since_window_start becomes a real pending count (reports 48 today vs ~3,459 actual). Costs: daily spine goes back to 2009, MAs span a decade of sparse history. Currently: renamed to reflect it's a trend, not a level. Widening the window here would likely fix the above window issue also.

created_revisions split by reviewer_type — retroactively mutable (27% of the last 30 days will move buckets). Drop the split (aka drop `reviewer_type` column) from creations for a stable series, or keep for dashboard parity. Currently: documented; day-level totals are unaffected either way.

reviewed_revisions under 'Unreviewed' — 554 revisions inherit a review date and land in that bucket. Exclude backfilled dates from the reviewer-type split (same fix as above - drop `reviewer_type`), or keep matching the dashboard. Currently: documented.


## One thing to confirm before merge

The new base table drops **5 revisions** (0.2%) that the dashboard kept. Both are general Firefox-audience articles that merely also carry a Thunderbird tag, on paths the dashboard's `CASE` never enumerated (so it fell through to `ELSE 'other'` and kept them):

- `/firefox/ios/mobile/thunderbird/` — "Avoid and report Mozilla tech support scams" (4 revisions)
- `/firefox/thunderbird/` — "What is the Mozilla Maintenance Service?" (1 revision)

The UDF classifies these as `Thunderbird`, so the "another team handles Thunderbird" filter excludes them. Whether that's correct depends on what the exclusion means: if it's "articles the Thunderbird team maintains," these should arguably stay. It won't move the KPIs either way. Current behaviour is consistent with `kb_quality_metrics_article_v1`; happy to key the filter off the raw path instead if reviewers prefer that.

## Not done here

The tables aren't deployed or backfilled yet — validation was read-only dry runs plus `bq query` reads against prod, with both new queries inlined as CTEs since neither table exists.


[DENG-11504]: https://mozilla-hub.atlassian.net/browse/DENG-11504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ