### PR TITLE
chore(DENG-11356): complete Play Store attribution sidefill for firefox_android_clients

### DIFF
--- a/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/backfill.yaml
@@ -23,7 +23,7 @@
     so a run overlapping the copy loop would silently revert partitions already copied.
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   custom_query_path: sql/moz-fx-data-shared-prod/fenix_derived/firefox_android_clients_v1/backfill_deng_11356.sql
   override_depends_on_past_null_partition: true
   override_depends_on_past_end_date: true


### PR DESCRIPTION
Marks the `2026-07-31` backfill entry for `fenix_derived.firefox_android_clients_v1` as `Complete` so the staging partitions are copied into production. Completes the sidefill initiated in #9744 for [DENG-11356](https://mozilla-hub.atlassian.net/browse/DENG-11356).

One line: `status: Initiate` → `status: Complete`.

## ⚠️ Before merging

**Pause `bqetl_analytics_tables.firefox_android_clients`, unpause after the copy finishes.** Completion copies staging partitions in one at a time ([backfill.py:1412-1427](https://github.com/mozilla/bigquery-etl/blob/main/bigquery_etl/cli/backfill.py#L1412-L1427)) while the scheduled task overwrites the whole table each run (`date_partition_parameter: null`), so an overlapping run would silently revert partitions already copied.

## Validation

Staging (`backfills_staging_derived.fenix_derived__firefox_android_clients_v1_2026_07_31`) is fully built: 116 partitions, `first_seen_date` 2026-04-06 → 2026-07-30, matching `start_date`/`end_date`.

Recomputed the `play_store_attribution` ping independently and compared per partition, over 1,270,129 attributed clients — **0 missing values, 0 conflicts, 0 `__ping_datetime` mismatches**. Untouched columns vs prod: **0 row-count diffs, 0 duplicate `client_id`s, 0 `adjust_network`/`install_source` diffs**.

Expected effect, non-empty `play_store_attribution_term` over the window: **15,841 → 362,264**. (Non-empty, not non-null — the pre-fix path wrote empty strings, so `IS NOT NULL` hides the regression.)

| `first_seen_date` | campaign | term |
|---|---|---|
| 2026-04-06 | 6,683 → 6,706 | 3,447 → 3,480 |
| 2026-04-09 | 755 → 7,356 | 395 → 3,477 |
| 2026-05-15 | 35 → 9,207 | 17 → 2,811 |
| 2026-07-01 | 31 → 17,175 | 13 → 3,614 |
| 2026-07-30 | 15,068 → 15,068 | 3,658 → 3,658 |

2026-07-01 reproduces #9744's figure (3,617 there, 3,614 now — late-arriving pings). The flat rows are expected: the old path still worked on 04-06, and #9740 was live by 07-30. `end_date` 2026-07-30 meets the fix's first correct partition, so no `first_seen_date` is left permanently NULL.

No downstream backfill needed — no consumer reads `play_store_attribution_*`.

[DENG-11356]: https://mozilla-hub.atlassian.net/browse/DENG-11356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ