### PR TITLE
feat(firefox_desktop): add safe_browsing_interstitials daily aggregate

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop/safe_browsing_interstitials/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/safe_browsing_interstitials/metadata.yaml
@@ -1,0 +1,13 @@
+friendly_name: Safe Browsing Interstitials
+description: |-
+  The Safe Browsing interstitial funnel for Firefox Desktop: about:blocked
+  displays plus the two button presses users can make on the warning page.
+
+  Read the caveats on the underlying table
+  firefox_desktop_derived.safe_browsing_interstitials_v1 before computing rates.
+  Displays count renders rather than unique encounters, so action/displays
+  ratios are lower bounds.
+owners:
+- lcrouch@mozilla.com
+labels:
+  owner: lcrouch

--- a/sql/moz-fx-data-shared-prod/firefox_desktop/safe_browsing_interstitials/view.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop/safe_browsing_interstitials/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.firefox_desktop.safe_browsing_interstitials`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.firefox_desktop_derived.safe_browsing_interstitials_v1`

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/checks.sql
@@ -1,0 +1,79 @@
+#fail
+{{ not_null(["submission_date", "threat_type", "scope"], "submission_date = @submission_date") }}
+
+#fail
+{{ is_unique(["submission_date", "normalized_channel", "normalized_os", "country", "threat_type", "scope"], "submission_date = @submission_date") }}
+
+#warn
+{{ min_row_count(1, "submission_date = @submission_date") }}
+-- Drift alarm for the event-code and category-label mappings.
+--
+-- threat_type and scope are transcribed from two source files:
+-- IUrlClassifierUITelemetry.idl (event codes 1-32) and
+-- nsDocShellTelemetryUtils.cpp (page.load_error category labels). Both decodes
+-- fall through to NULL rather than mislabelling if a new value appears. The
+-- not_null check above turns that into a failure so the mapping gets updated
+-- instead of the table quietly under-reporting.
+--
+-- Actions without a matching display are the signal that the join keys have
+-- drifted apart, for example if a category label is renamed on one side only.
+
+#warn
+ASSERT (
+  SELECT
+    COUNTIF(displays = 0 AND (left_site > 0 OR proceeded_anyway > 0))
+  FROM
+    `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE
+    submission_date = @submission_date
+) = 0
+AS
+  "Interstitial actions recorded with zero displays for the same date, channel, OS, country, threat type and scope. The page.load_error category labels and the ui_events codes may have drifted apart.";
+
+-- The reload inflation should stay in its observed range.
+--
+-- Displays count renders, not unique encounters, because blocked URLs are never
+-- cache-tagged. Measured 1.7-2.1 displays per client in July and August 2026.
+-- Below 1.0 is impossible and means the client count is wrong. A jump well above
+-- the observed range would change how much the bypass rate is understated, and
+-- the caveat in the docs would need revisiting.
+
+#warn
+ASSERT (
+  SELECT
+    SAFE_DIVIDE(SUM(displays), SUM(display_clients))
+  FROM
+    `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE
+    submission_date = @submission_date
+    AND normalized_channel = 'release'
+    AND scope = 'Top-level page'
+)
+BETWEEN 1.0
+AND 4.0
+AS
+  "Displays per client on release is outside the observed 1.7-2.1 range (bounds 1.0-4.0). Either the reload inflation has changed or the client counts are wrong.";
+
+-- Sanity bound on the override rate.
+--
+-- proceeded_anyway / displays for top-level phishing on release measured ~23% in
+-- August 2026. This is a LOWER BOUND, not a point estimate, because the
+-- denominator is inflated by reloads. Wide bounds here on purpose: this catches a
+-- decode regression that swaps the two actions, not a subtle behavioural shift.
+
+#warn
+ASSERT (
+  SELECT
+    SAFE_DIVIDE(SUM(proceeded_anyway), SUM(displays))
+  FROM
+    `{{ project_id }}.{{ dataset_id }}.{{ table_name }}`
+  WHERE
+    submission_date = @submission_date
+    AND normalized_channel = 'release'
+    AND scope = 'Top-level page'
+    AND threat_type = 'Phishing'
+)
+BETWEEN 0.05
+AND 0.6
+AS
+  "Top-level phishing override rate on release is outside its historical 5-60% band; check for a behavioural shift or a swapped action mapping.";

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/metadata.yaml
@@ -1,0 +1,38 @@
+friendly_name: Safe Browsing Interstitials
+description: |-
+  The Safe Browsing interstitial funnel for Firefox Desktop: how often an
+  about:blocked warning page is rendered, and what users then do with it.
+
+  One row per day, channel, OS, country, threat type (Malware / Phishing /
+  Unwanted / Harmful) and scope (top-level page or iframe), with display counts
+  from page.load_error and button-press counts from urlclassifier.ui_events.
+
+  KNOWN BIAS: displays count renders, not unique encounters. A blocked URL is
+  never added to the classifier cache, so every reload and session restore
+  re-renders the interstitial and re-counts. Observed displays per client run
+  1.7-2.1 where a single warning would be 1.0. Because the actions are counted
+  per click, any action/displays ratio is a LOWER BOUND on the true
+  per-encounter rate. The inflation cannot be divided out; neither metric
+  carries a navigation or session key.
+
+  Also note that left_site undercounts how many people left the blocked page.
+  Most users who take a warning seriously close the tab or navigate away without
+  pressing a button, and Firefox records nothing in that case.
+owners:
+- lcrouch@mozilla.com
+labels:
+  incremental: true
+  owner1: lcrouch
+scheduling:
+  dag_name: bqetl_default
+bigquery:
+  time_partitioning:
+    type: day
+    field: submission_date
+    require_partition_filter: true
+    expiration_days: null
+  clustering:
+    fields:
+    - normalized_channel
+    - threat_type
+require_column_descriptions: true

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/query.sql
@@ -1,0 +1,172 @@
+-- Query for firefox_desktop_derived.safe_browsing_interstitials_v1
+--
+-- The Safe Browsing interstitial funnel: how often Firefox renders an
+-- about:blocked warning page, and what users then do with it.
+--
+-- Two metrics, both in the metrics ping, joined on threat type and scope.
+--
+-- DISPLAYS come from page.load_error, a dual labeled counter recorded in
+-- nsDocShell::DisplayLoadError
+-- It is a general page-load-error counter; Safe Browsing is four of its ~45
+-- categories, filtered below.
+--
+-- ACTIONS come from urlclassifier.ui_events, accumulated in
+-- browser/actors/BlockedSiteParent.sys.mjs on exactly two button presses:
+-- goBackButton -> *_GET_ME_OUT_OF_HERE, ignore_warning_link ->
+-- *_IGNORE_WARNING. Event codes are defined in
+-- toolkit/components/url-classifier/IUrlClassifierUITelemetry.idl (1-32). The
+-- *_PAGE_TOP and *_WHY_BLOCKED codes exist there but nothing writes them.
+--
+-- KNOWN BIAS, read before using this table. Displays count renders, not unique
+-- encounters. nsChannelClassifier::MarkEntryClassified returns early for
+-- blocking error codes, so a blocked URL is never cache-tagged, and so every
+-- reload or session restore re-classifies and re-renders.
+-- Observed displays per client run 1.7-2.1 where a single warning would be 1.0.
+-- The actions are per click. So any action/displays ratio is a LOWER BOUND on
+-- the real per-encounter rate, and the inflation cannot be divided out --
+-- neither metric carries a navigation or session key.
+-- Do not present these ratios as point estimates.
+WITH base AS (
+  SELECT
+    DATE(submission_timestamp) AS submission_date,
+    normalized_channel,
+    normalized_os,
+    IFNULL(normalized_country_code, '??') AS country,
+    client_info.client_id AS client_id,
+    metrics.dual_labeled_counter.page_load_error AS page_load_error,
+    metrics.custom_distribution.urlclassifier_ui_events.values AS ui_events
+  FROM
+    `moz-fx-data-shared-prod.firefox_desktop_stable.metrics_v1`
+  WHERE
+    DATE(submission_timestamp) = @submission_date
+),
+displays AS (
+  SELECT
+    submission_date,
+    normalized_channel,
+    normalized_os,
+    country,
+    CASE
+      scope_label.key
+      WHEN 'top'
+        THEN 'Top-level page'
+      WHEN 'frame'
+        THEN 'Iframe'
+    END AS scope,
+    CASE
+      threat_label.key
+      WHEN 'PHISHING_URI'
+        THEN 'Phishing'
+      WHEN 'MALWARE_URI'
+        THEN 'Malware'
+      WHEN 'UNWANTED_URI'
+        THEN 'Unwanted'
+      WHEN 'HARMFUL_URI'
+        THEN 'Harmful'
+    END AS threat_type,
+    SUM(threat_label.value) AS displays,
+    COUNT(DISTINCT client_id) AS display_clients
+  FROM
+    base
+  CROSS JOIN
+    UNNEST(page_load_error) AS scope_label
+  CROSS JOIN
+    UNNEST(scope_label.value) AS threat_label
+  WHERE
+    threat_label.key IN ('PHISHING_URI', 'MALWARE_URI', 'UNWANTED_URI', 'HARMFUL_URI')
+    AND threat_label.value > 0
+  GROUP BY
+    submission_date,
+    normalized_channel,
+    normalized_os,
+    country,
+    scope,
+    threat_type
+),
+actions AS (
+  SELECT
+    submission_date,
+    normalized_channel,
+    normalized_os,
+    country,
+    CASE
+      WHEN event_code
+        BETWEEN 1
+        AND 8
+        THEN 'Malware'
+      WHEN event_code
+        BETWEEN 9
+        AND 16
+        THEN 'Phishing'
+      WHEN event_code
+        BETWEEN 17
+        AND 24
+        THEN 'Unwanted'
+      WHEN event_code
+        BETWEEN 25
+        AND 32
+        THEN 'Harmful'
+    END AS threat_type,
+    CASE
+      WHEN event_code IN (1, 2, 3, 4, 9, 10, 11, 12, 17, 18, 19, 20, 25, 26, 27, 28)
+        THEN 'Top-level page'
+      WHEN event_code IN (5, 6, 7, 8, 13, 14, 15, 16, 21, 22, 23, 24, 29, 30, 31, 32)
+        THEN 'Iframe'
+    END AS scope,
+    -- Event codes transcribed from IUrlClassifierUITelemetry.idl.
+    -- *_GET_ME_OUT_OF_HERE and *_IGNORE_WARNING respectively.
+    SUM(IF(event_code IN (3, 7, 11, 15, 19, 23, 27, 31), event_count, 0)) AS left_site,
+    SUM(IF(event_code IN (4, 8, 12, 16, 20, 24, 28, 32), event_count, 0)) AS proceeded_anyway,
+    COUNT(
+      DISTINCT IF(event_code IN (3, 7, 11, 15, 19, 23, 27, 31), client_id, NULL)
+    ) AS left_site_clients,
+    COUNT(
+      DISTINCT IF(event_code IN (4, 8, 12, 16, 20, 24, 28, 32), client_id, NULL)
+    ) AS proceeded_anyway_clients
+  FROM
+    (
+      SELECT
+        submission_date,
+        normalized_channel,
+        normalized_os,
+        country,
+        client_id,
+        SAFE_CAST(ui_event.key AS INT64) AS event_code,
+        ui_event.value AS event_count
+      FROM
+        base
+      CROSS JOIN
+        UNNEST(ui_events) AS ui_event
+      WHERE
+        -- Zero-count entries are bucket padding, not observations.
+        ui_event.value > 0
+    )
+  GROUP BY
+    submission_date,
+    normalized_channel,
+    normalized_os,
+    country,
+    threat_type,
+    scope
+)
+-- FULL OUTER JOIN so a row survives when only one side has data: a display with
+-- no button press (the common case), or an action whose display landed in a
+-- different ping.
+SELECT
+  submission_date,
+  normalized_channel,
+  normalized_os,
+  country,
+  threat_type,
+  scope,
+  IFNULL(displays.displays, 0) AS displays,
+  IFNULL(displays.display_clients, 0) AS display_clients,
+  IFNULL(actions.left_site, 0) AS left_site,
+  IFNULL(actions.proceeded_anyway, 0) AS proceeded_anyway,
+  IFNULL(actions.left_site_clients, 0) AS left_site_clients,
+  IFNULL(actions.proceeded_anyway_clients, 0) AS proceeded_anyway_clients
+FROM
+  displays
+FULL OUTER JOIN
+  actions
+  USING (submission_date, normalized_channel, normalized_os, country, threat_type, scope)

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/schema.yaml
@@ -1,0 +1,78 @@
+fields:
+- name: submission_date
+  type: DATE
+  mode: NULLABLE
+  description: Date the ping was received by the ingestion edge server.
+- name: normalized_channel
+  type: STRING
+  mode: NULLABLE
+  description: Normalized release channel, e.g. release, beta, nightly.
+- name: normalized_os
+  type: STRING
+  mode: NULLABLE
+  description: Normalized operating system name.
+- name: country
+  type: STRING
+  mode: NULLABLE
+  description: Normalized ISO country code, or '??' when unknown.
+- name: threat_type
+  type: STRING
+  mode: NULLABLE
+  description: >
+    Which Safe Browsing list triggered the interstitial: Malware, Phishing,
+    Unwanted, or Harmful. Derived from the page.load_error category label on the
+    display side and from the event code on the action side.
+- name: scope
+  type: STRING
+  mode: NULLABLE
+  description: >
+    Whether the blocked resource was the top-level page or an iframe within it.
+    Iframe rows are rare; some days have none at all. Keep scope matched when
+    forming ratios -- mixing top-level actions with all-scope displays breaks
+    them.
+- name: displays
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Times an about:blocked interstitial was rendered, from page.load_error.
+    Counts renders, not unique encounters: a blocked URL is never cache-tagged,
+    so every reload and session restore re-counts. Inflated relative to distinct
+    warnings seen.
+- name: display_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Distinct clients counted within this one row, meaning this combination of
+    date, channel, OS, country, threat type and scope. NOT additive: summing this
+    column across rows double-counts any client that appears in more than one, for
+    example someone who saw both a phishing and a malware block on the same day.
+    To count clients across a wider slice, go back to the source ping.
+    Dividing displays by this gives displays per client, which runs 1.7-2.1 in
+    practice and is the measure of the reload inflation.
+- name: left_site
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Times a user pressed "Get me out of here" (the *_GET_ME_OUT_OF_HERE event
+    codes). Note that most users who heed a warning leave without pressing
+    anything, so this undercounts heeding.
+- name: proceeded_anyway
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Times a user used the override link and continued to the blocked site (the
+    *_IGNORE_WARNING event codes). Gated on browser.safebrowsing.allowOverride,
+    which defaults to true.
+- name: left_site_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Distinct clients that pressed "Go Back" within this one row. Not additive
+    across rows; see display_clients.
+- name: proceeded_anyway_clients
+  type: INTEGER
+  mode: NULLABLE
+  description: >
+    Distinct clients that overrode a warning within this one row. Not additive
+    across rows; see display_clients. Compare against proceeded_anyway to see
+    whether overriding is a one-off or a habit.


### PR DESCRIPTION
## Description
Adds `firefox_desktop_derived.safe_browsing_interstitials_v1`: daily counts of `about:blocked` warning pages and what users do with them.

Two metrics from the `metrics` ping, joined on threat type and scope:
- **Displays** — `page.load_error`, filtered to the four Safe Browsing categories (`PHISHING_URI` / `MALWARE_URI` / `UNWANTED_URI` / `HARMFUL_URI`). Recorded in `nsDocShell::DisplayLoadError`, after the gate that decides an error page will render.
- **Actions** — `urlclassifier.ui_events`, the two button presses recorded in `BlockedSiteParent.sys.mjs`: "Go Back" and the override link. Event codes are transcribed from `IUrlClassifierUITelemetry.idl` as explicit lists, and an unrecognised value yields `NULL` rather than a wrong label.

One row per `submission_date`, `normalized_channel`, `normalized_os`, `country`, `threat_type`, `scope`.

The decode lives here rather than in Looker so it has test coverage — `checks.sql` fails the build if either mapping drifts, and warns on the reload rate, the override rate, and actions appearing without displays.

Verified with `bqetl query validate` / `view validate` / `check render`, and by running one partition. Reproduces both source metrics exactly for 2026-08-11, release, top-level:

  | threat | displays | left site | overrode | override rate | displays/client |
  |---|---|---|---|---|---|
  | Phishing | 19,072 | 1,497 | 4,373 | 22.9% | 1.70 |
  | Malware | 2,603 | 431 | 830 | 31.9% | 2.13 |
  | Unwanted | 3,910 | 366 | 544 | 13.9% | 1.77 |

### things to know

**Every rate is a lower bound.** Displays count renders, not encounters. Blocked URLs are never cache-tagged, so each reload re-renders and re-counts — 1.7–2.1 displays per client where one warning would be 1.0. The inflation can't be divided out; neither metric has a navigation or session key. Documented in the query, metadata, and schema.

**I plan to backfill, but `shredder_mitigation` is intentionally absent.** Per the backfill cookbook, new tables omit it, backfill, validate, then set it true. Backfill is a follow-up PR.

## Related Tickets & Documents
  * https://mozilla-hub.atlassian.net/browse/MNTOR-5334
  * Dependent [`looker-spoke-default` PR](https://github.com/mozilla/looker-spoke-default/pull/1365) replaces a 380-line view with a thin one over this table — must merge **after** this deploys.