### PR TITLE
feat: add fxa_email_domain_counts_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/fxa_email_domain_counts_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/fxa_email_domain_counts_v1/metadata.yaml
@@ -1,0 +1,46 @@
+friendly_name: FxA Email Domain Counts
+description: |-
+  Daily per-domain rollup of FxA primary email addresses, grouped by registrable
+  domain (eTLD+1). One row per (as_of_date, registrable_domain). Supports fraud
+  and abuse analysis -- domain velocity, email verification rate, and subdomain
+  fan-out -- from a table that contains no email addresses, so it can back a
+  broadly readable dashboard.
+
+  Only domains with accounts created in the trailing 28 days are emitted: of the ~121k
+  domains holding 10+ accounts, only ~2.7% gain an account on a given day, so a
+  full snapshot would spend most of every partition restating unchanged totals.
+  A per-domain time series therefore has gaps on quiet stretches -- use the
+  window columns rather than differencing `accounts` across dates. Authoritative
+  account totals live in `monitoring_db_counts_v1`, not here.
+
+  Domains with fewer than 10 total accounts are pooled into a single
+  `__below_threshold__` row instead of being published individually, because a
+  low-count personal or vanity domain effectively identifies its owner. Filter
+  that row out for per-domain analysis; watch it on its own for sprays
+  distributed across thousands of individually-tiny throwaway domains.
+owners:
+- wclouser@mozilla.com
+labels:
+  incremental: true
+  owner1: wclouser@mozilla.com
+scheduling:
+  dag_name: bqetl_accounts_derived
+  date_partition_parameter: as_of_date
+  # Adjust the execution delta for the task dependency in the bqetl_accounts_db
+  # DAG so this depends on the latest bqetl_accounts_db DAG run. The emails
+  # mirror refreshes every 3h and the query time-travels to 02:30 UTC to read a
+  # complete as_of_date; this dependency is what guarantees the 01:30 import has
+  # landed before we snapshot it.
+  depends_on:
+  - dag_name: bqetl_accounts_db
+    task_id: accounts_db_external__fxa_emails__v1
+    execution_delta: -20h
+bigquery:
+  time_partitioning:
+    type: day
+    field: as_of_date
+    require_partition_filter: false
+    expiration_days: null
+  clustering:
+    fields:
+    - registrable_domain

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/fxa_email_domain_counts_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/fxa_email_domain_counts_v1/query.sql
@@ -1,0 +1,139 @@
+-- Daily per-domain rollup of FxA primary email addresses. One row per
+-- (as_of_date, registrable_domain).
+--
+-- Publishes the domain-level shape that the fraud detection scripts already
+-- compute privately, so it can be graphed on a broadly readable dashboard
+-- without exposing addresses. Accounts are grouped by registrable domain
+-- (eTLD+1, via the PSL-aware NET.REG_DOMAIN) rather than by the full host, so
+-- subdomain-spray campaigns -- where every account uses a unique throwaway
+-- subdomain -- collapse into one row instead of vanishing as thousands of
+-- single-account hosts. `distinct_hosts` preserves the fan-out they produce.
+--
+-- Only domains with activity in the trailing 28 days are emitted. Of the ~121k
+-- domains holding 10+ accounts, just ~2.7% gain an account on any given day, so
+-- a full daily snapshot would spend 97% of every partition restating unchanged
+-- cumulative totals. Restricting to the active set is ~23k rows/day instead of
+-- ~121k, and a domain dormant for a month is not a live fraud signal. Note the
+-- consequence: a per-domain time series has gaps on quiet stretches, so use the
+-- window columns rather than differencing `accounts` across dates. Authoritative
+-- account totals live in `monitoring_db_counts_v1`, not here.
+--
+-- Verified flags reflect state at the 02:30 snapshot, so a registration late on
+-- as_of_date has had less time to confirm than one early in the day. Expect a
+-- small systematic dip in verified share for late-day cohorts.
+--
+-- Verified counts are emitted per window as well as cumulatively, because the
+-- cumulative ratio is useless as a signal: it sits at ~99.9% for every large
+-- provider (gmail.com included), since unverified accounts get cleaned up. It is
+-- the verified share of *recent* registrations that separates an attacker
+-- confirming their own signups from ordinary traffic.
+--
+-- Domains with fewer than 10 accounts are pooled into a single
+-- `__below_threshold__` row rather than published individually: a personal or
+-- vanity domain with one account effectively names its owner. The pooled row is
+-- itself a signal -- a spray distributed across thousands of tiny throwaway
+-- domains shows up there and nowhere else.
+WITH primary_emails AS (
+  SELECT
+    LOWER(REGEXP_EXTRACT(email, r'@(.+)$')) AS host,
+    isVerified,
+    createdAt
+  FROM
+    `moz-fx-data-shared-prod.accounts_db_external.fxa_emails_v1`
+    -- Snapshot at 02:30 UTC the morning after as_of_date, not at midnight.
+    -- bqetl_accounts_db refreshes this mirror on `30 1/3 * * *`, so a midnight
+    -- snapshot only sees what the 22:30 run captured and silently drops the
+    -- day's last ~1.5 hours of registrations (~4.7% of a day, measured). Those
+    -- rows never reappear either: the next partition counts createdAt >=
+    -- as_of_date + 1, so they fall out of new_accounts_1d entirely while still
+    -- landing in the 7d/28d windows -- an inconsistency within a single row,
+    -- and a blind spot a campaign could sit in. 02:30 is after the 01:30 run
+    -- has imported all of as_of_date, and is this ETL's own schedule
+    -- (bqetl_accounts_derived, `30 2 * * *`), so it is never in the future.
+    FOR SYSTEM_TIME AS OF TIMESTAMP(DATETIME(@as_of_date + 1, TIME '02:30:00'), 'UTC')
+  WHERE
+    isPrimary = TRUE
+    AND email LIKE '%@%'
+    -- Reading past midnight to get a complete day means also excluding the next
+    -- day's rows, so every count below is bounded to as_of_date.
+    AND createdAt < TIMESTAMP(@as_of_date + 1, 'UTC')
+),
+windowed AS (
+  SELECT
+    NET.REG_DOMAIN(host) AS registrable_domain,
+    host,
+    isVerified,
+    createdAt,
+    createdAt >= TIMESTAMP(@as_of_date, 'UTC') AS in_1d,
+    createdAt >= TIMESTAMP(DATE_SUB(@as_of_date, INTERVAL 6 DAY), 'UTC') AS in_7d,
+    createdAt >= TIMESTAMP(DATE_SUB(@as_of_date, INTERVAL 27 DAY), 'UTC') AS in_28d
+  FROM
+    primary_emails
+),
+per_domain AS (
+  SELECT
+    registrable_domain,
+    COUNT(*) AS accounts,
+    COUNTIF(isVerified) AS verified_accounts,
+    COUNTIF(in_1d) AS new_accounts_1d,
+    COUNTIF(in_1d AND isVerified) AS verified_new_accounts_1d,
+    COUNTIF(in_7d) AS new_accounts_7d,
+    COUNTIF(in_7d AND isVerified) AS verified_new_accounts_7d,
+    COUNTIF(in_28d) AS new_accounts_28d,
+    COUNTIF(in_28d AND isVerified) AS verified_new_accounts_28d,
+    COUNT(DISTINCT host) AS distinct_hosts,
+    COUNT(DISTINCT IF(in_28d, host, NULL)) AS distinct_hosts_28d,
+    MIN(createdAt) AS first_account_at,
+    MAX(createdAt) AS last_account_at
+  FROM
+    windowed
+  WHERE
+    registrable_domain IS NOT NULL
+  GROUP BY
+    registrable_domain
+  HAVING
+    new_accounts_28d > 0
+)
+SELECT
+  @as_of_date AS as_of_date,
+  registrable_domain,
+  accounts,
+  verified_accounts,
+  new_accounts_1d,
+  verified_new_accounts_1d,
+  new_accounts_7d,
+  verified_new_accounts_7d,
+  new_accounts_28d,
+  verified_new_accounts_28d,
+  distinct_hosts,
+  distinct_hosts_28d,
+  first_account_at,
+  last_account_at,
+  CAST(NULL AS INT64) AS domains_pooled
+FROM
+  per_domain
+WHERE
+  accounts >= 10
+UNION ALL
+-- The pooled low-count tail, emitted as one row so a spray across thousands of
+-- individually-tiny throwaway domains stays visible in aggregate.
+SELECT
+  @as_of_date AS as_of_date,
+  '__below_threshold__' AS registrable_domain,
+  SUM(accounts) AS accounts,
+  SUM(verified_accounts) AS verified_accounts,
+  SUM(new_accounts_1d) AS new_accounts_1d,
+  SUM(verified_new_accounts_1d) AS verified_new_accounts_1d,
+  SUM(new_accounts_7d) AS new_accounts_7d,
+  SUM(verified_new_accounts_7d) AS verified_new_accounts_7d,
+  SUM(new_accounts_28d) AS new_accounts_28d,
+  SUM(verified_new_accounts_28d) AS verified_new_accounts_28d,
+  SUM(distinct_hosts) AS distinct_hosts,
+  SUM(distinct_hosts_28d) AS distinct_hosts_28d,
+  MIN(first_account_at) AS first_account_at,
+  MAX(last_account_at) AS last_account_at,
+  COUNT(*) AS domains_pooled
+FROM
+  per_domain
+WHERE
+  accounts < 10

--- a/sql/moz-fx-data-shared-prod/accounts_backend_derived/fxa_email_domain_counts_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/accounts_backend_derived/fxa_email_domain_counts_v1/schema.yaml
@@ -1,0 +1,92 @@
+fields:
+- name: as_of_date
+  type: DATE
+  mode: NULLABLE
+  description: >-
+    The date the domain counts were captured for, read from a snapshot of the
+    emails mirror taken at the end of this day. Used as the partition column.
+- name: registrable_domain
+  type: STRING
+  mode: NULLABLE
+  description: >-
+    The registrable domain (eTLD+1) of the account's primary email address, via
+    NET.REG_DOMAIN. Subdomains roll up into their parent, so a subdomain-spray
+    campaign appears as one row. The literal `__below_threshold__` is the pooled
+    tail of all domains with fewer than 10 accounts; exclude it for per-domain
+    analysis, and watch it on its own for sprays spread across thousands of
+    individually-tiny throwaway domains.
+- name: accounts
+  type: INTEGER
+  mode: NULLABLE
+  description: >-
+    Total accounts whose primary email address is on this domain, as of the
+    snapshot. Cumulative, not a daily delta. Because only domains active in the
+    trailing 28 days are emitted, this series has gaps -- do not difference it
+    across dates to derive growth; use the window columns instead.
+- name: verified_accounts
+  type: INTEGER
+  mode: NULLABLE
+  description: >-
+    Of all accounts on this domain, how many have a verified primary email.
+    Useful as a base rate only: this ratio sits at ~99.9% for every large
+    provider, so it does not discriminate. Use the per-window verified counts
+    below to judge a campaign.
+- name: new_accounts_1d
+  type: INTEGER
+  mode: NULLABLE
+  description: Accounts on this domain created on as_of_date.
+- name: verified_new_accounts_1d
+  type: INTEGER
+  mode: NULLABLE
+  description: >-
+    Of new_accounts_1d, how many have a verified primary email. A near-100%
+    share on a domain that is accumulating accounts quickly is the signal that
+    an attacker controls the domain's MX and is confirming their own signups.
+    Verified state is read at 02:30 UTC the morning after as_of_date, so a
+    registration late in the day has had less time to confirm than one early in
+    the day; expect a small systematic dip for late-day cohorts.
+- name: new_accounts_7d
+  type: INTEGER
+  mode: NULLABLE
+  description: Accounts on this domain created in the 7 days ending on as_of_date.
+- name: verified_new_accounts_7d
+  type: INTEGER
+  mode: NULLABLE
+  description: Of new_accounts_7d, how many have a verified primary email.
+- name: new_accounts_28d
+  type: INTEGER
+  mode: NULLABLE
+  description: Accounts on this domain created in the 28 days ending on as_of_date.
+- name: verified_new_accounts_28d
+  type: INTEGER
+  mode: NULLABLE
+  description: Of new_accounts_28d, how many have a verified primary email.
+- name: distinct_hosts
+  type: INTEGER
+  mode: NULLABLE
+  description: >-
+    Distinct full email hosts seen under this registrable domain. Large values
+    relative to `accounts` mean a subdomain spray, where each account uses its
+    own throwaway host.
+- name: distinct_hosts_28d
+  type: INTEGER
+  mode: NULLABLE
+  description: >-
+    Distinct full email hosts among accounts created in the 28 days ending on
+    as_of_date. Separates an active subdomain spray from one that has stopped.
+- name: first_account_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: >-
+    When the earliest account on this domain was created. A recent value on a
+    domain with many accounts means the domain is new, which raises suspicion.
+- name: last_account_at
+  type: TIMESTAMP
+  mode: NULLABLE
+  description: When the most recent account on this domain was created.
+- name: domains_pooled
+  type: INTEGER
+  mode: NULLABLE
+  description: >-
+    How many distinct domains are pooled into this row. Only set on the
+    `__below_threshold__` row; NULL for named domains.


### PR DESCRIPTION
## Description

Daily per-domain rollup of FxA primary email addresses for fraud analysis: velocity, verification rate, and subdomain fan-out. Contains no addresses, so it can back a broadly readable dashboard.

Emits only domains active in the trailing 28 days, and pools domains under 10 accounts into one row so vanity domains are never named.

## Related Tickets & Documents
* FXA-14404

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
