### PR TITLE
fix(firefox_desktop): coalesce null join keys in safe_browsing_inters…

### DIFF
--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/checks.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/checks.sql
@@ -1,5 +1,11 @@
+-- Every column in the two checks below is a FULL OUTER JOIN key in query.sql.
+-- NULL never matches NULL in a join, so a null key leaves the displays half and
+-- the actions half of one group as two separate rows, which the uniqueness check
+-- reads as a duplicate. The query coalesces each key to '??'; not_null holds that
+-- line.
+
 #fail
-{{ not_null(["submission_date", "threat_type", "scope"], "submission_date = @submission_date") }}
+{{ not_null(["submission_date", "normalized_channel", "normalized_os", "country", "threat_type", "scope"], "submission_date = @submission_date") }}
 
 #fail
 {{ is_unique(["submission_date", "normalized_channel", "normalized_os", "country", "threat_type", "scope"], "submission_date = @submission_date") }}

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/query.sql
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/query.sql
@@ -29,8 +29,11 @@
 WITH base AS (
   SELECT
     DATE(submission_timestamp) AS submission_date,
-    normalized_channel,
-    normalized_os,
+    -- '??' rather than NULL on every dimension, because these are the FULL OUTER
+    -- JOIN keys below and NULL never matches NULL. A null channel splits one
+    -- group into a displays-only row and an actions-only row.
+    IFNULL(normalized_channel, '??') AS normalized_channel,
+    IFNULL(normalized_os, '??') AS normalized_os,
     IFNULL(normalized_country_code, '??') AS country,
     client_info.client_id AS client_id,
     metrics.dual_labeled_counter.page_load_error AS page_load_error,

--- a/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/firefox_desktop_derived/safe_browsing_interstitials_v1/schema.yaml
@@ -6,11 +6,13 @@ fields:
 - name: normalized_channel
   type: STRING
   mode: NULLABLE
-  description: Normalized release channel, e.g. release, beta, nightly.
+  description: >
+    Normalized release channel, e.g. release, beta, nightly, or '??' when the
+    ping did not report one.
 - name: normalized_os
   type: STRING
   mode: NULLABLE
-  description: Normalized operating system name.
+  description: Normalized operating system name, or '??' when unknown.
 - name: country
   type: STRING
   mode: NULLABLE


### PR DESCRIPTION
…titials

normalized_channel is NULL on a handful of rows every day. NULL never matches NULL in a join, so the displays half and the actions half of those groups never met across the FULL OUTER JOIN, and each stayed as its own row. The is_unique check groups NULLs together, so it saw the pair as a duplicate and failed. It has failed every day since the table launched.

Coalesce normalized_channel and normalized_os to '??', the sentinel the query already used for country, and add all six join keys to the not_null check so a NULL cannot come back unseen.

This also clears the spurious "actions recorded with zero displays" warning. Those rows were the split halves, not mapping drift.

Verified on 2026-08-20: duplicate groups 0, null keys 0, and 750 rows become 747 as the three pairs merge.

Existing partitions still hold the split rows and need a backfill.

Bug 2065607: https://bugzilla.mozilla.org/show_bug.cgi?id=2065607

## Description

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-XXXX
* DSRE-XXXX

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
