### PR TITLE
fix: use env python version for pip cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
         id: restore-venv
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
           path: .venv
       - name: Build
         run: |
@@ -238,7 +238,7 @@ jobs:
         if: steps.restore-venv.outputs.cache-hit != 'true' && github.event.pull_request.head.repo.fork != true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
-          key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+          key: venv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('requirements.txt') }}
           path: .venv
 
   verify-requirements:


### PR DESCRIPTION
## Description

Symptoms:
- intermittent test failures with error that `yaml` cannot be imported
- these failures also report failure to find cache with the specified key
- python versions don't always match between runs (maybe GH is rolling out 3.11.16 in some runners and 3.11.15 is still in place on others?)

Fix:
- instead of using the runner's full version of python, which includes the patch version, use the `env.PYTHON_VERSION` that we already use to specify the python version
- this var should always be consistent with the python on the runner

Other
- we could change the env var to include the patch version as a separate or additional fix

## Related Tickets & Documents


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
