### PR TITLE
feat(market_research): add user-facing views for market research tables

### DIFF
--- a/sql/moz-fx-data-shared-prod/external/market_research_blogs/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external/market_research_blogs/metadata.yaml
@@ -1,0 +1,7 @@
+friendly_name: Market Research Browser Blog Posts
+description: |-
+  Browser and product vendor blog posts scraped from RSS/Atom feeds, for
+  competitive intelligence on what other browser vendors are announcing.
+  One row per scraped blog post, refreshed weekly as a full reload.
+owners:
+- lmcfall@mozilla.com

--- a/sql/moz-fx-data-shared-prod/external/market_research_blogs/view.sql
+++ b/sql/moz-fx-data-shared-prod/external/market_research_blogs/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.external.market_research_blogs`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.external_derived.market_research_blogs_v1`

--- a/sql/moz-fx-data-shared-prod/external/market_research_jobs/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external/market_research_jobs/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Market Research Competitor Job Postings
+description: |-
+  Competitor job postings scraped from Greenhouse and Teamtailor careers
+  sites, for competitive intelligence on where other browser vendors are
+  hiring. Each weekly run captures a full snapshot of the postings open at
+  that time, so a posting that stays open appears once per `scraped_date` --
+  filter to a single scraped_date to avoid counting the same job more than
+  once. Refreshed weekly as a full reload.
+owners:
+- lmcfall@mozilla.com

--- a/sql/moz-fx-data-shared-prod/external/market_research_jobs/view.sql
+++ b/sql/moz-fx-data-shared-prod/external/market_research_jobs/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.external.market_research_jobs`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.external_derived.market_research_jobs_v1`

--- a/sql/moz-fx-data-shared-prod/external/market_research_releases/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/external/market_research_releases/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: Market Research Browser Releases
+description: |-
+  Browser and product release-note records scraped from vendor release-note
+  pages, for competitive intelligence on what other browser vendors are
+  shipping. One row per release; use `source_type` to distinguish
+  developer_release_notes from user_release_notes. Refreshed weekly as a
+  full reload.
+owners:
+- lmcfall@mozilla.com

--- a/sql/moz-fx-data-shared-prod/external/market_research_releases/view.sql
+++ b/sql/moz-fx-data-shared-prod/external/market_research_releases/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.external.market_research_releases`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.external_derived.market_research_releases_v1`


### PR DESCRIPTION
## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->
Exposes market_research_{blogs,jobs,releases} in the user-facing external dataset so the tables are reachable via mozdata rather than only by their fully qualified external_derived paths.

## Related Tickets & Documents
* [DENG-11287](https://mozilla-hub.atlassian.net/browse/DENG-11287)

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-11287]: https://mozilla-hub.atlassian.net/browse/DENG-11287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ