### PR TITLE
fix(glean_usage): Fix `event_counts_glean_v2` bug when the final dataset has multiple events tables

### DIFF
--- a/sql_generators/glean_usage/templates/event_counts_glean_v2.query.sql
+++ b/sql_generators/glean_usage/templates/event_counts_glean_v2.query.sql
@@ -55,7 +55,7 @@ WITH
       *
     FROM
       {{ dataset['bq_dataset_family'] }}_{{ events_table }}
-    {% if not outer_loop.last -%}
+    {% if not (outer_loop.last and loop.last) -%}
       UNION ALL
     {% endif -%}
   {% endfor %}


### PR DESCRIPTION
## Description
This is currently causing SQL generation to fail ([example](https://github.com/mozilla/bigquery-etl/actions/runs/32775195543/job/97584657198)).

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/9212

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
