### PR TITLE
Bug 2063419 - More Sync team metrics ETLs

### DIFF
--- a/sql_generators/rust_component_metrics/__init__.py
+++ b/sql_generators/rust_component_metrics/__init__.py
@@ -32,6 +32,19 @@ def all_metric_groups() -> list["MetricGroup"]:
         ),
         MetricGroup(
             ping="metrics",
+            category="logins_store_key_regeneration",
+            applications=[
+                Application.firefox_ios,
+            ],
+            metrics=[
+                Event("corrupt"),
+                Event("keychain_data_lost"),
+                Event("lost"),
+                Event("other"),
+            ],
+        ),
+        MetricGroup(
+            ping="metrics",
             category="logins_store",
             applications=[
                 Application.firefox_android,
@@ -70,6 +83,16 @@ def all_metric_groups() -> list["MetricGroup"]:
                 LabeledDistribution("ingest_download_time", DistributionType.timing),
                 LabeledDistribution("ingest_time", DistributionType.timing),
                 LabeledDistribution("query_time", DistributionType.timing),
+            ],
+        ),
+        MetricGroup(
+            ping="metrics",
+            category="user",
+            applications=[
+                Application.firefox_ios,
+            ],
+            metrics=[
+                Counter("credit_cards_undecryptable_count"),
             ],
         ),
     ]

--- a/sql_generators/rust_component_metrics/templates/counter/query.sql
+++ b/sql_generators/rust_component_metrics/templates/counter/query.sql
@@ -2,7 +2,8 @@ SELECT
     DATE(submission_timestamp) AS submission_date,
     "{{ application }}" as application,
     normalized_channel AS channel,
-    SUM(metrics.counter.{{ category }}_{{ metric.name }}) as count
+    SUM(metrics.counter.{{ category }}_{{ metric.name }}) as count,
+    COUNT(DISTINCT client_info.client_id) as client_count
 FROM `moz-fx-data-shared-prod.{{ dataset_name }}.metrics`
 WHERE
   DATE(submission_timestamp) = @submission_date AND

--- a/sql_generators/rust_component_metrics/templates/counter/schema.yaml
+++ b/sql_generators/rust_component_metrics/templates/counter/schema.yaml
@@ -15,3 +15,7 @@ fields:
   type: INTEGER
   description: |-
     Total count
+- name: client_count
+  type: INTEGER
+  description: |-
+    Unique client count

--- a/sql_generators/rust_component_metrics/templates/event/query.sql
+++ b/sql_generators/rust_component_metrics/templates/event/query.sql
@@ -2,7 +2,8 @@ SELECT
     DATE(submission_timestamp) AS submission_date,
     "{{ application }}" as application,
     normalized_channel AS channel,
-    COUNT(*) as count
+    COUNT(*) as count,
+    COUNT(DISTINCT client_info.client_id) as client_count
 FROM `moz-fx-data-shared-prod.{{ dataset_name }}.events`
 CROSS JOIN UNNEST(events) as events 
 WHERE

--- a/sql_generators/rust_component_metrics/templates/event/schema.yaml
+++ b/sql_generators/rust_component_metrics/templates/event/schema.yaml
@@ -15,3 +15,7 @@ fields:
   type: INTEGER
   description: |-
     Total count
+- name: client_count
+  type: INTEGER
+  description: |-
+    Unique client count


### PR DESCRIPTION
## Description

- Added ETLs for key regeneration and undecryptable record metrics
- Adding client count for counter/event metrics

## Related Tickets & Documents
* [Bug 2063419](https://bugzilla.mozilla.org/show_bug.cgi?id=2063419)
* [SYNC-5399](https://mozilla-hub.atlassian.net/browse/SYNC-5399)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[SYNC-5399]: https://mozilla-hub.atlassian.net/browse/SYNC-5399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ