### PR TITLE
fix: pass each data check to bq independently

### DIFF
--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -68,11 +68,9 @@ def _parse_check_output(output: str) -> str:
     return output
 
 
-@click.group(
-    help="""
+@click.group(help="""
         Commands for managing and running bqetl data checks.
-    """
-)
+    """)
 @click.pass_context
 def check(ctx):
     """Create the CLI group for the check command."""

--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -263,30 +263,22 @@ def _run_check(
     checks = sqlparse.split(result_split_by_marker)
     check_failed = False
 
-    with tempfile.NamedTemporaryFile(mode="w+") as query_stream:
-        for rendered_check in checks:
-            # since the last check will end with ; the last entry will be empty string.
-            if len(rendered_check) == 0:
-                continue
-            rendered_check = rendered_check.strip()
-            # reset the stream for each check so only the current check is passed to
-            # bq; tracking offsets would need byte lengths, not character lengths.
-            query_stream.seek(0)
-            query_stream.truncate()
-            query_stream.write(rendered_check)
-            query_stream.flush()
-            query_stream.seek(0)
+    for rendered_check in checks:
+        # since the last check will end with ; the last entry will be empty string.
+        if len(rendered_check) == 0:
+            continue
+        rendered_check = rendered_check.strip()
 
-            # run the query as shell command so that passed parameters can be used as is
-            try:
-                subprocess.check_output(
-                    ["bq", "query"] + query_arguments,
-                    stdin=query_stream,
-                    encoding="UTF-8",
-                )
-            except CalledProcessError as e:
-                print(_parse_check_output(e.output))
-                check_failed = True
+        # run the query as shell command so that passed parameters can be used as is
+        try:
+            subprocess.check_output(
+                ["bq", "query"] + query_arguments,
+                input=rendered_check,
+                encoding="UTF-8",
+            )
+        except CalledProcessError as e:
+            print(_parse_check_output(e.output))
+            check_failed = True
 
     if check_failed:
         sys.exit(1)

--- a/bigquery_etl/cli/check.py
+++ b/bigquery_etl/cli/check.py
@@ -68,9 +68,11 @@ def _parse_check_output(output: str) -> str:
     return output
 
 
-@click.group(help="""
+@click.group(
+    help="""
         Commands for managing and running bqetl data checks.
-    """)
+    """
+)
 @click.pass_context
 def check(ctx):
     """Create the CLI group for the check command."""
@@ -261,7 +263,6 @@ def _run_check(
     )
     result_split_by_marker = _render_result_split_by_marker(marker, rendered_result)
     checks = sqlparse.split(result_split_by_marker)
-    seek_location = 0
     check_failed = False
 
     with tempfile.NamedTemporaryFile(mode="w+") as query_stream:
@@ -270,9 +271,13 @@ def _run_check(
             if len(rendered_check) == 0:
                 continue
             rendered_check = rendered_check.strip()
+            # reset the stream for each check so only the current check is passed to
+            # bq; tracking offsets would need byte lengths, not character lengths.
+            query_stream.seek(0)
+            query_stream.truncate()
             query_stream.write(rendered_check)
-            query_stream.seek(seek_location)
-            seek_location += len(rendered_check)
+            query_stream.flush()
+            query_stream.seek(0)
 
             # run the query as shell command so that passed parameters can be used as is
             try:

--- a/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/sumo_metrics_derived/kb_revisions_base_v1/checks.sql
@@ -55,7 +55,7 @@ SELECT
     (SELECT COUNT(*) FROM unmapped) > 0,
     ERROR(
       FORMAT(
-        'Unmapped KB product paths — add to normalize_product UDF: %t',
+        'Unmapped KB product paths - add to normalize_product UDF: %t',
         ARRAY(SELECT AS STRUCT products, revisions FROM unmapped ORDER BY revisions DESC)
       )
     ),
@@ -103,7 +103,7 @@ SELECT
     (SELECT COUNT(*) FROM thunderbird_excluded) > 0,
     ERROR(
       FORMAT(
-        'New Thunderbird-mapped KB product paths are being excluded from kb_revisions_base_v1 — confirm they are Thunderbird-team content: %t',
+        'New Thunderbird-mapped KB product paths are being excluded from kb_revisions_base_v1 - confirm they are Thunderbird-team content: %t',
         ARRAY(
           SELECT AS STRUCT
             products,


### PR DESCRIPTION
## Problem

`checks__warn_sumo_metrics_derived__kb_revisions_base__v1` fails in `bqetl_sumo_metrics` with:

```
Error in query string: ... Syntax error: Unexpected ")" at [1:1]
```

The SQL is valid — `bqetl check render` produces two well-formed statements. The corruption happens in `_run_check`, which writes all checks into a single temp file and seeks back to the start of the current check using an offset accumulated from `len(rendered_check)` (characters), while `seek()` operates on bytes. `kb_revisions_base_v1`'s first check contains an em dash in its `ERROR(FORMAT(...))` message, so the offset landed 2 bytes short and `bq` received `);` prepended to check 2.

Any check file with a non-ASCII character in a non-final check hits this. `telemetry_derived/clients_first_seen_v2/checks.sql` has a curly apostrophe in the first of three checks and is affected the same way.

## Fix

- Truncate and rewrite the temp file for each check instead of tracking offsets, so only the current check is ever passed to `bq`. Also adds an explicit `flush()` (previously relied on `seek()` flushing the write buffer).
- Replace the em dashes in `kb_revisions_base_v1/checks.sql` messages with ASCII hyphens, so the failing check is unblocked on the currently deployed image without waiting for the Python fix to ship.
