### PR TITLE
fix(firefox_desktop): schedule safe_browsing_interstitials on its own DAG

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2850,3 +2850,28 @@ bqetl_socorro_import:
     depends_on_past: false
   tags:
     - impact/tier_2
+
+bqetl_safe_browsing:
+  catchup: false
+  default_args:
+    depends_on_past: false
+    email:
+      - telemetry-alerts@mozilla.com
+      - lcrouch@mozilla.com
+    email_on_failure: true
+    email_on_retry: true
+    end_date: null
+    max_active_tis_per_dag: null
+    owner: lcrouch@mozilla.com
+    retries: 2
+    retry_delay: 30m
+    start_date: '2025-09-01'
+  description: 'Daily aggregation of the Safe Browsing interstitial funnel for Firefox
+    Desktop: about:blocked warning page displays and the button presses users make
+    on them.'
+  max_active_runs: null
+  repo: bigquery-etl
+  schedule_interval: 0 4 * * *
+  tags:
+    - impact/tier_3
+    - repo/bigquery-etl

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/metadata.yaml
@@ -24,7 +24,7 @@ labels:
   incremental: true
   owner1: lcrouch
 scheduling:
-  dag_name: bqetl_default
+  dag_name: bqetl_safe_browsing
 bigquery:
   time_partitioning:
     type: day


### PR DESCRIPTION
## Description
`safe_browsing_interstitials_v1` was scheduled on `bqetl_default`, which is paused in Airflow and has never run. Its only other member is `bqetl_default_task_v1`, a no-op placeholder that exists to keep the DAG valid. Tables placed on `bqetl_default` never populate, and nothing warns you: `dags.yaml` documents it as the destination for queries created without an explicit `--dag`.

Add `bqetl_safe_browsing` and point the table at it, following the feature-scoped DAG convention used by `bqetl_newtab`, `bqetl_urlbar` and `bqetl_pageload_v1`.

Schedule and tier match what `bqetl_default` would have given the table (`0 4 * * *`, `impact/tier_3`), so this changes where it runs, not when. start_date is 2025-09-01, when `page.load_error` first recorded data; catchup defaults to false, so deploying this does not trigger a backfill. History still needs a managed backfill entry.

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
