### PR TITLE
fix: skip dry run for fxa_email_domain_counts_v1

### DIFF
--- a/bqetl_project.yaml
+++ b/bqetl_project.yaml
@@ -110,6 +110,7 @@ dry_run:
   - sql/moz-fx-data-shared-prod/sumo_metrics_derived/translation_daily_locale_base_v1/query.sql
   - sql/moz-fx-data-shared-prod/sumo_metrics_derived/freshness_metrics_base_v1/query.sql
   # uses time travel, will error on dates prior to the time travel window
+  - sql/moz-fx-data-shared-prod/accounts_backend_derived/fxa_email_domain_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend_derived/monitoring_db_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_backend_derived/monitoring_db_recovery_phones_counts_v1/query.sql
   - sql/moz-fx-data-shared-prod/accounts_db_external/**/*.sql


### PR DESCRIPTION
Follow-up to #9817.

`fxa_email_domain_counts_v1` reads `accounts_db_external` tables with `FOR SYSTEM_TIME AS OF`. Dry running it in stage fails because the stage version of the table was just created and didn't exist at the timestamp the query time travels to, so it needs to be on the dry run skip list alongside the other time-travel queries.

Requested by @sean-rose in https://github.com/mozilla/bigquery-etl/pull/9817.