### PR TITLE
[DENG-11456] Support external data subscriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,5 +56,5 @@ Reference docs (`docs/reference/`) - read the relevant one when a change touches
 - `airflow_tags.md` - Airflow tags for filtering DAGs in the UI and conveying failure impact during triage.
 - `bigconfig.md` - Bigeye `bigConfig` for declaring which tables to monitor and what data-quality monitors/alerts apply.
 - `public_data.md` - marking datasets as public and how public data is exposed.
-- `external_sharing.md` - declaring external partner sharing of a `_shared` dataset via BigQuery Sharing (`external_sharing` in `dataset_metadata.yaml`); provisioned by Terraform in cloudops-infra.
+- `external_sharing.md` - BigQuery Sharing in both directions, provisioned by Terraform in cloudops-infra: sharing a `_shared` dataset out to partners (`external_sharing`) and subscribing to a partner's listing to link a read-only `_external` dataset in (`external_data_subscription`), both in `dataset_metadata.yaml`.
 - `stage-deploys-continuous-integration.md` - how CI deploys schema/view/UDF changes to the stage environment for validation.

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -255,32 +255,22 @@ class ExternalDataSubscriptionMetadata:
     into our project. Provisioned from this config by Terraform in cloudops-infra.
     """
 
-    # Project hosting the source data exchange (project id or number).
+    # Source project (id or number), exchange and listing identifying the
+    # partner's listing to subscribe to.
     source_project: str
-    # Source data exchange resource ID (from the partner's listing).
     data_exchange_id: str = attr.ib()
-    # Source listing resource ID (from the partner's listing).
     listing_id: str = attr.ib()
     data_review: str = attr.ib()  # link to bug
-    # workgroup: identities granted read access on the linked dataset.
-    readers: List[str] = attr.ib()
-    # Location the linked dataset is created in. Defaults to "us" when unset.
-    location: Optional[str] = attr.ib(None)
-    # Friendly name of the linked (destination) dataset.
+    readers: List[str] = attr.ib()  # workgroup: identities granted read access
+    # Linked (destination) dataset properties; sensible defaults when unset.
+    location: Optional[str] = attr.ib(None)  # defaults to "us"
     friendly_name: Optional[str] = attr.ib(None)
-    # Description of the linked (destination) dataset.
     description: Optional[str] = attr.ib(None)
-    # Labels applied to the linked (destination) dataset.
     labels: Optional[Dict] = attr.ib(None)
 
     @readers.validator
     def validate_readers(self, attribute, value):
-        """Check that each reader is a workgroup: identity.
-
-        Internal access to externally-sourced data is granted through
-        Mozilla-managed workgroups (e.g. `workgroup:mozilla-confidential/data-viewers`),
-        consistent with `workgroup_access`.
-        """
+        """Check that each reader is a workgroup: identity."""
         for reader in value:
             if not reader.startswith("workgroup:") or not reader[len("workgroup:") :]:
                 raise ValueError(

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -262,7 +262,8 @@ class ExternalDataSubscriptionMetadata:
     data_exchange_id: str = attr.ib()
     listing_id: str = attr.ib()
     # Linked (destination) dataset properties; sensible defaults when unset.
-    location: Optional[str] = attr.ib(None)  # defaults to "us"
+    # Location is intentionally not configurable here: it is fixed by
+    # cloudops-infra to a region with GCPv2 networking allocated.
     friendly_name: Optional[str] = attr.ib(None)
     description: Optional[str] = attr.ib(None)
     labels: Optional[Dict] = attr.ib(None)

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -260,7 +260,6 @@ class ExternalDataSubscriptionMetadata:
     source_project: str
     data_exchange_id: str = attr.ib()
     listing_id: str = attr.ib()
-    data_review: str = attr.ib()  # link to bug
     readers: List[str] = attr.ib()  # workgroup: identities granted read access
     # Linked (destination) dataset properties; sensible defaults when unset.
     location: Optional[str] = attr.ib(None)  # defaults to "us"

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -256,29 +256,16 @@ class ExternalDataSubscriptionMetadata:
     """
 
     # Source project (id or number), exchange and listing identifying the
-    # partner's listing to subscribe to.
+    # partner's listing to subscribe to. Read access to the linked dataset is
+    # granted via the dataset's own `workgroup_access` (not configured here).
     source_project: str
     data_exchange_id: str = attr.ib()
     listing_id: str = attr.ib()
-    readers: List[str] = attr.ib()  # workgroup: identities granted read access
     # Linked (destination) dataset properties; sensible defaults when unset.
     location: Optional[str] = attr.ib(None)  # defaults to "us"
     friendly_name: Optional[str] = attr.ib(None)
     description: Optional[str] = attr.ib(None)
     labels: Optional[Dict] = attr.ib(None)
-
-    @readers.validator
-    def validate_readers(self, attribute, value):
-        """Check that each reader is a workgroup: identity."""
-        for reader in value:
-            # workgroups are `<namespace>/<group>` (e.g.
-            # workgroup:braze/data-viewers); fail fast here instead of at
-            # `terraform apply` in cloudops-infra
-            if not re.fullmatch(r"workgroup:[a-z0-9-]+/[a-z0-9-]+", reader):
-                raise ValueError(
-                    f"Invalid external_data_subscription reader {reader!r}: "
-                    "must be a 'workgroup:<namespace>/<group>' identity."
-                )
 
     @data_exchange_id.validator
     @listing_id.validator

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -246,6 +246,64 @@ class ExternalSharingMetadata:
 
 
 @attr.s(auto_attribs=True)
+class ExternalDataSubscriptionMetadata:
+    """Metadata to configure subscribing to data an external partner shares with us.
+
+    This is the inbound counterpart of `ExternalSharingMetadata`: instead of
+    Mozilla sharing a dataset out, a partner shares a BigQuery Sharing
+    (Analytics Hub) listing with us. Subscribing to it links a read-only dataset
+    into our project. Provisioned from this config by Terraform in cloudops-infra.
+    """
+
+    # Project hosting the source data exchange (project id or number).
+    source_project: str
+    # Source data exchange resource ID (from the partner's listing).
+    data_exchange_id: str = attr.ib()
+    # Source listing resource ID (from the partner's listing).
+    listing_id: str = attr.ib()
+    data_review: str = attr.ib()  # link to bug
+    # workgroup: identities granted read access on the linked dataset.
+    readers: List[str] = attr.ib()
+    # Location the linked dataset is created in. Defaults to "us" when unset.
+    location: Optional[str] = attr.ib(None)
+    # Friendly name of the linked (destination) dataset.
+    friendly_name: Optional[str] = attr.ib(None)
+    # Description of the linked (destination) dataset.
+    description: Optional[str] = attr.ib(None)
+    # Labels applied to the linked (destination) dataset.
+    labels: Optional[Dict] = attr.ib(None)
+
+    @readers.validator
+    def validate_readers(self, attribute, value):
+        """Check that each reader is a workgroup: identity.
+
+        Internal access to externally-sourced data is granted through
+        Mozilla-managed workgroups (e.g. `workgroup:mozilla-confidential/data-viewers`),
+        consistent with `workgroup_access`.
+        """
+        for reader in value:
+            if not reader.startswith("workgroup:") or not reader[len("workgroup:") :]:
+                raise ValueError(
+                    f"Invalid external_data_subscription reader {reader!r}: "
+                    "must be a 'workgroup:<name>' identity."
+                )
+
+    @data_exchange_id.validator
+    @listing_id.validator
+    def validate_resource_id(self, attribute, value):
+        """Check resource IDs contain only letters, numbers and underscores.
+
+        BigQuery Sharing restricts exchange/listing IDs to this set; validating
+        here fails fast instead of at `terraform apply` in cloudops-infra.
+        """
+        if not re.fullmatch(r"[A-Za-z0-9_]+", value):
+            raise ValueError(
+                f"Invalid external_data_subscription {attribute.name} {value!r}: "
+                "must contain only letters, numbers and underscores."
+            )
+
+
+@attr.s(auto_attribs=True)
 class Metadata:
     """
     Representation of a table or view Metadata configuration.
@@ -562,6 +620,26 @@ def _structure_external_sharing(value):
     return cattrs.BaseConverter().structure(value, ExternalSharingMetadata)
 
 
+def _structure_external_data_subscription(value):
+    """Structure a raw dict into ExternalDataSubscriptionMetadata for attrs.
+
+    Rejects unrecognized keys so a typo is a hard error rather than silently
+    dropped and then missing from the resources Terraform provisions.
+    """
+    if value is None or isinstance(value, ExternalDataSubscriptionMetadata):
+        return value
+    if isinstance(value, dict):
+        unknown = set(value) - {
+            field.name for field in attr.fields(ExternalDataSubscriptionMetadata)
+        }
+        if unknown:
+            raise ValueError(
+                "Unknown external_data_subscription key(s): "
+                + ", ".join(sorted(unknown))
+            )
+    return cattrs.BaseConverter().structure(value, ExternalDataSubscriptionMetadata)
+
+
 @attr.s(auto_attribs=True)
 class DatasetMetadata:
     """
@@ -584,6 +662,12 @@ class DatasetMetadata:
     # datasets. Provisioned from this config by Terraform in cloudops-infra.
     external_sharing: Optional[ExternalSharingMetadata] = attr.ib(
         None, converter=_structure_external_sharing
+    )
+    # Subscription to data an external partner shares with us via BigQuery
+    # Sharing; only valid on `_external` datasets. Provisioned from this config
+    # by Terraform in cloudops-infra.
+    external_data_subscription: Optional[ExternalDataSubscriptionMetadata] = attr.ib(
+        None, converter=_structure_external_data_subscription
     )
 
     def __attrs_post_init__(self):

--- a/bigquery_etl/metadata/parse_metadata.py
+++ b/bigquery_etl/metadata/parse_metadata.py
@@ -271,10 +271,13 @@ class ExternalDataSubscriptionMetadata:
     def validate_readers(self, attribute, value):
         """Check that each reader is a workgroup: identity."""
         for reader in value:
-            if not reader.startswith("workgroup:") or not reader[len("workgroup:") :]:
+            # workgroups are `<namespace>/<group>` (e.g.
+            # workgroup:braze/data-viewers); fail fast here instead of at
+            # `terraform apply` in cloudops-infra
+            if not re.fullmatch(r"workgroup:[a-z0-9-]+/[a-z0-9-]+", reader):
                 raise ValueError(
                     f"Invalid external_data_subscription reader {reader!r}: "
-                    "must be a 'workgroup:<name>' identity."
+                    "must be a 'workgroup:<namespace>/<group>' identity."
                 )
 
     @data_exchange_id.validator

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -513,6 +513,8 @@ def validate_external_data_subscription(dataset_name, dataset_metadata, dataset_
       and
     * the dataset defines no tables/views: a subscription links a read-only
       dataset provisioned by BigQuery Sharing, so no ETL can be defined in it.
+      This includes schema-only tables (a `metadata.yaml`/`schema.yaml` with no
+      query), which deploy without a query file.
     """
     if not dataset_metadata.external_data_subscription:
         return True
@@ -529,6 +531,8 @@ def validate_external_data_subscription(dataset_name, dataset_metadata, dataset_
         )
         is_valid = False
 
+    # a table/view lives in a subdirectory and is defined by any of these; the
+    # metadata/schema files catch schema-only tables that have no query file
     table_definition_files = sorted(
         definition_file
         for pattern in (
@@ -538,6 +542,8 @@ def validate_external_data_subscription(dataset_name, dataset_metadata, dataset_
             "materialized_view.sql",
             "script.sql",
             "init.sql",
+            "metadata.yaml",
+            "schema.yaml",
         )
         for definition_file in Path(dataset_path).glob(f"*/{pattern}")
     )

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -502,6 +502,49 @@ def validate_external_sharing(dataset_name, dataset_metadata, dataset_path):
     return is_valid
 
 
+def validate_external_data_subscription(dataset_name, dataset_metadata, dataset_path):
+    """Validate external_data_subscription config on a dataset.
+
+    Reader identities (`workgroup:`) and the source exchange/listing ID charset
+    are validated at parse time. Enforces that:
+    * only `_external` datasets may subscribe to external data (the linked
+      dataset is externally-sourced, matching the repo's `_external` convention),
+      and
+    * the dataset defines no tables/views: a subscription links a read-only
+      dataset provisioned by BigQuery Sharing, so no ETL can be defined in it.
+    """
+    if not dataset_metadata.external_data_subscription:
+        return True
+
+    is_valid = True
+
+    if not dataset_name.endswith("_external"):
+        click.echo(
+            click.style(
+                f"ERROR: dataset '{dataset_name}' configures "
+                "external_data_subscription but is not suffixed with '_external'.",
+                fg="red",
+            )
+        )
+        is_valid = False
+
+    for query_file in sorted(Path(dataset_path).glob("*/query.sql")) + sorted(
+        Path(dataset_path).glob("*/view.sql")
+    ):
+        click.echo(
+            click.style(
+                f"ERROR: dataset '{dataset_name}' configures "
+                "external_data_subscription but defines "
+                f"'{query_file.parent.name}/{query_file.name}'. A subscription "
+                "links a read-only dataset; it cannot contain tables or views.",
+                fg="red",
+            )
+        )
+        is_valid = False
+
+    return is_valid
+
+
 def validate_workgroup_access(metadata, path):
     """Check if there are any specifications of table-level access that are redundant with dataset access."""
     is_valid = True
@@ -778,6 +821,11 @@ def validate_datasets(target):
                         failed = True
 
                     if not validate_external_sharing(
+                        dataset_name, dataset_metadata, root
+                    ):
+                        failed = True
+
+                    if not validate_external_data_subscription(
                         dataset_name, dataset_metadata, root
                     ):
                         failed = True

--- a/bigquery_etl/metadata/validate_metadata.py
+++ b/bigquery_etl/metadata/validate_metadata.py
@@ -505,8 +505,9 @@ def validate_external_sharing(dataset_name, dataset_metadata, dataset_path):
 def validate_external_data_subscription(dataset_name, dataset_metadata, dataset_path):
     """Validate external_data_subscription config on a dataset.
 
-    Reader identities (`workgroup:`) and the source exchange/listing ID charset
-    are validated at parse time. Enforces that:
+    The source exchange/listing ID charset is validated at parse time. Read
+    access to the linked dataset is granted via the dataset's own
+    `workgroup_access`. Enforces that:
     * only `_external` datasets may subscribe to external data (the linked
       dataset is externally-sourced, matching the repo's `_external` convention),
       and
@@ -528,15 +529,26 @@ def validate_external_data_subscription(dataset_name, dataset_metadata, dataset_
         )
         is_valid = False
 
-    for query_file in sorted(Path(dataset_path).glob("*/query.sql")) + sorted(
-        Path(dataset_path).glob("*/view.sql")
-    ):
+    table_definition_files = sorted(
+        definition_file
+        for pattern in (
+            "query.sql",
+            "query.py",
+            "view.sql",
+            "materialized_view.sql",
+            "script.sql",
+            "init.sql",
+        )
+        for definition_file in Path(dataset_path).glob(f"*/{pattern}")
+    )
+    for definition_file in table_definition_files:
         click.echo(
             click.style(
                 f"ERROR: dataset '{dataset_name}' configures "
                 "external_data_subscription but defines "
-                f"'{query_file.parent.name}/{query_file.name}'. A subscription "
-                "links a read-only dataset; it cannot contain tables or views.",
+                f"'{definition_file.parent.name}/{definition_file.name}'. A "
+                "subscription links a read-only dataset; it cannot contain tables "
+                "or views.",
                 fg="red",
             )
         )

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -76,31 +76,44 @@ the **inbound** counterpart of `external_sharing`: subscribing links a
 
 Subscribing is configured at the **dataset level** because a subscription links a
 whole dataset. One listing subscription is created per configured dataset,
-creating the linked dataset, and the configured `readers` are granted
-`roles/bigquery.dataViewer` on it.
+creating the linked dataset, and the dataset's `workgroup_access` is applied to
+it.
 
 ### Configuration
 
 ```yaml
 # sql/moz-fx-data-shared-prod/<name>_external/dataset_metadata.yaml
+friendly_name: PMG External
+description: Data shared with us by PMG via BigQuery Data Sharing.
+dataset_base_acl: restricted
+user_facing: false
+
+# read access to the linked dataset (resolved to IAM members by Terraform)
+workgroup_access:
+  - role: roles/bigquery.dataViewer
+    members:
+      - workgroup:mozilla-confidential/data-viewers
+
 external_data_subscription:
   source_project: "65960090760"   # project hosting the source exchange (id or number)
   data_exchange_id: client_04ea3564_cf0e_4809_bb70_b8912beff9cc  # source exchange ID
   listing_id: mozilla_analytics_cross_channel                    # source listing ID
-  readers:
-    - workgroup:mozilla-confidential/data-viewers
 
   # all optional:
   location: us                    # location the linked dataset is created in
                                   # (default: us)
-  friendly_name: PMG Analytics    # friendly name of the linked dataset
-  description: Data shared with … # description of the linked dataset
+  friendly_name: PMG Analytics    # linked dataset friendly name
+                                  # (default: "<Dataset> (External via BigQuery Data Sharing)")
+  description: Data shared with … # linked dataset description
+                                  # (default: the dataset `description` above)
   labels:                         # labels applied to the linked dataset
-    domain: marketing
+    domain: marketing             # (default: none)
 ```
 
 The `source_project`, `data_exchange_id` and `listing_id` identify the partner's
-listing to subscribe to — the partner provides these values.
+listing to subscribe to — the partner provides these values. Read access is
+granted through the dataset's own `workgroup_access` (the same field used by every
+other dataset), applied to the linked dataset by Terraform.
 
 ### Constraints (enforced by `bqetl metadata validate`)
 
@@ -108,12 +121,14 @@ listing to subscribe to — the partner provides these values.
   dataset whose name ends with `_external`, matching the repo convention for
   externally-sourced datasets (e.g. `acoustic_external`).
 - **No tables or views.** A subscription links a read-only dataset, so the dataset
-  directory must not define any `query.sql` or `view.sql`. Build derived tables or
-  views in a separate dataset that reads from the linked one.
-- **`workgroup:` readers only.** Every reader must be a `workgroup:<namespace>/<group>`
-  identity (a Mozilla-managed workgroup, e.g. `workgroup:mozilla-confidential/data-viewers`).
-  Access is scoped by workgroup membership and revoked by removing the workgroup
-  from `readers`.
+  directory must not define any table/view artifact (`query.sql`, `query.py`,
+  `view.sql`, `materialized_view.sql`, `script.sql`, `init.sql`). Build derived
+  tables or views in a separate dataset that reads from the linked one.
+- **Access via `workgroup_access`.** Read access to the linked dataset is granted
+  through the dataset's normal `workgroup_access` block (typically
+  `roles/bigquery.dataViewer` for a Mozilla workgroup), not a subscription-specific
+  field. Terraform applies it to the linked dataset; scope is controlled by
+  workgroup membership.
 - **Valid resource IDs.** `data_exchange_id` and `listing_id` must contain only
   letters, numbers and underscores (validated at parse time so a bad value fails
   fast rather than at `terraform apply`).

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -110,8 +110,8 @@ listing to subscribe to — the partner provides these values.
 - **No tables or views.** A subscription links a read-only dataset, so the dataset
   directory must not define any `query.sql` or `view.sql`. Build derived tables or
   views in a separate dataset that reads from the linked one.
-- **`workgroup:` readers only.** Every reader must be a `workgroup:<name>` identity
-  (a Mozilla-managed workgroup, e.g. `workgroup:mozilla-confidential/data-viewers`).
+- **`workgroup:` readers only.** Every reader must be a `workgroup:<namespace>/<group>`
+  identity (a Mozilla-managed workgroup, e.g. `workgroup:mozilla-confidential/data-viewers`).
   Access is scoped by workgroup membership and revoked by removing the workgroup
   from `readers`.
 - **Valid resource IDs.** `data_exchange_id` and `listing_id` must contain only

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -121,9 +121,11 @@ The linked dataset's location is not configurable here due to https://mozilla-hu
   dataset whose name ends with `_external`, matching the repo convention for
   externally-sourced datasets (e.g. `acoustic_external`).
 - **No tables or views.** A subscription links a read-only dataset, so the dataset
-  directory must not define any table/view artifact (`query.sql`, `query.py`,
-  `view.sql`, `materialized_view.sql`, `script.sql`, `init.sql`). Build derived
-  tables or views in a separate dataset that reads from the linked one.
+  directory must not define any table/view artifact — a query/script/view file
+  (`query.sql`, `query.py`, `view.sql`, `materialized_view.sql`, `script.sql`,
+  `init.sql`) or a schema-only table (`metadata.yaml`/`schema.yaml` with no
+  query). Build derived tables or views in a separate dataset that reads from the
+  linked one.
 - **Access via `workgroup_access`.** Read access to the linked dataset is granted
   through the dataset's normal `workgroup_access` block (typically
   `roles/bigquery.dataViewer` for a Mozilla workgroup), not a subscription-specific

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -1,10 +1,24 @@
 # BigQuery Sharing
 
-Share a dataset with external partners through [BigQuery Sharing](https://cloud.google.com/bigquery/docs/analytics-hub-introduction)
-(formerly Analytics Hub) by adding an `external_sharing` block to a dataset's
-`dataset_metadata.yaml`. This is distinct from
-[public data](public_data.md) sharing, which exposes data publicly rather than
-to specific partners.
+Share data with, or ingest data from, external partners through
+[BigQuery Sharing](https://cloud.google.com/bigquery/docs/analytics-hub-introduction)
+(formerly Analytics Hub). Both directions are configured at the **dataset level**
+in a dataset's `dataset_metadata.yaml` and are **provisioned by Terraform in
+`cloudops-infra`** — bigquery-etl owns the metadata schema and its validation only.
+
+Two directions are supported:
+
+- **[Sharing data out](#sharing-data-with-external-partners)** to partners, via the
+  `external_sharing` block.
+- **[Subscribing to data](#subscribing-to-external-partner-data)** a partner shares
+  with us, via the `external_data_subscription` block.
+
+This is distinct from [public data](public_data.md) sharing, which exposes data
+publicly rather than to specific partners.
+
+## Sharing data with external partners
+
+Add an `external_sharing` block to a dataset's `dataset_metadata.yaml`.
 
 Sharing is configured at the **dataset level** because a BigQuery Sharing
 listing shares a whole dataset. One data exchange and one listing are created
@@ -12,12 +26,7 @@ per configured dataset, and the configured groups are granted the
 `roles/analyticshub.subscriber` role on the listing so they can subscribe to
 (link) the shared dataset in their own project.
 
-The `external_sharing` block declares the desired sharing config in
-bigquery-etl; the exchange, listing and subscriber grants are **provisioned by
-Terraform in `cloudops-infra`** (alongside the `mozdata` dataset the listing
-points at). bigquery-etl owns the metadata schema and its validation only.
-
-## Configuration
+### Configuration
 
 ```yaml
 # sql/moz-fx-data-shared-prod/<dataset>_shared/dataset_metadata.yaml
@@ -43,7 +52,7 @@ The optional `*_id` / `*_display_name` / `*_description` fields exist mainly to
 **adopt exchanges/listings that were created by hand** (matching their existing
 IDs/names) so provisioning doesn't create duplicates.
 
-## Constraints (enforced by `bqetl metadata validate`)
+### Constraints (enforced by `bqetl metadata validate`)
 
 - **`_shared` datasets only.** `external_sharing` may only be set on a dataset
   whose name ends with `_shared`. These datasets are published to the
@@ -56,3 +65,56 @@ IDs/names) so provisioning doesn't create duplicates.
 - **Authorized views.** Every view in a `_shared` dataset must set
   `labels: {authorized: true}` in its `metadata.yaml`, so the shared listing can
   read through it.
+
+## Subscribing to external partner data
+
+Subscribe to data an external partner shares with Mozilla by adding an
+`external_data_subscription` block to a dataset's `dataset_metadata.yaml`. This is
+the **inbound** counterpart of `external_sharing`: subscribing links a
+**read-only** dataset (provisioned by BigQuery Sharing) into
+`moz-fx-data-shared-prod`, which internal consumers can then query.
+
+Subscribing is configured at the **dataset level** because a subscription links a
+whole dataset. One listing subscription is created per configured dataset,
+creating the linked dataset, and the configured `readers` are granted
+`roles/bigquery.dataViewer` on it.
+
+### Configuration
+
+```yaml
+# sql/moz-fx-data-shared-prod/<name>_external/dataset_metadata.yaml
+external_data_subscription:
+  source_project: "65960090760"   # project hosting the source exchange (id or number)
+  data_exchange_id: client_04ea3564_cf0e_4809_bb70_b8912beff9cc  # source exchange ID
+  listing_id: mozilla_analytics_cross_channel                    # source listing ID
+  data_review: https://bugzilla.mozilla.org/show_bug.cgi?id=<bug>
+  readers:
+    - workgroup:mozilla-confidential/data-viewers
+
+  # all optional:
+  location: us                    # location the linked dataset is created in
+                                  # (default: us)
+  friendly_name: PMG Analytics    # friendly name of the linked dataset
+  description: Data shared with … # description of the linked dataset
+  labels:                         # labels applied to the linked dataset
+    domain: marketing
+```
+
+The `source_project`, `data_exchange_id` and `listing_id` identify the partner's
+listing to subscribe to — the partner provides these values.
+
+### Constraints (enforced by `bqetl metadata validate`)
+
+- **`_external` datasets only.** `external_data_subscription` may only be set on a
+  dataset whose name ends with `_external`, matching the repo convention for
+  externally-sourced datasets (e.g. `acoustic_external`).
+- **No tables or views.** A subscription links a read-only dataset, so the dataset
+  directory must not define any `query.sql` or `view.sql`. Build derived tables or
+  views in a separate dataset that reads from the linked one.
+- **`workgroup:` readers only.** Every reader must be a `workgroup:<name>` identity
+  (a Mozilla-managed workgroup, e.g. `workgroup:mozilla-confidential/data-viewers`).
+  Access is scoped by workgroup membership and revoked by removing the workgroup
+  from `readers`.
+- **Valid resource IDs.** `data_exchange_id` and `listing_id` must contain only
+  letters, numbers and underscores (validated at parse time so a bad value fails
+  fast rather than at `terraform apply`).

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -100,8 +100,6 @@ external_data_subscription:
   listing_id: mozilla_analytics_cross_channel                    # source listing ID
 
   # all optional:
-  location: us                    # location the linked dataset is created in
-                                  # (default: us)
   friendly_name: PMG Analytics    # linked dataset friendly name
                                   # (default: "<Dataset> (External via BigQuery Data Sharing)")
   description: Data shared with … # linked dataset description
@@ -114,6 +112,8 @@ The `source_project`, `data_exchange_id` and `listing_id` identify the partner's
 listing to subscribe to — the partner provides these values. Read access is
 granted through the dataset's own `workgroup_access` (the same field used by every
 other dataset), applied to the linked dataset by Terraform.
+
+The linked dataset's location is not configurable here due to https://mozilla-hub.atlassian.net/browse/MZCLD-2714
 
 ### Constraints (enforced by `bqetl metadata validate`)
 

--- a/docs/reference/external_sharing.md
+++ b/docs/reference/external_sharing.md
@@ -87,7 +87,6 @@ external_data_subscription:
   source_project: "65960090760"   # project hosting the source exchange (id or number)
   data_exchange_id: client_04ea3564_cf0e_4809_bb70_b8912beff9cc  # source exchange ID
   listing_id: mozilla_analytics_cross_channel                    # source listing ID
-  data_review: https://bugzilla.mozilla.org/show_bug.cgi?id=<bug>
   readers:
     - workgroup:mozilla-confidential/data-viewers
 

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -162,7 +162,6 @@ class TestParseMetadata(object):
             "  source_project: '65960090760'\n"
             "  data_exchange_id: partner_exchange\n"
             "  listing_id: partner_listing\n"
-            "  location: us\n"
             "  friendly_name: PMG Analytics\n"
             "  description: Data shared with us by PMG.\n"
             "  labels:\n"
@@ -177,7 +176,6 @@ class TestParseMetadata(object):
             source_project="65960090760",
             data_exchange_id="partner_exchange",
             listing_id="partner_listing",
-            location="us",
             friendly_name="PMG Analytics",
             description="Data shared with us by PMG.",
             labels={"domain": "marketing"},

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -127,7 +127,6 @@ class TestParseMetadata(object):
             source_project="65960090760",
             data_exchange_id="partner_exchange",
             listing_id="partner_listing",
-            data_review="https://bugzilla.mozilla.org/1",
             readers=[
                 "workgroup:mozilla-confidential/data-viewers",
                 "workgroup:braze/data-viewers",
@@ -151,7 +150,6 @@ class TestParseMetadata(object):
                     source_project="65960090760",
                     data_exchange_id="partner_exchange",
                     listing_id="partner_listing",
-                    data_review="https://bugzilla.mozilla.org/1",
                     readers=bad,
                 )
 
@@ -161,7 +159,6 @@ class TestParseMetadata(object):
                 "source_project": "65960090760",
                 "data_exchange_id": "partner_exchange",
                 "listing_id": "partner_listing",
-                "data_review": "https://bugzilla.mozilla.org/1",
                 "readers": ["workgroup:mozilla-confidential/data-viewers"],
                 field: "has-hyphen",
             }
@@ -179,7 +176,6 @@ class TestParseMetadata(object):
             "  source_project: '65960090760'\n"
             "  data_exchange_id: partner_exchange\n"
             "  listing_id: partner_listing\n"
-            "  data_review: r\n"
             "  reader:\n"  # typo of readers
             "    - workgroup:mozilla-confidential/data-viewers\n"
         )
@@ -204,7 +200,6 @@ class TestParseMetadata(object):
             "  description: Data shared with us by PMG.\n"
             "  labels:\n"
             "    domain: marketing\n"
-            "  data_review: https://bugzilla.mozilla.org/1\n"
             "  readers:\n"
             "    - workgroup:mozilla-confidential/data-viewers\n"
         )
@@ -217,7 +212,6 @@ class TestParseMetadata(object):
             source_project="65960090760",
             data_exchange_id="partner_exchange",
             listing_id="partner_listing",
-            data_review="https://bugzilla.mozilla.org/1",
             readers=["workgroup:mozilla-confidential/data-viewers"],
             location="us",
             friendly_name="PMG Analytics",

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -139,11 +139,14 @@ class TestParseMetadata(object):
         ]
 
     def test_invalid_external_data_subscription_readers(self):
-        # non-workgroup: and workgroup: without a name are rejected
+        # non-workgroup: and workgroups that aren't `<namespace>/<group>` are
+        # rejected
         for bad in (
             ["group:partner@example.org"],
             ["mozilla-confidential/data-viewers"],
             ["workgroup:"],
+            ["workgroup:mozilla-confidential"],  # missing /<group>
+            ["workgroup:not a workgroup"],
         ):
             with pytest.raises(ValueError):
                 ExternalDataSubscriptionMetadata(

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -4,6 +4,7 @@ import pytest
 
 from bigquery_etl.metadata.parse_metadata import (
     DatasetMetadata,
+    ExternalDataSubscriptionMetadata,
     ExternalSharingMetadata,
     Metadata,
     PartitionType,
@@ -119,6 +120,109 @@ class TestParseMetadata(object):
             exchange_display_name="Mozilla - Partner",
             exchange_description="Data for partner",
             restrict_export=True,
+        )
+
+    def test_valid_external_data_subscription_readers(self):
+        metadata = ExternalDataSubscriptionMetadata(
+            source_project="65960090760",
+            data_exchange_id="partner_exchange",
+            listing_id="partner_listing",
+            data_review="https://bugzilla.mozilla.org/1",
+            readers=[
+                "workgroup:mozilla-confidential/data-viewers",
+                "workgroup:braze/data-viewers",
+            ],
+        )
+
+        assert metadata.readers == [
+            "workgroup:mozilla-confidential/data-viewers",
+            "workgroup:braze/data-viewers",
+        ]
+
+    def test_invalid_external_data_subscription_readers(self):
+        # non-workgroup: and workgroup: without a name are rejected
+        for bad in (
+            ["group:partner@example.org"],
+            ["mozilla-confidential/data-viewers"],
+            ["workgroup:"],
+        ):
+            with pytest.raises(ValueError):
+                ExternalDataSubscriptionMetadata(
+                    source_project="65960090760",
+                    data_exchange_id="partner_exchange",
+                    listing_id="partner_listing",
+                    data_review="https://bugzilla.mozilla.org/1",
+                    readers=bad,
+                )
+
+    def test_invalid_external_data_subscription_resource_id(self):
+        for field in ("data_exchange_id", "listing_id"):
+            kwargs = {
+                "source_project": "65960090760",
+                "data_exchange_id": "partner_exchange",
+                "listing_id": "partner_listing",
+                "data_review": "https://bugzilla.mozilla.org/1",
+                "readers": ["workgroup:mozilla-confidential/data-viewers"],
+                field: "has-hyphen",
+            }
+            with pytest.raises(ValueError):
+                ExternalDataSubscriptionMetadata(**kwargs)
+
+    def test_external_data_subscription_rejects_unknown_key(self, tmp_path):
+        # an unknown key (e.g. a typo) must be a hard error, not silently dropped
+        (tmp_path / "dataset_metadata.yaml").write_text(
+            "friendly_name: T\n"
+            "description: T\n"
+            "dataset_base_acl: view\n"
+            "user_facing: true\n"
+            "external_data_subscription:\n"
+            "  source_project: '65960090760'\n"
+            "  data_exchange_id: partner_exchange\n"
+            "  listing_id: partner_listing\n"
+            "  data_review: r\n"
+            "  reader:\n"  # typo of readers
+            "    - workgroup:mozilla-confidential/data-viewers\n"
+        )
+        with pytest.raises(ValueError):
+            DatasetMetadata.from_file(tmp_path / "dataset_metadata.yaml")
+
+    def test_external_data_subscription_all_fields_round_trip(self, tmp_path):
+        # Guards against schema drift from the cloudops-infra sharing module:
+        # every key the module reads must map to a field here (unknown keys are
+        # now rejected, so a field missing here would break a valid config).
+        (tmp_path / "dataset_metadata.yaml").write_text(
+            "friendly_name: T\n"
+            "description: T\n"
+            "dataset_base_acl: view\n"
+            "user_facing: true\n"
+            "external_data_subscription:\n"
+            "  source_project: '65960090760'\n"
+            "  data_exchange_id: partner_exchange\n"
+            "  listing_id: partner_listing\n"
+            "  location: us\n"
+            "  friendly_name: PMG Analytics\n"
+            "  description: Data shared with us by PMG.\n"
+            "  labels:\n"
+            "    domain: marketing\n"
+            "  data_review: https://bugzilla.mozilla.org/1\n"
+            "  readers:\n"
+            "    - workgroup:mozilla-confidential/data-viewers\n"
+        )
+
+        subscription = DatasetMetadata.from_file(
+            tmp_path / "dataset_metadata.yaml"
+        ).external_data_subscription
+
+        assert subscription == ExternalDataSubscriptionMetadata(
+            source_project="65960090760",
+            data_exchange_id="partner_exchange",
+            listing_id="partner_listing",
+            data_review="https://bugzilla.mozilla.org/1",
+            readers=["workgroup:mozilla-confidential/data-viewers"],
+            location="us",
+            friendly_name="PMG Analytics",
+            description="Data shared with us by PMG.",
+            labels={"domain": "marketing"},
         )
 
     def test_invalid_label(self):

--- a/tests/metadata/test_parse_metadata.py
+++ b/tests/metadata/test_parse_metadata.py
@@ -122,47 +122,12 @@ class TestParseMetadata(object):
             restrict_export=True,
         )
 
-    def test_valid_external_data_subscription_readers(self):
-        metadata = ExternalDataSubscriptionMetadata(
-            source_project="65960090760",
-            data_exchange_id="partner_exchange",
-            listing_id="partner_listing",
-            readers=[
-                "workgroup:mozilla-confidential/data-viewers",
-                "workgroup:braze/data-viewers",
-            ],
-        )
-
-        assert metadata.readers == [
-            "workgroup:mozilla-confidential/data-viewers",
-            "workgroup:braze/data-viewers",
-        ]
-
-    def test_invalid_external_data_subscription_readers(self):
-        # non-workgroup: and workgroups that aren't `<namespace>/<group>` are
-        # rejected
-        for bad in (
-            ["group:partner@example.org"],
-            ["mozilla-confidential/data-viewers"],
-            ["workgroup:"],
-            ["workgroup:mozilla-confidential"],  # missing /<group>
-            ["workgroup:not a workgroup"],
-        ):
-            with pytest.raises(ValueError):
-                ExternalDataSubscriptionMetadata(
-                    source_project="65960090760",
-                    data_exchange_id="partner_exchange",
-                    listing_id="partner_listing",
-                    readers=bad,
-                )
-
     def test_invalid_external_data_subscription_resource_id(self):
         for field in ("data_exchange_id", "listing_id"):
             kwargs = {
                 "source_project": "65960090760",
                 "data_exchange_id": "partner_exchange",
                 "listing_id": "partner_listing",
-                "readers": ["workgroup:mozilla-confidential/data-viewers"],
                 field: "has-hyphen",
             }
             with pytest.raises(ValueError):
@@ -179,14 +144,13 @@ class TestParseMetadata(object):
             "  source_project: '65960090760'\n"
             "  data_exchange_id: partner_exchange\n"
             "  listing_id: partner_listing\n"
-            "  reader:\n"  # typo of readers
-            "    - workgroup:mozilla-confidential/data-viewers\n"
+            "  listings_id: partner_listing\n"  # typo of listing_id
         )
         with pytest.raises(ValueError):
             DatasetMetadata.from_file(tmp_path / "dataset_metadata.yaml")
 
     def test_external_data_subscription_all_fields_round_trip(self, tmp_path):
-        # Guards against schema drift from the cloudops-infra sharing module:
+        # Guards against schema drift from the cloudops-infra subscription module:
         # every key the module reads must map to a field here (unknown keys are
         # now rejected, so a field missing here would break a valid config).
         (tmp_path / "dataset_metadata.yaml").write_text(
@@ -203,8 +167,6 @@ class TestParseMetadata(object):
             "  description: Data shared with us by PMG.\n"
             "  labels:\n"
             "    domain: marketing\n"
-            "  readers:\n"
-            "    - workgroup:mozilla-confidential/data-viewers\n"
         )
 
         subscription = DatasetMetadata.from_file(
@@ -215,7 +177,6 @@ class TestParseMetadata(object):
             source_project="65960090760",
             data_exchange_id="partner_exchange",
             listing_id="partner_listing",
-            readers=["workgroup:mozilla-confidential/data-viewers"],
             location="us",
             friendly_name="PMG Analytics",
             description="Data shared with us by PMG.",

--- a/tests/metadata/test_validate_metadata.py
+++ b/tests/metadata/test_validate_metadata.py
@@ -177,7 +177,8 @@ class TestValidateMetadata(object):
             is False
         )
 
-        # invalid: `_external` dataset that defines any table/view artifact
+        # invalid: `_external` dataset that defines any table/view artifact,
+        # including a schema-only table (metadata.yaml/schema.yaml, no query)
         for i, table in enumerate(
             (
                 "query.sql",
@@ -186,6 +187,8 @@ class TestValidateMetadata(object):
                 "materialized_view.sql",
                 "script.sql",
                 "init.sql",
+                "metadata.yaml",
+                "schema.yaml",
             )
         ):
             assert (

--- a/tests/metadata/test_validate_metadata.py
+++ b/tests/metadata/test_validate_metadata.py
@@ -135,7 +135,6 @@ class TestValidateMetadata(object):
             source_project="65960090760",
             data_exchange_id="partner_exchange",
             listing_id="partner_listing",
-            data_review="https://bugzilla.mozilla.org/1",
             readers=["workgroup:mozilla-confidential/data-viewers"],
         )
 

--- a/tests/metadata/test_validate_metadata.py
+++ b/tests/metadata/test_validate_metadata.py
@@ -2,12 +2,14 @@ from datetime import date
 
 from bigquery_etl.metadata.parse_metadata import (
     DatasetMetadata,
+    ExternalDataSubscriptionMetadata,
     ExternalSharingMetadata,
     Metadata,
 )
 from bigquery_etl.metadata.validate_metadata import (
     validate_dataset_classification,
     validate_deprecation,
+    validate_external_data_subscription,
     validate_external_sharing,
     validate_public_data,
 )
@@ -127,6 +129,66 @@ class TestValidateMetadata(object):
             )
             is False
         )
+
+    def test_validate_external_data_subscription(self, tmp_path):
+        external_data_subscription = ExternalDataSubscriptionMetadata(
+            source_project="65960090760",
+            data_exchange_id="partner_exchange",
+            listing_id="partner_listing",
+            data_review="https://bugzilla.mozilla.org/1",
+            readers=["workgroup:mozilla-confidential/data-viewers"],
+        )
+
+        def _dataset_metadata(external_data_subscription=None):
+            return DatasetMetadata(
+                friendly_name="test",
+                description="test",
+                dataset_base_acl="view",
+                user_facing=True,
+                external_data_subscription=external_data_subscription,
+            )
+
+        def _dataset_dir(name, table=None):
+            dataset_dir = tmp_path / name
+            dataset_dir.mkdir(parents=True)
+            if table:
+                table_dir = dataset_dir / "my_table"
+                table_dir.mkdir()
+                (table_dir / table).write_text("SELECT 1\n")
+            return str(dataset_dir)
+
+        # no external_data_subscription configured -> always valid
+        assert validate_external_data_subscription(
+            "some_dataset", _dataset_metadata(), _dataset_dir("some_dataset")
+        )
+
+        # valid: `_external` dataset with no tables/views defined
+        assert validate_external_data_subscription(
+            "pmg_external",
+            _dataset_metadata(external_data_subscription),
+            _dataset_dir("pmg_external"),
+        )
+
+        # invalid: dataset not suffixed with _external
+        assert (
+            validate_external_data_subscription(
+                "pmg_derived",
+                _dataset_metadata(external_data_subscription),
+                _dataset_dir("pmg_derived"),
+            )
+            is False
+        )
+
+        # invalid: `_external` dataset that defines a query or view
+        for i, table in enumerate(("query.sql", "view.sql")):
+            assert (
+                validate_external_data_subscription(
+                    "pmg_external",
+                    _dataset_metadata(external_data_subscription),
+                    _dataset_dir(f"with_{i}_external", table=table),
+                )
+                is False
+            )
 
     def test_validate_deprecation(self):
         metadata_valid = Metadata(

--- a/tests/metadata/test_validate_metadata.py
+++ b/tests/metadata/test_validate_metadata.py
@@ -135,7 +135,6 @@ class TestValidateMetadata(object):
             source_project="65960090760",
             data_exchange_id="partner_exchange",
             listing_id="partner_listing",
-            readers=["workgroup:mozilla-confidential/data-viewers"],
         )
 
         def _dataset_metadata(external_data_subscription=None):
@@ -178,8 +177,17 @@ class TestValidateMetadata(object):
             is False
         )
 
-        # invalid: `_external` dataset that defines a query or view
-        for i, table in enumerate(("query.sql", "view.sql")):
+        # invalid: `_external` dataset that defines any table/view artifact
+        for i, table in enumerate(
+            (
+                "query.sql",
+                "query.py",
+                "view.sql",
+                "materialized_view.sql",
+                "script.sql",
+                "init.sql",
+            )
+        ):
             assert (
                 validate_external_data_subscription(
                     "pmg_external",


### PR DESCRIPTION
## Description

Add support to subscribe to Analytics Hub/BigQuery sharing datasets that were shared with us by an external partner. Currently, this needs to be done in Terraform, but this PR adds a `external_data_subscription` config option for `dataset_metadata.yaml` to create these subscriptions:

```yaml
external_data_subscription:
  source_project: "..."   # project hosting the source exchange (id or number)
  data_exchange_id: ...  # source exchange ID
  listing_id: ...                    # source listing ID

  # all optional:
  location: us                    # location the linked dataset is created in
                                  # (default: us)
  friendly_name: Some Analytics    # friendly name of the linked dataset
  description: Data shared with … # description of the linked dataset
  labels:                         # labels applied to the linked dataset
    domain: marketing

# read access to the linked dataset (resolved to IAM members by Terraform)
workgroup_access:
  - role: roles/bigquery.dataViewer
    members:
      - workgroup:mozilla-confidential/data-viewers
```

Depends on https://github.com/mozilla-services/cloudops-infra/pull/6991, jenkins is used to apply the subscriptions

## Related Tickets & Documents
* [DENG-11456](https://mozilla-hub.atlassian.net/browse/DENG-11456)
* https://github.com/mozilla-services/cloudops-infra/pull/6976

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**


[DENG-11456]: https://mozilla-hub.atlassian.net/browse/DENG-11456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ