### PR TITLE
fix(monitoring): bound enrollment funnel scan window to 90 days (bug 2066888)

### DIFF
--- a/sql/moz-fx-data-experiments/monitoring/experiment_enrollment_funnel_v1/metadata.yaml
+++ b/sql/moz-fx-data-experiments/monitoring/experiment_enrollment_funnel_v1/metadata.yaml
@@ -4,7 +4,8 @@ description: |-
   Exports a current-state enrollment funnel snapshot for each live recipe to GCS
   for use by Experimenter visualization and alerting. Covers firefox_desktop,
   firefox_ios, and fenix. For each client-recipe pair, uses the client's most
-  recent evaluation. Groups by (app_name, slug, branch, status, reason, conflict_slug)
+  recent evaluation, considering only evaluations from the last 90 days (matching
+  the window of recipes included). Groups by (app_name, slug, branch, status, reason, conflict_slug)
   with an estimated client count (1% sample scaled by 100). Does not create any BigQuery artifacts.
 owners:
   - ykhurana@mozilla.com

--- a/sql/moz-fx-data-experiments/monitoring/experiment_enrollment_funnel_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experiment_enrollment_funnel_v1/query.py
@@ -15,12 +15,19 @@ Exports as JSON to GCS for the Experimenter ingestion task to consume.
 import json
 import logging
 from argparse import ArgumentParser
-from datetime import date
+from datetime import date, timedelta
 
 from google.cloud import bigquery, storage
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+# Only each client's most recent evaluation is used, so the scan window need only
+# be long enough to capture every active client's latest nimbus_targeting_context
+# ping. Without this bound, never-ending rollouts (end_date IS NULL) pin the window
+# open to the earliest start_date (3+ years), which pushed the task past BigQuery's
+# 6h job limit. See bug 2066888.
+SCAN_WINDOW_DAYS = 30
 
 MIN_START_QUERY = """
 SELECT MIN(start_date) AS min_start_date
@@ -160,6 +167,11 @@ def main():
             bucket.blob(path).upload_from_string(empty, content_type="application/json")
         return
 
+    # Bound the scan to the recent window. The funnel uses only each client's most
+    # recent evaluation, so pings older than SCAN_WINDOW_DAYS are always superseded
+    # and need not be scanned; this keeps the job well under the 6h limit (bug 2066888).
+    scan_start_date = max(min_start_date, run_date - timedelta(days=SCAN_WINDOW_DAYS))
+
     rows = list(
         bq_client.query(
             FUNNEL_QUERY,
@@ -167,7 +179,7 @@ def main():
                 query_parameters=[
                     bigquery.ScalarQueryParameter("run_date", "DATE", run_date),
                     bigquery.ScalarQueryParameter(
-                        "min_start_date", "DATE", min_start_date
+                        "min_start_date", "DATE", scan_start_date
                     ),
                 ]
             ),

--- a/sql/moz-fx-data-experiments/monitoring/experiment_enrollment_funnel_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experiment_enrollment_funnel_v1/query.py
@@ -22,12 +22,19 @@ from google.cloud import bigquery, storage
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Only each client's most recent evaluation is used, so the scan window need only
-# be long enough to capture every active client's latest nimbus_targeting_context
-# ping. Without this bound, never-ending rollouts (end_date IS NULL) pin the window
-# open to the earliest start_date (3+ years), which pushed the task past BigQuery's
-# 6h job limit. See bug 2066888.
-SCAN_WINDOW_DAYS = 30
+# Bound the nimbus_targeting_context scan window. Only each client's most recent
+# evaluation is used, so pings older than this are always superseded.
+#
+# This MUST stay >= the active_experiments horizon (end_date >= run_date - 90d):
+# recipes that ended within that horizon are still exported, but their clients stop
+# emitting enrollment_status events around their end_date, so a shorter scan would
+# make those slugs produce zero rows and disappear from the funnel entirely rather
+# than shrink. Keep the two windows equal at 90 days.
+#
+# Without any bound, never-ending rollouts (end_date IS NULL) pin the window open to
+# the earliest start_date (3+ years), which pushed the task past BigQuery's 6h job
+# limit. See bug 2066888.
+SCAN_WINDOW_DAYS = 90
 
 MIN_START_QUERY = """
 SELECT MIN(start_date) AS min_start_date
@@ -57,7 +64,7 @@ all_apps_raw AS (
     t.submission_timestamp
   FROM `moz-fx-data-shared-prod.firefox_desktop.nimbus_targeting_context` t,
   UNNEST(t.events) AS event
-  WHERE DATE(t.submission_timestamp) BETWEEN @min_start_date AND @run_date
+  WHERE DATE(t.submission_timestamp) BETWEEN @scan_start_date AND @run_date
     AND t.sample_id = 0
     AND event.category = 'nimbus_events'
     AND event.name = 'enrollment_status'
@@ -76,7 +83,7 @@ all_apps_raw AS (
     t.submission_timestamp
   FROM `moz-fx-data-shared-prod.org_mozilla_ios_firefox.nimbus_targeting_context` t,
   UNNEST(t.events) AS event
-  WHERE DATE(t.submission_timestamp) BETWEEN @min_start_date AND @run_date
+  WHERE DATE(t.submission_timestamp) BETWEEN @scan_start_date AND @run_date
     AND t.sample_id = 0
     AND event.category = 'nimbus_events'
     AND event.name = 'enrollment_status'
@@ -95,7 +102,7 @@ all_apps_raw AS (
     t.submission_timestamp
   FROM `moz-fx-data-shared-prod.fenix.nimbus_targeting_context` t,
   UNNEST(t.events) AS event
-  WHERE DATE(t.submission_timestamp) BETWEEN @min_start_date AND @run_date
+  WHERE DATE(t.submission_timestamp) BETWEEN @scan_start_date AND @run_date
     AND t.sample_id = 0
     AND event.category = 'nimbus_events'
     AND event.name = 'enrollment_status'
@@ -179,7 +186,7 @@ def main():
                 query_parameters=[
                     bigquery.ScalarQueryParameter("run_date", "DATE", run_date),
                     bigquery.ScalarQueryParameter(
-                        "min_start_date", "DATE", scan_start_date
+                        "scan_start_date", "DATE", scan_start_date
                     ),
                 ]
             ),


### PR DESCRIPTION
## Description

This PR fixes `monitoring__experiment_enrollment_funnel__v1` scanning an unbounded window that exceeded BigQuery's 6h job limit.

The funnel query keeps only **each client's most recent evaluation** (`ROW_NUMBER() ... ORDER BY submission_timestamp DESC`, `WHERE rn = 1`), so it is a current-state snapshot and does not need old pings. However, `min_start_date` is derived from experiments where `end_date IS NULL OR end_date >= run_date - 90d`, and never-ending rollouts (`end_date IS NULL`, e.g. the relay-integration and product-insight-telemetry rollouts from 2023) pin the window open to the earliest `start_date`. As of 2026-08-26 that was `2023-06-06` — a **1,177-day scan** of three `nimbus_targeting_context` tables with `UNNEST(events)`, which ran 0.12h (Aug 23) → 5.77h (Aug 25) → over the 6h ceiling (Aug 26) as the cluster slowed down.

**Fix:** bound the scan to `SCAN_WINDOW_DAYS` via `max(min_start_date, run_date - 90d)`, resolved in Python so BigQuery still prunes partitions on literal date bounds. The window is set to **90 days to match the `active_experiments` horizon** (`end_date >= run_date - 90d`) — see the review discussion below. That is still a ~13× reduction from the 1,177-day scan and comfortably under the 6h limit.

**Behavior:** because the scan window equals the recipe horizon, every recipe that `active_experiments` selects is still fully represented; no slug drops out. The only clients excluded are those whose most recent evaluation is older than 90 days — i.e. inactive clients that shouldn't appear in a current-state snapshot anyway.

## Related Tickets & Documents
* https://bugzilla.mozilla.org/show_bug.cgi?id=2066888
* DENG-10831 (cluster-wide slot-usage slowdown — the trigger; this PR is the independent per-task fix)

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
