### PR TITLE
chore(DENG-11237): complete backfill for referral_installs_daily_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_referral_derived/referral_installs_daily_v1/backfill.yaml
@@ -7,7 +7,7 @@
     is never present in attribution data.'
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
Completes the backfill (step 2 of 2). Flips `status: Initiate` → `Complete`, which backs up prod and swaps in the staged 2026-08-17 partition.

**Merge order:** #9792 → #9795 → this.

**Do not merge until the staged data is checked.** It should show exactly:

| invite_code | install_count | normalized_channel |
|---|---|---|
| `1WYYSNCNGE6S7WKGF` | 2 | nightly |
| `1SKKBY6ZV9YWKHRXZ` | 2 | nightly |

Anything else — set the entry to `Cancelled` instead.