### PR TITLE
feat(DENG-11530): mark suggest_revenue_levers_daily_v1, sponsored_tiles_clients_daily_v1, and adm_forecasting_v1 as deprecated

### DIFF
--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/adm_forecasting_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/adm_forecasting_v1/metadata.yaml
@@ -14,3 +14,4 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/contextual_services_derived/suggest_revenue_levers_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/contextual_services_derived/suggest_revenue_levers_daily_v1/metadata.yaml
@@ -19,3 +19,4 @@ bigquery:
     field: submission_date
     require_partition_filter: true
     expiration_days: null
+deprecated: true

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/sponsored_tiles_clients_daily_v1/metadata.yaml
@@ -25,3 +25,4 @@ bigquery:
     - normalized_channel
     - sample_id
 require_column_descriptions: false
+deprecated: true


### PR DESCRIPTION
# feat(DENG-11530): mark suggest_revenue_levers_daily_v1, sponsored_tiles_clients_daily_v1, and adm_forecasting_v1 as deprecated

Those are downstream of unified_metrics_v1 and appear to be no longer be in use (based on lineage and conversations).

relates to: https://github.com/mozilla/bigquery-etl/pull/9468 (PR to mark unified_metrics as deprecated)

Once this is merged and we confirm we can proceed forward a follow-up PR will be opened to remove scheduling from those queries.