### PR TITLE
feat(DENG-11287): load scraped market intel corpus from GCS into BigQuery

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2113,6 +2113,30 @@ bqetl_fred_daily_exchange_rate:
   repo: bigquery-etl
   schedule_interval: 30 23 * * *
 
+bqetl_market_research:
+  description: |
+    This DAG loads the market-research GCS corpus (browser release notes,
+    vendor blog posts, and competitor job postings) scraped by
+    docker-etl's release_scraping job into BigQuery. Scheduled on the same
+    cron as telemetry-airflow's web_scraping DAG, whose read_release_data
+    task is declared as an explicit depends_on dependency so these tasks
+    wait for that run to finish before loading.
+  default_args:
+    depends_on_past: false
+    owner: lmcfall@mozilla.com
+    email:
+      - lmcfall@mozilla.com
+      - telemetry-alerts@mozilla.com
+    email_on_failure: true
+    email_on_retry: false
+    start_date: "2026-08-11"
+    retries: 2
+    retry_delay: 25m
+  tags:
+    - impact/tier_2
+  repo: bigquery-etl
+  schedule_interval: 0 15 * * 2
+
 bqetl_us_bls_unemployment_data:
   description: |
     This DAG pulls US unemployment data from the BLS API

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_blogs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_blogs_v1/metadata.yaml
@@ -1,0 +1,28 @@
+friendly_name: Market Research Browser Blog Posts
+description: |-
+  Browser and product vendor blog posts scraped from RSS/Atom feeds by
+  docker-etl's release_scraping job, scheduled weekly by telemetry-airflow's
+  web_scraping DAG (task read_release_data). Source records are written as
+  individual JSON files to
+  gs://moz-fx-data-prod-external-data/MARKET_RESEARCH/BLOGS/.
+  This table is a full truncate & reload of that corpus on each run.
+owners:
+- lmcfall@mozilla.com
+labels:
+  incremental: false
+  owner1: lmcfall
+scheduling:
+  dag_name: bqetl_market_research
+  date_partition_parameter: null
+  arguments: ["--date", "{{ds}}"]
+  depends_on:
+  - task_id: read_release_data
+    dag_name: web_scraping
+    execution_delta: 0h
+bigquery:
+  range_partitioning: null
+  clustering:
+    fields:
+    - browser
+    - release_date
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_blogs_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_blogs_v1/query.py
@@ -1,0 +1,169 @@
+"""Load browser vendor blog post records from GCS into BigQuery.
+
+Reads every blog post JSON record written by docker-etl's release_scraping
+job (scheduled weekly by telemetry-airflow's web_scraping DAG) under
+gs://moz-fx-data-prod-external-data/MARKET_RESEARCH/BLOGS/, and
+truncate-and-reloads the destination table from the full corpus on each run.
+"""
+
+import json
+from argparse import ArgumentParser
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+from google.cloud import bigquery, storage
+
+from bigquery_etl.schema import Schema
+
+GCS_BUCKET = "moz-fx-data-prod-external-data"
+GCS_BLOGS_PREFIX = "MARKET_RESEARCH/BLOGS"
+TABLE_ID = "moz-fx-data-shared-prod.external_derived.market_research_blogs_v1"
+
+# Filename prefix release_scraping uses for blog post records.
+BLOB_PREFIX = "post_"
+
+# Each record is its own small blob, so reloading the corpus is bound by request
+# latency rather than bandwidth. Downloading concurrently keeps the runtime flat
+# as the corpus grows instead of scaling with the number of blobs.
+DOWNLOAD_WORKERS = 16
+
+# schema.yaml is the single source of truth for the destination schema. This
+# load truncates the table, which replaces its schema, so passing a separately
+# maintained schema here would silently overwrite the field descriptions that
+# `bqetl deploy` applies from schema.yaml.
+SCHEMA_FILE = Path(__file__).parent / "schema.yaml"
+SCHEMA = Schema.from_schema_file(SCHEMA_FILE).to_bigquery_schema()
+COLUMNS = [field.name for field in SCHEMA]
+
+# Malformed dates encountered while normalizing, so that one bad value in one
+# blob degrades to NULL instead of failing the whole weekly reload. Appended to
+# from worker threads, so the order of entries isn't meaningful.
+unparseable_dates = []
+
+
+def list_blog_blobs(client):
+    """List blog post JSON blobs under the blogs GCS prefix.
+
+    Returns `(matched, skipped)`, where `skipped` holds the names of JSON
+    files that don't match the expected filename prefix. Those would
+    otherwise be dropped silently if the upstream scraper changed its naming.
+    """
+    matched = []
+    skipped = []
+    for blob in client.list_blobs(GCS_BUCKET, prefix=GCS_BLOGS_PREFIX + "/"):
+        if not blob.name.endswith(".json"):
+            continue
+        if blob.name.split("/")[-1].startswith(BLOB_PREFIX):
+            matched.append(blob)
+        else:
+            skipped.append(blob.name)
+    return matched, skipped
+
+
+def parse_date(value, date_format, blob_name, field):
+    """Parse a date string into a `date`.
+
+    Returns None for empty values, and for values that don't match
+    `date_format` -- scraped feed dates vary in format, and a single bad value
+    shouldn't block the reload of the entire corpus.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, date_format).date()
+    except ValueError:
+        unparseable_dates.append(f"{blob_name}: {field}={value!r}")
+        return None
+
+
+def normalize_blog_record(record, blob_name):
+    """Flatten a scraped blog post record into a row matching schema.yaml.
+
+    TODO: `features` is always an empty list in every record today, so it's
+    dropped rather than modeled as a column. Re-add it if the scraper starts
+    populating it.
+    """
+    return {
+        "browser": record.get("browser"),
+        "release_date": parse_date(
+            record.get("release_date"), "%Y-%m-%d", blob_name, "release_date"
+        ),
+        "scraped_date": parse_date(
+            record.get("scraped_date"), "%Y%m%d", blob_name, "scraped_date"
+        ),
+        "source_url": record.get("source_url"),
+        "source_type": record.get("source_type") or "blog_post",
+        "title": record.get("title"),
+        "raw_text": record.get("raw_text"),
+        "blob_name": blob_name,
+    }
+
+
+def fetch_and_normalize(blob):
+    """Download a single blob and normalize it into a row."""
+    return normalize_blog_record(json.loads(blob.download_as_text()), blob.name)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--date", required=True)
+    args = parser.parse_args()
+    # This corpus is a cumulative, re-listable snapshot rather than a daily
+    # time series, so --date isn't used to filter source data -- it's only
+    # accepted to keep the CLI shape consistent with other bqetl query.py jobs.
+    datetime.strptime(args.date, "%Y-%m-%d")
+
+    storage_client = storage.Client()
+    blobs, skipped_blobs = list_blog_blobs(storage_client)
+    print(
+        f"Found {len(blobs)} blog post blobs under "
+        f"gs://{GCS_BUCKET}/{GCS_BLOGS_PREFIX}/"
+    )
+    if skipped_blobs:
+        print(
+            f"WARNING: skipped {len(skipped_blobs)} JSON blob(s) that don't "
+            f"start with {BLOB_PREFIX!r}; release_scraping may have changed its "
+            f"filename convention. Examples: {skipped_blobs[:5]}"
+        )
+
+    with ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as pool:
+        rows = list(pool.map(fetch_and_normalize, blobs))
+
+    # The corpus only ever grows, so an empty listing always means something
+    # upstream broke (failed scrape, renamed prefix, lost bucket access).
+    # Loading it would truncate the table, and because --date is ignored a
+    # rerun can't restore the previous contents, so fail loudly instead.
+    if not rows:
+        raise ValueError(
+            f"No blog post records found under gs://{GCS_BUCKET}/"
+            f"{GCS_BLOGS_PREFIX}/ -- refusing to truncate {TABLE_ID}"
+        )
+
+    if unparseable_dates:
+        print(
+            f"WARNING: {len(unparseable_dates)} date value(s) could not be "
+            "parsed and were loaded as NULL:"
+        )
+        for detail in unparseable_dates[:20]:
+            print(f"  {detail}")
+
+    results_df = pd.DataFrame(rows, columns=COLUMNS)
+    print(f"Parsed {len(results_df)} rows")
+
+    bq_client = bigquery.Client()
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        autodetect=False,
+        schema=SCHEMA,
+    )
+
+    load_job = bq_client.load_table_from_dataframe(
+        results_df,
+        TABLE_ID,
+        job_config=job_config,
+    )
+    load_job.result()  # waits for completion
+
+    print(f"Loaded {len(results_df)} rows into {TABLE_ID} (full reload)")

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_blogs_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_blogs_v1/schema.yaml
@@ -1,0 +1,34 @@
+fields:
+- name: browser
+  type: STRING
+  mode: NULLABLE
+  description: Browser or product name, e.g. Chrome, Firefox.
+- name: release_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the blog post was published.
+- name: scraped_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the record was scraped by release_scraping.
+- name: source_url
+  type: STRING
+  mode: NULLABLE
+  description: URL of the blog post that was scraped.
+- name: source_type
+  type: STRING
+  mode: NULLABLE
+  description: Kind of record. Always "blog_post" for this table.
+- name: title
+  type: STRING
+  mode: NULLABLE
+  description: Title of the blog post.
+- name: raw_text
+  type: STRING
+  mode: NULLABLE
+  description: Plain text scraped from the blog post page.
+- name: blob_name
+  type: STRING
+  mode: NULLABLE
+  description: Full GCS object path this row was loaded from, for traceability
+    back to the source file.

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_jobs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_jobs_v1/metadata.yaml
@@ -1,0 +1,32 @@
+friendly_name: Market Research Competitor Job Postings
+description: |-
+  Competitor job postings scraped from Greenhouse boards and Opera's
+  Teamtailor careers site by docker-etl's release_scraping job, scheduled
+  weekly by telemetry-airflow's web_scraping DAG (task read_release_data).
+  Each run's source records are a full snapshot of currently-open postings,
+  written as individual JSON files to
+  gs://moz-fx-data-prod-external-data/MARKET_RESEARCH/JOBS/. A job open
+  across multiple runs will appear once per scraped_date snapshot.
+  This table is a full truncate & reload of that corpus on each run.
+owners:
+- lmcfall@mozilla.com
+labels:
+  incremental: false
+  owner1: lmcfall
+scheduling:
+  dag_name: bqetl_market_research
+  date_partition_parameter: null
+  arguments: ["--date", "{{ds}}"]
+  depends_on:
+  - task_id: read_release_data
+    dag_name: web_scraping
+    execution_delta: 0h
+bigquery:
+  range_partitioning: null
+  clustering:
+    # scraped_date leads because a posting appears once per snapshot, so
+    # queries have to pick a snapshot to avoid counting a job repeatedly.
+    fields:
+    - scraped_date
+    - company
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_jobs_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_jobs_v1/query.py
@@ -1,0 +1,179 @@
+"""Load competitor job posting records from GCS into BigQuery.
+
+Reads every job posting JSON record written by docker-etl's release_scraping
+job (scheduled weekly by telemetry-airflow's web_scraping DAG) under
+gs://moz-fx-data-prod-external-data/MARKET_RESEARCH/JOBS/, and
+truncate-and-reloads the destination table from the full corpus on each run.
+
+Records come from two different scrapers (Greenhouse and Teamtailor)
+with slightly different construction but the same final key set, so one
+normalization function covers both.
+"""
+
+import json
+from argparse import ArgumentParser
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+from google.cloud import bigquery, storage
+
+from bigquery_etl.schema import Schema
+
+GCS_BUCKET = "moz-fx-data-prod-external-data"
+GCS_JOBS_PREFIX = "MARKET_RESEARCH/JOBS"
+TABLE_ID = "moz-fx-data-shared-prod.external_derived.market_research_jobs_v1"
+
+# Filename prefix release_scraping uses for job posting records.
+BLOB_PREFIX = "job_"
+
+# Each record is its own small blob, so reloading the corpus is bound by request
+# latency rather than bandwidth. Downloading concurrently keeps the runtime flat
+# as the corpus grows instead of scaling with the number of blobs -- this matters
+# most here, since every run adds a full snapshot under a new scraped_date.
+DOWNLOAD_WORKERS = 16
+
+# schema.yaml is the single source of truth for the destination schema. This
+# load truncates the table, which replaces its schema, so passing a separately
+# maintained schema here would silently overwrite the field descriptions that
+# `bqetl deploy` applies from schema.yaml.
+SCHEMA_FILE = Path(__file__).parent / "schema.yaml"
+SCHEMA = Schema.from_schema_file(SCHEMA_FILE).to_bigquery_schema()
+COLUMNS = [field.name for field in SCHEMA]
+
+# Malformed dates encountered while normalizing, so that one bad value in one
+# blob degrades to NULL instead of failing the whole weekly reload. Appended to
+# from worker threads, so the order of entries isn't meaningful.
+unparseable_dates = []
+
+
+def list_job_blobs(client):
+    """List job posting JSON blobs under the jobs GCS prefix.
+
+    Returns `(matched, skipped)`, where `skipped` holds the names of JSON
+    files that don't match the expected filename prefix. Those would
+    otherwise be dropped silently if the upstream scraper changed its naming.
+    """
+    matched = []
+    skipped = []
+    for blob in client.list_blobs(GCS_BUCKET, prefix=GCS_JOBS_PREFIX + "/"):
+        if not blob.name.endswith(".json"):
+            continue
+        if blob.name.split("/")[-1].startswith(BLOB_PREFIX):
+            matched.append(blob)
+        else:
+            skipped.append(blob.name)
+    return matched, skipped
+
+
+def parse_date(value, date_format, blob_name, field):
+    """Parse a date string into a `date`.
+
+    Returns None for empty values, and for values that don't match
+    `date_format` -- a single bad value shouldn't block the reload of the
+    entire corpus.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, date_format).date()
+    except ValueError:
+        unparseable_dates.append(f"{blob_name}: {field}={value!r}")
+        return None
+
+
+def normalize_job_record(record, blob_name):
+    """Flatten a scraped job posting record into a row matching schema.yaml.
+
+    `first_published` and `updated_at` are kept as STRING rather than
+    TIMESTAMP/DATE: Greenhouse returns full ISO datetimes while Opera's
+    JSON-LD only has date-only strings, and typing the column would break
+    the load on whichever source doesn't match.
+
+    `offices` is REPEATED, which can't hold SQL NULL, so a missing/empty
+    list of offices is normalized to an empty array rather than None.
+    """
+    return {
+        "company": record.get("company"),
+        "source": record.get("source"),
+        "scraped_date": parse_date(
+            record.get("scraped_date"), "%Y%m%d", blob_name, "scraped_date"
+        ),
+        "job_id": record.get("job_id"),
+        "title": record.get("title"),
+        "department": record.get("department"),
+        "location": record.get("location"),
+        "offices": record.get("offices") or [],
+        "url": record.get("url"),
+        "first_published": record.get("first_published"),
+        "updated_at": record.get("updated_at"),
+        "description_html": record.get("description_html"),
+        "description_text": record.get("description_text"),
+        "blob_name": blob_name,
+    }
+
+
+def fetch_and_normalize(blob):
+    """Download a single blob and normalize it into a row."""
+    return normalize_job_record(json.loads(blob.download_as_text()), blob.name)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--date", required=True)
+    args = parser.parse_args()
+    # This corpus is a cumulative, re-listable snapshot rather than a daily
+    # time series, so --date isn't used to filter source data -- it's only
+    # accepted to keep the CLI shape consistent with other bqetl query.py jobs.
+    datetime.strptime(args.date, "%Y-%m-%d")
+
+    storage_client = storage.Client()
+    blobs, skipped_blobs = list_job_blobs(storage_client)
+    print(f"Found {len(blobs)} job blobs under gs://{GCS_BUCKET}/{GCS_JOBS_PREFIX}/")
+    if skipped_blobs:
+        print(
+            f"WARNING: skipped {len(skipped_blobs)} JSON blob(s) that don't "
+            f"start with {BLOB_PREFIX!r}; release_scraping may have changed its "
+            f"filename convention. Examples: {skipped_blobs[:5]}"
+        )
+
+    with ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as pool:
+        rows = list(pool.map(fetch_and_normalize, blobs))
+
+    # The corpus only ever grows, so an empty listing always means something
+    # upstream broke (failed scrape, renamed prefix, lost bucket access).
+    # Loading it would truncate the table, and because --date is ignored a
+    # rerun can't restore the previous contents, so fail loudly instead.
+    if not rows:
+        raise ValueError(
+            f"No job posting records found under gs://{GCS_BUCKET}/"
+            f"{GCS_JOBS_PREFIX}/ -- refusing to truncate {TABLE_ID}"
+        )
+
+    if unparseable_dates:
+        print(
+            f"WARNING: {len(unparseable_dates)} date value(s) could not be "
+            "parsed and were loaded as NULL:"
+        )
+        for detail in unparseable_dates[:20]:
+            print(f"  {detail}")
+
+    results_df = pd.DataFrame(rows, columns=COLUMNS)
+    print(f"Parsed {len(results_df)} rows")
+
+    bq_client = bigquery.Client()
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        autodetect=False,
+        schema=SCHEMA,
+    )
+
+    load_job = bq_client.load_table_from_dataframe(
+        results_df,
+        TABLE_ID,
+        job_config=job_config,
+    )
+    load_job.result()  # waits for completion
+
+    print(f"Loaded {len(results_df)} rows into {TABLE_ID} (full reload)")

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_jobs_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_jobs_v1/schema.yaml
@@ -1,0 +1,65 @@
+fields:
+- name: company
+  type: STRING
+  mode: NULLABLE
+  description: Company the job posting belongs to.
+- name: source
+  type: STRING
+  mode: NULLABLE
+  description: 'Scraper source: "greenhouse" or "teamtailor".'
+- name: scraped_date
+  type: DATE
+  mode: NULLABLE
+  description: Date this snapshot of the job posting was scraped.
+- name: job_id
+  type: STRING
+  mode: NULLABLE
+  description: Source-specific identifier for the job posting.
+- name: title
+  type: STRING
+  mode: NULLABLE
+  description: Job title.
+- name: department
+  type: STRING
+  mode: NULLABLE
+  description: Department the job posting belongs to.
+- name: location
+  type: STRING
+  mode: NULLABLE
+  description: Primary location listed on the job posting.
+- name: offices
+  type: STRING
+  mode: REPEATED
+  description: Office names associated with the job posting. Empty when the
+    source record has no offices listed.
+- name: url
+  type: STRING
+  mode: NULLABLE
+  description: URL of the job posting.
+- name: first_published
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Date/time the job posting was first published, as returned by the
+    source (format varies by source, so this is kept as a string rather
+    than parsed).
+- name: updated_at
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Date/time the job posting was last updated, as returned by the source
+    (format varies by source, so this is kept as a string rather than
+    parsed).
+- name: description_html
+  type: STRING
+  mode: NULLABLE
+  description: Job posting description as raw HTML.
+- name: description_text
+  type: STRING
+  mode: NULLABLE
+  description: Job posting description as plain text.
+- name: blob_name
+  type: STRING
+  mode: NULLABLE
+  description: Full GCS object path this row was loaded from, for traceability
+    back to the source file.

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_releases_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_releases_v1/metadata.yaml
@@ -1,0 +1,28 @@
+friendly_name: Market Research Browser Releases
+description: |-
+  Browser and product release-note records (developer and user-facing)
+  scraped from vendor release-note pages by docker-etl's release_scraping
+  job, scheduled weekly by telemetry-airflow's web_scraping DAG
+  (task read_release_data). Source records are written as individual JSON
+  files to gs://moz-fx-data-prod-external-data/MARKET_RESEARCH/STRUCTURED/.
+  This table is a full truncate & reload of that corpus on each run.
+owners:
+- lmcfall@mozilla.com
+labels:
+  incremental: false
+  owner1: lmcfall
+scheduling:
+  dag_name: bqetl_market_research
+  date_partition_parameter: null
+  arguments: ["--date", "{{ds}}"]
+  depends_on:
+  - task_id: read_release_data
+    dag_name: web_scraping
+    execution_delta: 0h
+bigquery:
+  range_partitioning: null
+  clustering:
+    fields:
+    - browser
+    - release_date
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_releases_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_releases_v1/query.py
@@ -1,0 +1,175 @@
+"""Load browser release-note records from GCS into BigQuery.
+
+Reads every developer- and user-facing release-note JSON record written by
+docker-etl's release_scraping job (scheduled weekly by telemetry-airflow's
+web_scraping DAG) under
+gs://moz-fx-data-prod-external-data/MARKET_RESEARCH/STRUCTURED/, and
+truncate-and-reloads the destination table from the full corpus on each run.
+"""
+
+import json
+from argparse import ArgumentParser
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+from google.cloud import bigquery, storage
+
+from bigquery_etl.schema import Schema
+
+GCS_BUCKET = "moz-fx-data-prod-external-data"
+GCS_STRUCTURED_PREFIX = "MARKET_RESEARCH/STRUCTURED"
+TABLE_ID = "moz-fx-data-shared-prod.external_derived.market_research_releases_v1"
+
+# Filename prefixes release_scraping uses for developer and user release notes.
+BLOB_PREFIXES = ("release_", "user_release_")
+
+# Each record is its own small blob, so reloading the corpus is bound by request
+# latency rather than bandwidth. Downloading concurrently keeps the runtime flat
+# as the corpus grows instead of scaling with the number of blobs.
+DOWNLOAD_WORKERS = 16
+
+# schema.yaml is the single source of truth for the destination schema. This
+# load truncates the table, which replaces its schema, so passing a separately
+# maintained schema here would silently overwrite the field descriptions that
+# `bqetl deploy` applies from schema.yaml.
+SCHEMA_FILE = Path(__file__).parent / "schema.yaml"
+SCHEMA = Schema.from_schema_file(SCHEMA_FILE).to_bigquery_schema()
+COLUMNS = [field.name for field in SCHEMA]
+
+# Malformed dates encountered while normalizing, so that one bad value in one
+# blob degrades to NULL instead of failing the whole weekly reload. Appended to
+# from worker threads, so the order of entries isn't meaningful.
+unparseable_dates = []
+
+
+def list_release_blobs(client):
+    """List release-note JSON blobs under the structured GCS prefix.
+
+    Returns `(matched, skipped)`, where `skipped` holds the names of JSON
+    files that don't match the expected filename prefixes. Those would
+    otherwise be dropped silently if the upstream scraper changed its naming.
+    """
+    matched = []
+    skipped = []
+    for blob in client.list_blobs(GCS_BUCKET, prefix=GCS_STRUCTURED_PREFIX + "/"):
+        if not blob.name.endswith(".json"):
+            continue
+        if blob.name.split("/")[-1].startswith(BLOB_PREFIXES):
+            matched.append(blob)
+        else:
+            skipped.append(blob.name)
+    return matched, skipped
+
+
+def parse_date(value, date_format, blob_name, field):
+    """Parse a date string into a `date`.
+
+    Returns None for empty values, and for values that don't match
+    `date_format` -- scraped vendor dates vary in format, and a single bad
+    value shouldn't block the reload of the entire corpus.
+    """
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, date_format).date()
+    except ValueError:
+        unparseable_dates.append(f"{blob_name}: {field}={value!r}")
+        return None
+
+
+def normalize_release_record(record, blob_name):
+    """Flatten a scraped release-note record into a row matching schema.yaml.
+
+    Developer release-note records don't have a `source_type` key at all
+    (only user releases and blog posts do), so it's defaulted to
+    "developer_release_notes" here to keep the column non-null across both
+    release kinds.
+
+    TODO: `features` is always an empty list in every record today, so it's
+    dropped rather than modeled as a column. Re-add it if the scraper starts
+    populating it.
+    """
+    return {
+        "browser": record.get("browser"),
+        "version": record.get("version"),
+        "release_date": parse_date(
+            record.get("release_date"), "%Y-%m-%d", blob_name, "release_date"
+        ),
+        "scraped_date": parse_date(
+            record.get("scraped_date"), "%Y%m%d", blob_name, "scraped_date"
+        ),
+        "source_url": record.get("source_url"),
+        "source_type": record.get("source_type") or "developer_release_notes",
+        "raw_text": record.get("raw_text"),
+        "blob_name": blob_name,
+    }
+
+
+def fetch_and_normalize(blob):
+    """Download a single blob and normalize it into a row."""
+    return normalize_release_record(json.loads(blob.download_as_text()), blob.name)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument("--date", required=True)
+    args = parser.parse_args()
+    # This corpus is a cumulative, re-listable snapshot rather than a daily
+    # time series, so --date isn't used to filter source data -- it's only
+    # accepted to keep the CLI shape consistent with other bqetl query.py jobs.
+    datetime.strptime(args.date, "%Y-%m-%d")
+
+    storage_client = storage.Client()
+    blobs, skipped_blobs = list_release_blobs(storage_client)
+    print(
+        f"Found {len(blobs)} release blobs under "
+        f"gs://{GCS_BUCKET}/{GCS_STRUCTURED_PREFIX}/"
+    )
+    if skipped_blobs:
+        print(
+            f"WARNING: skipped {len(skipped_blobs)} JSON blob(s) that don't "
+            f"start with any of {BLOB_PREFIXES}; release_scraping may have "
+            f"changed its filename convention. Examples: {skipped_blobs[:5]}"
+        )
+
+    with ThreadPoolExecutor(max_workers=DOWNLOAD_WORKERS) as pool:
+        rows = list(pool.map(fetch_and_normalize, blobs))
+
+    # The corpus only ever grows, so an empty listing always means something
+    # upstream broke (failed scrape, renamed prefix, lost bucket access).
+    # Loading it would truncate the table, and because --date is ignored a
+    # rerun can't restore the previous contents, so fail loudly instead.
+    if not rows:
+        raise ValueError(
+            f"No release-note records found under gs://{GCS_BUCKET}/"
+            f"{GCS_STRUCTURED_PREFIX}/ -- refusing to truncate {TABLE_ID}"
+        )
+
+    if unparseable_dates:
+        print(
+            f"WARNING: {len(unparseable_dates)} date value(s) could not be "
+            "parsed and were loaded as NULL:"
+        )
+        for detail in unparseable_dates[:20]:
+            print(f"  {detail}")
+
+    results_df = pd.DataFrame(rows, columns=COLUMNS)
+    print(f"Parsed {len(results_df)} rows")
+
+    bq_client = bigquery.Client()
+    job_config = bigquery.LoadJobConfig(
+        write_disposition=bigquery.WriteDisposition.WRITE_TRUNCATE,
+        autodetect=False,
+        schema=SCHEMA,
+    )
+
+    load_job = bq_client.load_table_from_dataframe(
+        results_df,
+        TABLE_ID,
+        job_config=job_config,
+    )
+    load_job.result()  # waits for completion
+
+    print(f"Loaded {len(results_df)} rows into {TABLE_ID} (full reload)")

--- a/sql/moz-fx-data-shared-prod/external_derived/market_research_releases_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/external_derived/market_research_releases_v1/schema.yaml
@@ -1,0 +1,37 @@
+fields:
+- name: browser
+  type: STRING
+  mode: NULLABLE
+  description: Browser or product name, e.g. Chrome, Firefox.
+- name: version
+  type: STRING
+  mode: NULLABLE
+  description: Release version string, e.g. 128.0.
+- name: release_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the release was published by the vendor.
+- name: scraped_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the record was scraped by release_scraping.
+- name: source_url
+  type: STRING
+  mode: NULLABLE
+  description: URL of the release notes page that was scraped.
+- name: source_type
+  type: STRING
+  mode: NULLABLE
+  description: |-
+    Kind of release record: developer_release_notes or user_release_notes.
+    Developer release-note source records don't include this field, so it's
+    defaulted to developer_release_notes at load time.
+- name: raw_text
+  type: STRING
+  mode: NULLABLE
+  description: Plain text scraped from the release notes page.
+- name: blob_name
+  type: STRING
+  mode: NULLABLE
+  description: Full GCS object path this row was loaded from, for traceability
+    back to the source file.


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
Loads the data from GCS into BQ for more strealined retrieval.

## Related Tickets & Documents
* DENG-11287

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
