### PR TITLE
Support workgroups in external sharing

### DIFF
--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -225,8 +225,11 @@ class ExternalSharingMetadata:
             is_group = subscriber.startswith("group:") and is_email(
                 subscriber[len("group:") :]
             )
-            is_workgroup = subscriber.startswith("workgroup:") and bool(
-                subscriber[len("workgroup:") :]
+            # workgroups are `<namespace>/<group>` (e.g.
+            # workgroup:braze/data-viewers); fail fast here instead of at
+            # `terraform apply` in cloudops-infra
+            is_workgroup = bool(
+                re.fullmatch(r"workgroup:[a-z0-9-]+/[a-z0-9-]+", subscriber)
             )
             if not (is_group or is_workgroup):
                 raise ValueError(

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -220,14 +220,18 @@ class ExternalSharingMetadata:
 
     @subscribers.validator
     def validate_subscribers(self, attribute, value):
-        """Check that each subscriber is a group: email identity."""
+        """Check that each subscriber is a group: email or workgroup: identity."""
         for subscriber in value:
-            if not subscriber.startswith("group:") or not is_email(
+            is_group = subscriber.startswith("group:") and is_email(
                 subscriber[len("group:") :]
-            ):
+            )
+            is_workgroup = subscriber.startswith("workgroup:") and bool(
+                subscriber[len("workgroup:") :]
+            )
+            if not (is_group or is_workgroup):
                 raise ValueError(
-                    f"Invalid external_sharing subscriber {subscriber!r}: "
-                    "must be a 'group:<email>' identity."
+                    f"Invalid external_sharing subscriber {subscriber!r}: must be "
+                    "a 'group:<email>' or 'workgroup:<name>' identity."
                 )
 
     @listing_id.validator

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -456,7 +456,8 @@ def validate_exclusion_list_expiration_days(metadata, path):
 def validate_external_sharing(dataset_name, dataset_metadata, dataset_path):
     """Validate external_sharing config on a dataset.
 
-    Subscriber identities are validated at parse time (must be `group:`).
+    Subscriber identities are validated at parse time (must be `group:` or
+    `workgroup:`).
     Enforces that:
     * only `_shared` datasets may be shared (they are published to the
       user-facing project and the BigQuery Sharing listing points there), and

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -52,7 +52,7 @@ IDs/names) so provisioning doesn't create duplicates.
 - **`group:` or `workgroup:` subscribers only.** Every subscriber must be either
   a `group:<email>` identity (a Mozilla-managed Google group) or a
   `workgroup:<name>` identity (a Mozilla workgroup, e.g.
-  `workgroup:mozilla-confidential/data-viewers`). This keeps partner user/service
+  `workgroup:some-managed-workgroup/data-viewers`). This keeps partner user/service
   account emails out of the repo; add those accounts to the group or workgroup
   instead. `workgroup:` identities are resolved to IAM members by Terraform in
   cloudops-infra. Access is scoped by group/workgroup membership and revoked by

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -26,6 +26,7 @@ external_sharing:
   data_review: https://bugzilla.mozilla.org/show_bug.cgi?id=<bug>
   subscribers:
     - group:some-managed-group@mozilla.com
+    - workgroup:some-managed-workgroup/data-viewers
 
   # all optional:
   exchange_id: partner_exchange              # explicit exchange resource ID
@@ -48,11 +49,14 @@ IDs/names) so provisioning doesn't create duplicates.
 - **`_shared` datasets only.** `external_sharing` may only be set on a dataset
   whose name ends with `_shared`. These datasets are published to the
   user-facing project (`mozdata`), and the sharing listing points at that copy.
-- **`group:` subscribers only.** Every subscriber must be a `group:<email>`
-  identity — a Mozilla-managed Google group. This keeps partner user/service
-  account emails out of the repo; add those accounts to the group instead.
-  Access is scoped by group membership and revoked by removing the group from
-  `subscribers`.
+- **`group:` or `workgroup:` subscribers only.** Every subscriber must be either
+  a `group:<email>` identity (a Mozilla-managed Google group) or a
+  `workgroup:<name>` identity (a Mozilla workgroup, e.g.
+  `workgroup:mozilla-confidential/data-viewers`). This keeps partner user/service
+  account emails out of the repo; add those accounts to the group or workgroup
+  instead. `workgroup:` identities are resolved to IAM members by Terraform in
+  cloudops-infra. Access is scoped by group/workgroup membership and revoked by
+  removing the identity from `subscribers`.
 - **Authorized views.** Every view in a `_shared` dataset must set
   `labels: {authorized: true}` in its `metadata.yaml`, so the shared listing can
   read through it.

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -29,23 +29,27 @@ class TestParseMetadata(object):
             Metadata("Test metadata", "test description", ["testexample.org"])
 
     def test_valid_external_sharing_subscribers(self):
+        # both group: emails and workgroup: identities are accepted
+        subscribers = [
+            "group:partner@example.org",
+            "group:other@example.org",
+            "workgroup:mozilla-confidential/data-viewers",
+        ]
         metadata = ExternalSharingMetadata(
             exchange="test_exchange",
             data_review="https://bugzilla.mozilla.org/1",
-            subscribers=["group:partner@example.org", "group:other@example.org"],
+            subscribers=subscribers,
         )
 
-        assert metadata.subscribers == [
-            "group:partner@example.org",
-            "group:other@example.org",
-        ]
+        assert metadata.subscribers == subscribers
 
     def test_invalid_external_sharing_subscribers(self):
-        # non-group:, workgroup:, and group: without an email are all rejected
+        # bare emails, group: without an email, and empty-tailed identities are
+        # all rejected
         for bad in (
             ["partner@example.org"],
-            ["workgroup:mozilla/partner"],
             ["group:partner-data"],
+            ["workgroup:"],
         ):
             with pytest.raises(ValueError):
                 ExternalSharingMetadata(

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -44,12 +44,14 @@ class TestParseMetadata(object):
         assert metadata.subscribers == subscribers
 
     def test_invalid_external_sharing_subscribers(self):
-        # bare emails, group: without an email, and empty-tailed identities are
-        # all rejected
+        # bare emails, group: without an email, and workgroups that aren't
+        # `<namespace>/<group>` are all rejected
         for bad in (
             ["partner@example.org"],
             ["group:partner-data"],
             ["workgroup:"],
+            ["workgroup:some-managed-workgroup"],  # missing /<group>
+            ["workgroup:not a workgroup"],
         ):
             with pytest.raises(ValueError):
                 ExternalSharingMetadata(


### PR DESCRIPTION
## Description

Allows to use workgroup: when setting up external_sharing bigquery-etl. At the moment only Google groups are supported.
Depends on https://github.com/mozilla-services/cloudops-infra/pull/6990 (merged)

cc @kik-kik 

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
