### PR TITLE
[AIMOD-1468] Swapped engagement stratification in new tab engagement artifacts

### DIFF
--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_extract_v3/query.sql
@@ -2,7 +2,12 @@ WITH experiment_configs AS (
   SELECT
     *
   FROM
-    UNNEST([STRUCT('DE' AS region, 'publisher-constraint-in-germany' AS experiment_slug)])
+    UNNEST(
+      [
+        STRUCT('GB' AS region, 'hourly-seasonality-in-gb' AS experiment_slug),
+        STRUCT('FR' AS region, 'fixed-tile-in-fr' AS experiment_slug)
+      ]
+    )
 ),
 private_pings AS (
   SELECT

--- a/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/telemetry_derived/newtab_merino_priors_v1/query.sql
@@ -21,7 +21,12 @@ experiment_configs AS (
   SELECT
     *
   FROM
-    UNNEST([STRUCT('DE' AS region, 'publisher-constraint-in-germany' AS experiment_slug)])
+    UNNEST(
+      [
+        STRUCT('GB' AS region, 'hourly-seasonality-in-gb' AS experiment_slug),
+        STRUCT('FR' AS region, 'fixed-tile-in-fr' AS experiment_slug)
+      ]
+    )
 ),
 corpus_items AS (
   SELECT DISTINCT


### PR DESCRIPTION
## Description

The DE publisher constraint experiment has ended, so we will stop stratification there.

We want to run two new experiments. One in GB and another in FR. This PR adds stratification for those experiments.

## Related Tickets & Documents
* AIMOD-1468


**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
