### PR TITLE
chore: remove unneeded config to skip deployment of merino_log_sanitized_v4

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -388,7 +388,6 @@ schema:
     skip:
     # see comment in query file
     - sql/moz-fx-data-shared-prod/search_terms_derived/suggest_impression_sanitized_v2_external/query.sql
-    - sql/moz-fx-data-shared-prod/search_terms_derived/merino_log_sanitized_v4/view.sql
     - sql/moz-fx-data-shared-prod/*_stable/**
 
 docs:


### PR DESCRIPTION
This is just a follow-up of https://github.com/mozilla/bigquery-etl/pull/9809 to remove the unnecessary (and incorrect) config it introduced (see https://github.com/mozilla/bigquery-etl/pull/9809#discussion_r3833564629).
