### PR TITLE
chore(DENG-11237): backfill referral_installs_daily_v1 for 2026-08-17

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/backfill.yaml
@@ -1,0 +1,15 @@
+2026-08-18:
+  start_date: 2026-08-17
+  end_date: 2026-08-17
+  reason: 'https://mozilla-hub.atlassian.net/browse/DENG-11237 - repopulate the 2026-08-17
+    partition after switching the query from the GA4/dltoken path to the Glean referrals
+    ping (PR #9792). The original run produced zero rows because the referral code
+    is never present in attribution data.'
+  watchers:
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  override_depends_on_past_null_partition: false
+  ignore_date_partition_offset: false


### PR DESCRIPTION
Initiate backfill (step 1 of 2) for `firefox_referral_derived.referral_installs_daily_v1`.

## ⚠️ Merge after #9792

Backfill processing runs the query **as it stands on `main`**. #9792 is what replaces the query with the `referrals`-ping version; merging this PR first would stage the same zero rows the scheduled run already produced.

## Why only 2026-08-17

The table currently has **21 partitions and 0 rows total** (2026-07-27 → 2026-08-16). Only one day has data worth recovering:

- **2026-08-17** — the Glean `referrals` ping first reported on this day. The scheduled run for it used the old GA4/dltoken query, which returns zero rows by construction (see #9792), so the data was never picked up.
- **2026-07-27 → 2026-08-16** — genuinely empty, because the ping did not exist yet. Reprocessing would write zero rows either way, so they're excluded rather than padding the range.
- **2026-08-18 onward** — no backfill needed. Once #9792 deploys, the normal scheduled runs pick these up.

## Expected staged result

Verified by running the new query against 2026-08-17 directly:

| submission_date | invite_code | install_count | normalized_channel |
|---|---|---|---|
| 2026-08-17 | `1WYYSNCNGE6S7WKGF` | 2 | nightly |
| 2026-08-17 | `1SKKBY6ZV9YWKHRXZ` | 2 | nightly |

These are the manual test installs: `1WYYSNCNGE6S7WKGF` is the Windows + Mac pair, `1SKKBY6ZV9YWKHRXZ` is the second test code. Both nightly, which is expected — the instrumentation targets 155, which reaches release on 1 September.

If the staged data shows anything other than these four installs across two codes, do not complete the backfill.

## After the swap

`referral_installs_totals_v1` needs no backfill of its own — it has `date_partition_parameter: null` and recomputes the full window every run, so it picks up the swapped partition on the next scheduled DAG run, and the CSV export to the Websites team's bucket follows in the same DAG.

## Notes

- `shredder_mitigation: false` — the table holds no client-level data, only per-code install counts.
- `override_retention_limit: false` — the source ping is well within retention (400 days).
- Validated with `bqetl backfill validate`.