### PR TITLE
feat(MZCLD-3566): Introduce view of live sanitized search terms by Merino

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -388,6 +388,7 @@ schema:
     skip:
     # see comment in query file
     - sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/query.sql
+    - sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v4/view.sql
     - sql/moz-fx-data-shared-prod/*_stable/**
 
 docs:

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v4/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v4/metadata.yaml
@@ -1,0 +1,18 @@
+friendly_name: Sanitized Firefox Search Terms Straight from Search Requests
+description: |-
+  A sanitized variant of search terms submitted to Firefox.
+
+  Replaces merino_log_sanitized_v3. Where v3 was a table populated by a daily
+  sanitization job reading unsanitized logs out of a sequestered project, this
+  view reads terms that merino-fleece sanitized in-line, routed by Cloud Logging
+  sink into the merino tenant project. No unsanitized search terms are persisted.
+
+  This is not an authorized view: readers need access to the underlying dataset,
+  granted in webservices-infra/merino/tf/prod/bigquery.tf. See MZCLD-3566.
+owners:
+  - najiang@mozilla.com
+  - csadilek@mozilla.com
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:search-terms/sanitized

--- a/sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v4/view.sql
+++ b/sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v4/view.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.search_terms_derived.merino_log_sanitized_v4`
+AS
+SELECT
+  `timestamp`,
+  -- See field request_id in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  jsonPayload.fields.request_id AS request_id,
+  -- See field query in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  -- The values of query are sanitized directly in Merino.
+  jsonPayload.fields.query AS query,
+  -- See fields country, region, and dma in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  -- Merino emits the string 'none' rather than NULL for missing geo fields.
+  -- City is deliberately not propagated, matching merino_log_sanitized_v3.
+  NULLIF(CAST(jsonPayload.fields.country AS STRING), 'none') AS country,
+  NULLIF(CAST(jsonPayload.fields.region AS STRING), 'none') AS region,
+  NULLIF(CAST(jsonPayload.fields.dma AS STRING), 'none') AS dma,
+  -- See field form_factor in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  jsonPayload.fields.form_factor AS form_factor,
+  -- See field browser in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  jsonPayload.fields.browser AS browser,
+  -- See field os_family in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  jsonPayload.fields.os_family AS os_family,
+  -- See field session_id in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  jsonPayload.fields.session_id AS session_id,
+  -- See field sequence_no in sql/moz-fx-data-shared-prod/search_terms_derived/dataset_schema.yaml
+  CAST(jsonPayload.fields.sequence_no AS INT64) AS sequence_no,
+FROM
+  `moz-fx-merino-prod-5de4.search_terms.stdout`


### PR DESCRIPTION
The new merino_log_sanitized_v4 is using the same schema as v3 to allow for easy migration of downstream consumers such as suggest_impression_sanitized_v3.

In contrast to v3, v4 is a view of *live* sanitized data provided by Merino. Once all downstream consumers have been  migrated, we will be able to decommission the daily sanitization job and its sequestered environment. No un-sanitized data will be persisted.

The commit is authored by @whd, thank you! @ncloudioj and I have tested the change. We will continue to scale and test Merino sanitization before we eventually point the downstream consumers to v4.

I have provided change control approval in the ticket (see [comment](https://mozilla-hub.atlassian.net/browse/MZCLD-3566?focusedCommentId=1642517)), and here explicitly. If an additional / separate DENG ticket is preferred, please let me know!

## Related Tickets & Documents
* [MZCLD-3566](https://mozilla-hub.atlassian.net/browse/MZCLD-3566)


[MZCLD-3566]: https://mozilla-hub.atlassian.net/browse/MZCLD-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ