### PR TITLE
fix: query typo; initiate new backfill

### DIFF
--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/backfill.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/backfill.yaml
@@ -1,10 +1,31 @@
+2026-08-19:
+  start_date: 2026-02-22
+  end_date: 2026-08-12
+  reason: Update new table with historical data.
+  watchers:
+  - mwilliams@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  override_depends_on_past_null_partition: false
+  ignore_date_partition_offset: false
+  query_script_entrypoint: main
+  query_script_date_arg: date
+  query_script_dry_run_arg: --dry-run
+  query_script_args:
+  - --project=moz-fx-data-backfill-slots
+  - --destination_project=moz-fx-data-shared-prod
+  - --destination_dataset=backfills_staging_derived
+  - --destination_table=monitoring__analysis_results_monitoring_v1_2026_08_19
+
 2026-08-18:
   start_date: 2026-02-20
   end_date: 2026-08-12
   reason: Update new table with historical data.
   watchers:
   - mwilliams@mozilla.com
-  status: Initiate
+  status: Cancelled
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/analysis_results_monitoring_v1/query.py
@@ -341,7 +341,7 @@ def build_final_sql(tables: list[bigquery.Row]) -> str:
       COALESCE(f.window_index, s.window_index) AS window_index,
       COALESCE(f.analysis_basis, s.analysis_basis) AS analysis_basis,
       COALESCE(f.segment, s.segment) AS segment,
-      COALESCE(f.metric, s.metric) AS metric
+      COALESCE(f.metric, s.metric) AS metric,
       CASE
         WHEN f.status IS NOT NULL AND s.status IS NOT NULL THEN 'partial'
         WHEN f.status IS NOT NULL THEN 'failed'


### PR DESCRIPTION
## Description

- fixes a silly typo
- cancels the backfill that failed
- initiates a new backfill

## Related Tickets & Documents

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
