### PR TITLE
chore(DENG-11380): backfill Plausible events and sessions

### DIFF
--- a/dags.yaml
+++ b/dags.yaml
@@ -2165,12 +2165,6 @@ bqetl_plausible:
     retry_delay: 30m
   tags:
     - impact/tier_2
-    # Plausible has delivered nothing since 2026-08-05, so this DAG is expected
-    # to fail daily until the vendor feed resumes. Those failures are known and
-    # outside our control, and nothing downstream consumes these tables yet, so
-    # they should not cost triage a bug each morning. Drop this tag once the
-    # export cadence is confirmed -- email_on_failure still notifies the owner.
-    - triage/no_triage
   repo: bigquery-etl
   schedule_interval: 0 12 * * *
 

--- a/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
@@ -1,9 +1,10 @@
-2026-08-27:
+2026-08-31:
   start_date: 2026-07-30
-  end_date: 2026-08-26
-  reason: Initial load of all available Plausible exports (DENG-11380). The tables
-    were created empty by deploy; the vendor has since delivered every date from 2026-07-30
-    to 2026-08-26.
+  end_date: 2026-08-30
+  reason: Initial load of all available Plausible exports (DENG-11380). The vendor
+    has delivered every date from 2026-07-30 to 2026-08-30. The scheduled DAG has
+    loaded only 2026-08-25 and 2026-08-30, so this covers the full range; those two
+    partitions are replaced idempotently.
   watchers:
   - phlee@mozilla.com
   status: Initiate
@@ -15,5 +16,5 @@
   query_script_entrypoint: main
   query_script_date_arg: date
   query_script_args:
-  - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__events_v1_2026_08_27
+  - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__events_v1_2026_08_31
   - --billing-project=moz-fx-data-backfill-slots

--- a/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
@@ -16,3 +16,4 @@
   query_script_date_arg: date
   query_script_args:
   - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__events_v1_2026_08_27
+  - --billing-project=moz-fx-data-backfill-slots

--- a/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
@@ -1,0 +1,18 @@
+2026-08-27:
+  start_date: 2026-07-30
+  end_date: 2026-08-26
+  reason: Initial load of all available Plausible exports (DENG-11380). The tables
+    were created empty by deploy; the vendor has since delivered every date from 2026-07-30
+    to 2026-08-26.
+  watchers:
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  override_depends_on_past_null_partition: false
+  ignore_date_partition_offset: false
+  query_script_entrypoint: main
+  query_script_date_arg: date
+  query_script_args:
+  - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__events_v1_2026_08_27

--- a/sql/moz-fx-data-shared-prod/plausible_external/events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/events_v1/metadata.yaml
@@ -26,9 +26,11 @@ labels:
   owner1: phlee
 scheduling:
   dag_name: bqetl_plausible
-  # The load writes its own partition decorator from --date, because it stages
-  # the parquet file and validates it before replacing the partition.
-  date_partition_parameter: null
+  # date_partition_parameter is deliberately absent rather than null. The load
+  # writes its own partition decorator from --date, so the scheduled task needs
+  # no partition parameter either way -- DAG generation is byte-identical. But a
+  # null here makes `bqetl backfill complete` resolve no partition and raise
+  # after it has already cloned the production backup, so the key is left off.
   arguments: ["--date", "{{ds}}"]
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/plausible_external/events_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/events_v1/metadata.yaml
@@ -26,11 +26,6 @@ labels:
   owner1: phlee
 scheduling:
   dag_name: bqetl_plausible
-  # date_partition_parameter is deliberately absent rather than null. The load
-  # writes its own partition decorator from --date, so the scheduled task needs
-  # no partition parameter either way -- DAG generation is byte-identical. But a
-  # null here makes `bqetl backfill complete` resolve no partition and raise
-  # after it has already cloned the production backup, so the key is left off.
   arguments: ["--date", "{{ds}}"]
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/plausible_external/events_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/plausible_external/events_v1/query.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from load import parse_args, run  # noqa: E402
+from load import entrypoint, run  # noqa: E402
 
 # Empty strings are normalized to NULL: the source parquet declares every string
 # column non-nullable, so Plausible encodes "not collected" as "" (72% of
@@ -53,10 +53,11 @@ FROM
 """
 
 
-def main():
+@entrypoint
+def main(args):
     """Load one day. Also the `bqetl query backfill` script entrypoint."""
     run(
-        parse_args(__doc__),
+        args,
         table="events_v1",
         source_file="events.parquet",
         # Each events file holds exactly the events recorded on the export date,

--- a/sql/moz-fx-data-shared-prod/plausible_external/load.py
+++ b/sql/moz-fx-data-shared-prod/plausible_external/load.py
@@ -30,8 +30,10 @@ import tempfile
 import uuid
 from argparse import ArgumentParser
 from datetime import datetime
+from functools import wraps
 from pathlib import Path
 
+import click
 import pyarrow as pa
 import pyarrow.parquet as pq
 from google.cloud import bigquery, storage  # type: ignore[attr-defined]
@@ -60,6 +62,17 @@ def parse_args(description, argv=None):
     parser.add_argument("--project", default=DEFAULT_PROJECT)
     parser.add_argument("--dataset", default=DEFAULT_DATASET)
     parser.add_argument(
+        "--billing-project",
+        default=None,
+        help=(
+            "Project the BigQuery jobs bill to. Defaults to --project. Set this "
+            "for a backfill so a long run uses the backfill slots instead of "
+            "competing with scheduled ETL for production slots; it is kept "
+            "separate from --project because that still locates the temp "
+            "dataset and the default destination."
+        ),
+    )
+    parser.add_argument(
         "--tmp-dataset",
         default=TMP_DATASET,
         help="Dataset to stage the raw parquet in before typing it.",
@@ -79,6 +92,32 @@ def parse_args(description, argv=None):
     args = parser.parse_args(argv)
     args.date = datetime.strptime(args.date, "%Y-%m-%d").date()
     return args
+
+
+def entrypoint(fn):
+    """Wrap a table's loader as a click command taking an explicit argv.
+
+    `bqetl query backfill` runs dates concurrently (ThreadPoolExecutor, default
+    parallelism 16) whenever depends_on_past is false, and _backfill_script has
+    two branches: a click.Command is called with its arguments, while any other
+    callable is invoked after the process-global sys.argv has been reassigned.
+
+    On that second branch, concurrent dates race -- one thread can overwrite
+    sys.argv before another reads it, so two threads load the same date and a
+    third date is silently skipped, with every task reporting success. Being a
+    click.Command keeps the arguments per-call, which is the only reason this
+    wrapper exists; the options themselves still live in parse_args.
+    """
+
+    @click.command(
+        context_settings={"ignore_unknown_options": True, "help_option_names": []}
+    )
+    @click.argument("argv", nargs=-1, type=click.UNPROCESSED)
+    @wraps(fn)
+    def command(argv):
+        return fn(parse_args(fn.__doc__, list(argv)))
+
+    return command
 
 
 def _require_source_blob(args, source_file):
@@ -276,7 +315,7 @@ def run(args, *, table, source_file, partition_field, select_sql, duplicate_key=
     destination = resolve_destination(args, table)
     blob = _require_source_blob(args, source_file)
 
-    bq_client = bigquery.Client(args.project)
+    bq_client = bigquery.Client(args.billing_project or args.project)
     tmp_table = (
         f"{args.project}.{args.tmp_dataset}"
         f".plausible_{table}_{uuid.uuid4().hex[:8]}"

--- a/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
@@ -1,0 +1,18 @@
+2026-08-27:
+  start_date: 2026-07-30
+  end_date: 2026-08-26
+  reason: Initial load of all available Plausible exports (DENG-11380). The tables
+    were created empty by deploy; the vendor has since delivered every date from 2026-07-30
+    to 2026-08-26.
+  watchers:
+  - phlee@mozilla.com
+  status: Initiate
+  shredder_mitigation: false
+  override_retention_limit: false
+  override_depends_on_past_end_date: false
+  override_depends_on_past_null_partition: false
+  ignore_date_partition_offset: false
+  query_script_entrypoint: main
+  query_script_date_arg: date
+  query_script_args:
+  - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__sessions_v1_2026_08_27

--- a/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
@@ -1,9 +1,10 @@
-2026-08-27:
+2026-08-31:
   start_date: 2026-07-30
-  end_date: 2026-08-26
-  reason: Initial load of all available Plausible exports (DENG-11380). The tables
-    were created empty by deploy; the vendor has since delivered every date from 2026-07-30
-    to 2026-08-26.
+  end_date: 2026-08-30
+  reason: Initial load of all available Plausible exports (DENG-11380). The vendor
+    has delivered every date from 2026-07-30 to 2026-08-30. The scheduled DAG has
+    loaded only 2026-08-25 and 2026-08-30, so this covers the full range; those two
+    partitions are replaced idempotently.
   watchers:
   - phlee@mozilla.com
   status: Initiate
@@ -15,5 +16,5 @@
   query_script_entrypoint: main
   query_script_date_arg: date
   query_script_args:
-  - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__sessions_v1_2026_08_27
+  - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__sessions_v1_2026_08_31
   - --billing-project=moz-fx-data-backfill-slots

--- a/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
@@ -16,3 +16,4 @@
   query_script_date_arg: date
   query_script_args:
   - --destination-table=moz-fx-data-shared-prod.backfills_staging_derived.plausible_external__sessions_v1_2026_08_27
+  - --billing-project=moz-fx-data-backfill-slots

--- a/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/metadata.yaml
@@ -26,9 +26,11 @@ labels:
   owner1: phlee
 scheduling:
   dag_name: bqetl_plausible
-  # The load writes its own partition decorator from --date, because it stages
-  # the parquet file and validates it before replacing the partition.
-  date_partition_parameter: null
+  # date_partition_parameter is deliberately absent rather than null. The load
+  # writes its own partition decorator from --date, so the scheduled task needs
+  # no partition parameter either way -- DAG generation is byte-identical. But a
+  # null here makes `bqetl backfill complete` resolve no partition and raise
+  # after it has already cloned the production backup, so the key is left off.
   arguments: ["--date", "{{ds}}"]
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/metadata.yaml
@@ -26,11 +26,6 @@ labels:
   owner1: phlee
 scheduling:
   dag_name: bqetl_plausible
-  # date_partition_parameter is deliberately absent rather than null. The load
-  # writes its own partition decorator from --date, so the scheduled task needs
-  # no partition parameter either way -- DAG generation is byte-identical. But a
-  # null here makes `bqetl backfill complete` resolve no partition and raise
-  # after it has already cloned the production backup, so the key is left off.
   arguments: ["--date", "{{ds}}"]
 bigquery:
   time_partitioning:

--- a/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/query.py
+++ b/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/query.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from load import parse_args, run  # noqa: E402
+from load import entrypoint, run  # noqa: E402
 
 # Empty strings are normalized to NULL for the same reason as in events_v1: the
 # source parquet declares its string columns non-nullable, so "not collected" is
@@ -67,10 +67,11 @@ WHERE
 """
 
 
-def main():
+@entrypoint
+def main(args):
     """Load one day. Also the `bqetl query backfill` script entrypoint."""
     run(
-        parse_args(__doc__),
+        args,
         table="sessions_v1",
         source_file="sessions.parquet",
         # Sessions are filed by when they began, not when they were last

--- a/tests/plausible_external/test_plausible_queries.py
+++ b/tests/plausible_external/test_plausible_queries.py
@@ -15,6 +15,7 @@ import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
+import click
 import pytest
 import yaml
 from sqlglot import exp, parse_one
@@ -100,12 +101,19 @@ def test_no_duplicate_projected_columns(table):
 
 
 @pytest.mark.parametrize("table", TABLES)
-def test_backfill_entrypoint_is_callable(table):
-    """`bqetl query backfill` resolves a module-level callable, not __main__."""
+def test_backfill_entrypoint_is_a_click_command(table):
+    """`main` must be a click.Command, not just any callable.
+
+    `bqetl query backfill` runs dates concurrently when depends_on_past is
+    false. _backfill_script passes arguments to a click.Command directly, but
+    reassigns the process-global sys.argv for any other callable -- where
+    concurrent dates race, so one date is loaded twice and another is skipped
+    with every task still reporting success.
+    """
     main = getattr(_load_query_module(table), "main", None)
-    assert callable(main), (
-        f"{table}: query.py must expose a module-level main() for "
-        "`bqetl query backfill --query-script-entrypoint main`."
+    assert isinstance(main, click.Command), (
+        f"{table}: main must be a click.Command so backfill arguments are "
+        "passed per-call instead of through the shared sys.argv."
     )
 
 


### PR DESCRIPTION
[DENG-11380](https://mozilla-hub.atlassian.net/browse/DENG-11380). Follow-up to #9793.

Managed backfill entries for `plausible_external.events_v1` and `plausible_external.sessions_v1`, covering **2026-07-30 to 2026-08-26** (28 days).

## Why the full range, not just the new dates

Plausible has resumed and filled in the outage: every date from 2026-07-30 to 2026-08-26 is now present, with no gaps.

Both tables were created by the deploy that landed #9793 but are **empty** — `INFORMATION_SCHEMA.PARTITIONS` returns no rows for either, and `bq show` reports `numRows: 0`. The DAG has loaded nothing, since it was deployed while the feed was still stalled and `catchup=False` means it never scheduled the historical dates. So this covers the whole available range rather than only the 21 dates the vendor added. The scheduled DAG takes over from 2026-08-27.

## Checks before requesting

- **Schema is unchanged across the outage.** Compared parquet footers for 2026-07-30, 08-06, 08-15 and 08-26: 31 columns, identical types, and `session_id` / `site_id` still the only unsigned 64-bit columns. The loader's uint64 re-encode applies to the new files exactly as to the original seven days.
- **`site_id` is still constant.** A distinct scan of 2026-08-06, 08-15 and 08-26 returns exactly `{86997652}`. Worth confirming, because #9793 made an unexpected `site_id` a hard failure rather than a warning — a second Plausible property would have failed all 21 new dates.
- **Sessions are still unique per file.** `session_id` duplicates on those same three dates: zero. `sessions_v1` assumes one row per session and dedups defensively, so it is worth knowing the vendor's own dedup survived the outage.
- **Each file still covers exactly one day.** Checked 2026-08-06, 08-15 and 08-26: `timestamp` and `start` run `00:00:00`–`23:59:59` within the export date. That is the invariant the one-file-to-one-partition design depends on, and `load.py` asserts it per run regardless.
- `bqetl backfill validate` passes for both tables.

## Notes

`bqetl backfill create` generated the `--destination-table` argument pointing at `backfills_staging_derived`, and it is correct as generated — `load.py` accepts a fully qualified destination, added in #9793 precisely so managed backfills work. I removed the two advisory `# WARNING:` comments the generator appends, since the thing they ask you to verify is already satisfied.

The staging tables will be created by `deploy_table` during `backfill process`. That path is gated on the table having a `schema.yaml`, and both of these do.

Volume, from parquet metadata on the dates I sampled: events range from ~0.9M/day (2026-08-15) to ~3.2M/day (2026-08-26), sessions ~0.3M–1.3M/day. I did not total all 28 days, so treat the full-range figure as unmeasured.


[DENG-11380]: https://mozilla-hub.atlassian.net/browse/DENG-11380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

