### PR TITLE
feat(sql_generators): Add `sql_generator` labels to generated ETLs/views

### DIFF
--- a/docs/reference/recommended_practices.md
+++ b/docs/reference/recommended_practices.md
@@ -133,6 +133,7 @@ labels:
 ```
 
 - Queries that only select from legacy telemetry data should be assigned a `legacy: true` label.
+- Queries that are output from code in `sql_generators/` should be assigned a `sql_generator` label set to the name of the generator.
 - only labels where value types are eithers integers or strings are published, all other values types are being skipped
 
 ### Dynamic Schemas
@@ -173,6 +174,7 @@ Without this flag, `--skip-existing` will skip schema updates for queries that a
 - For each view, a `metadata.yaml` file may be created in the same directory.
 - This file contains a description, owners, and labels (see the query metadata example above).
 - Views that only select from legacy telemetry data should be assigned a `legacy: true` label.
+- Views that are output from code in `sql_generators/` should be assigned a `sql_generator` label set to the name of the generator.
 
 ## UDFs
 

--- a/sql_generators/active_users_aggregates_v3/templates/metadata.yaml
+++ b/sql_generators/active_users_aggregates_v3/templates/metadata.yaml
@@ -13,7 +13,7 @@ description: |-
 
   The table is labeled as "change_controlled", which implies
   that changes require the approval of at least one owner.
-  
+
   The label "shredder mitigation" indicates that this table is set up for
   managed backfill with shredder mitigation, as described in
   https://mozilla.github.io/bigquery-etl/cookbooks/creating_a_derived_dataset/#initiating-the-backfill.
@@ -24,6 +24,7 @@ owners:
   - lvargas@mozilla.com
   - mozilla/kpi_table_reviewers
 labels:
+  sql_generator: active_users_aggregates_v3
   level: gold
   incremental: true
   change_controlled: true

--- a/sql_generators/active_users_aggregates_v4/templates/metadata.yaml
+++ b/sql_generators/active_users_aggregates_v4/templates/metadata.yaml
@@ -13,7 +13,7 @@ description: |-
 
   The table is labeled as "change_controlled", which implies
   that changes require the approval of at least one owner.
-  
+
   The label "shredder mitigation" indicates that this table is set up for
   managed backfill with shredder mitigation, as described in
   https://mozilla.github.io/bigquery-etl/cookbooks/creating_a_derived_dataset/#initiating-the-backfill.
@@ -24,6 +24,7 @@ owners:
   - lvargas@mozilla.com
   - mozilla/kpi_table_reviewers
 labels:
+  sql_generator: active_users_aggregates_v4
   level: gold
   incremental: true
   change_controlled: true

--- a/sql_generators/active_users_deletion_requests/templates/metadata_deletion_request.yaml
+++ b/sql_generators/active_users_deletion_requests/templates/metadata_deletion_request.yaml
@@ -9,6 +9,7 @@ description: |-
 owners:
   - lvargas@mozilla.com
 labels:
+  sql_generator: active_users_deletion_requests
   incremental: true
 scheduling:
 #  dag_name: bqetl_kpis_shredder

--- a/sql_generators/baseline_clients_city_seen_v1/templates/metadata.yaml
+++ b/sql_generators/baseline_clients_city_seen_v1/templates/metadata.yaml
@@ -13,6 +13,7 @@ description: |-
 owners:
   - wichan@mozilla.com
 labels:
+  sql_generator: baseline_clients_city_seen_v1
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/event_types_history_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: >
 owners:
   - akomar@mozilla.com
 labels:
+  sql_generator: events_daily
   application: {{ dataset }}
   incremental: true
   schedule: daily
@@ -23,4 +24,3 @@ bigquery:
     fields:
       - category
       - event
-

--- a/sql_generators/events_daily/templates/event_types_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/event_types_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: >
 owners:
   - akomar@mozilla.com
 labels:
+  sql_generator: events_daily
   application: {{ dataset }}
   incremental: false
   schedule: daily
@@ -12,4 +13,3 @@ scheduling:
   dag_name: {{ dag_name }}
   date_partition_parameter: null
   parameters: ["submission_date:DATE:{% raw %}{{ds}}{% endraw %}"]
-

--- a/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
+++ b/sql_generators/events_daily/templates/events_daily_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: >
 owners:
   - akomar@mozilla.com
 labels:
+  sql_generator: events_daily
   application: {{ dataset }}
   schedule: daily
   incremental: true
@@ -25,4 +26,3 @@ bigquery:
   clustering:
     fields:
       - sample_id
-

--- a/sql_generators/experiment_monitoring/templates/experiment_crash_aggregates_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_crash_aggregates_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: |-
 owners:
 - ascholtz@mozilla.com
 labels:
+  sql_generator: experiment_monitoring
   application: experiments
   schedule: daily
   table_type: aggregate

--- a/sql_generators/experiment_monitoring/templates/experiment_crash_events_live_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_crash_events_live_v1/metadata.yaml
@@ -5,4 +5,5 @@ description: |-
 owners:
 - ascholtz@mozilla.com
 labels:
+  sql_generator: experiment_monitoring
   materialized_view: true

--- a/sql_generators/experiment_monitoring/templates/experiment_crash_rates_live/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_crash_rates_live/metadata.yaml
@@ -2,4 +2,5 @@ friendly_name: Experiment Crash Rates Live
 description: >
   View for live experiment crash rates.
 labels:
+  sql_generator: experiment_monitoring
   incremental: false

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v1/metadata.yaml
@@ -2,4 +2,5 @@ friendly_name: Experiment Enrollment Aggregates Live
 description: >
   View for live experiment enrollment events.
 labels:
+  sql_generator: experiment_monitoring
   incremental: false

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v2/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_live_v2/metadata.yaml
@@ -2,4 +2,5 @@ friendly_name: Experiment Enrollment Aggregates Live
 description: >
   View for live experiment enrollment events. (glean only)
 labels:
+  sql_generator: experiment_monitoring
   incremental: false

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v1/metadata.yaml
@@ -5,5 +5,6 @@ owners:
 scheduling:
   dag_name: bqetl_experiments_daily
 labels:
+  sql_generator: experiment_monitoring
   table_type: aggregate
   shredder_mitigation: false

--- a/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_enrollment_aggregates_v2/metadata.yaml
@@ -6,6 +6,7 @@ owners:
 scheduling:
   dag_name: bqetl_experiments_daily
 labels:
+  sql_generator: experiment_monitoring
   table_type: aggregate
   shredder_mitigation: false
 bigquery:

--- a/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_events_live_v1/metadata.yaml
@@ -5,4 +5,5 @@ description: |-
 owners:
 - ascholtz@mozilla.com
 labels:
+  sql_generator: experiment_monitoring
   materialized_view: true

--- a/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_aggregates_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: |-
 owners:
 - ascholtz@mozilla.com
 labels:
+  sql_generator: experiment_monitoring
   application: experiments
   schedule: daily
   table_type: aggregate

--- a/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiment_search_events_live_v1/metadata.yaml
@@ -5,4 +5,5 @@ description: |-
 owners:
 - ascholtz@mozilla.com
 labels:
+  sql_generator: experiment_monitoring
   materialized_view: true

--- a/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v1/metadata.yaml
@@ -4,6 +4,7 @@ description: |
 owners:
 - ascholtz@mozilla.com
 labels:
+  sql_generator: experiment_monitoring
   application: experiments
   schedule: daily
   table_type: aggregate

--- a/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v2/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/experiments_daily_active_clients_v2/metadata.yaml
@@ -5,6 +5,7 @@ owners:
 - ascholtz@mozilla.com
 - mwilliams@mozilla.com
 labels:
+  sql_generator: experiment_monitoring
   application: experiments
   schedule: daily
   table_type: aggregate

--- a/sql_generators/feature_usage/templates/metadata.yaml
+++ b/sql_generators/feature_usage/templates/metadata.yaml
@@ -9,6 +9,7 @@ owners:
   - shong@mozilla.com
   - ascholtz@mozilla.com
 labels:
+  sql_generator: feature_usage
   incremental: true
   application: firefox
   schedule: daily

--- a/sql_generators/firefox_crashes/templates/crash_live.metadata.yaml
+++ b/sql_generators/firefox_crashes/templates/crash_live.metadata.yaml
@@ -11,6 +11,7 @@ description: |-
 
   Use `{{ dataset }}.crash` for analysis of complete days.
 labels:
+  sql_generator: firefox_crashes
   authorized: true
 workgroup_access:
 - role: roles/bigquery.dataViewer

--- a/sql_generators/funnels/templates/metadata.yaml
+++ b/sql_generators/funnels/templates/metadata.yaml
@@ -3,6 +3,7 @@ friendly_name: {{ funnel_name }}
 owners: {{ owners }}
 {% endif %}
 labels:
+  sql_generator: funnels
   incremental: true
   table_type: aggregate
 

--- a/sql_generators/fxa_fastly_logs/templates/metadata.yaml
+++ b/sql_generators/fxa_fastly_logs/templates/metadata.yaml
@@ -7,5 +7,6 @@ owners:
 - bewu@mozilla.com
 - atoufali@mozilla.com
 labels:
+  sql_generator: fxa_fastly_logs
   owner1: benwu
   owner2: atoufali

--- a/sql_generators/glean_usage/glean_app_ping_views.py
+++ b/sql_generators/glean_usage/glean_app_ping_views.py
@@ -248,6 +248,7 @@ class GleanAppPingViews(GleanTable):
                     app_name=release_app["canonical_app_name"],
                     app_channels=", ".join(included_channel_views),
                 )
+                labels = {"sql_generator": "glean_usage"}
                 metadata_file = Path(
                     get_table_dir(output_dir, full_view_id) / "metadata.yaml"
                 )
@@ -258,9 +259,10 @@ class GleanAppPingViews(GleanTable):
                             "friendly_name" not in existing_metadata
                             and "description" not in existing_metadata
                         ):
-                            metadata_content = metadata_content + yaml.dump(
-                                existing_metadata
-                            )
+                            labels.update(existing_metadata.pop("labels", None) or {})
+                            if existing_metadata:
+                                metadata_content += yaml.dump(existing_metadata)
+                metadata_content += yaml.dump({"labels": labels})
 
                 write_sql(
                     output_dir,

--- a/sql_generators/glean_usage/templates/baseline_clients_daily.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily.metadata.yaml
@@ -8,3 +8,5 @@ description: |-
   See also: `baseline_clients_last_seen`
 owners:
   - ascholtz@mozilla.com
+labels:
+  sql_generator: glean_usage

--- a/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_daily_v1.metadata.yaml
@@ -9,6 +9,7 @@ description: |-
 owners:
   - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen.metadata.yaml
@@ -12,3 +12,5 @@ description: |-
   See also: `baseline_clients_daily` and `baseline_clients_last_seen`.
 owners:
   - ascholtz@mozilla.com
+labels:
+  sql_generator: glean_usage

--- a/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_first_seen_v1.metadata.yaml
@@ -13,6 +13,7 @@ description: |-
 owners:
   - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: false
   schedule: daily
 scheduling:

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen.metadata.yaml
@@ -9,3 +9,5 @@ description: |-
   See also: `baseline_clients_daily`
 owners:
   - ascholtz@mozilla.com
+labels:
+  sql_generator: glean_usage

--- a/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/baseline_clients_last_seen_v1.metadata.yaml
@@ -10,6 +10,7 @@ description: |-
 owners:
   - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
+++ b/sql_generators/glean_usage/templates/clients_last_seen_joined.metadata.yaml
@@ -14,6 +14,7 @@ description: |-
 owners:
   - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/glean_usage/templates/event_counts_glean_v2.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_counts_glean_v2.metadata.yaml
@@ -5,6 +5,7 @@ description: |-
 owners:
 - bewu@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
 scheduling:
   dag_name: bqetl_monitoring

--- a/sql_generators/glean_usage/templates/event_error_monitoring_aggregates_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_error_monitoring_aggregates_v1.metadata.yaml
@@ -5,6 +5,7 @@ owners:
 - akomar@mozilla.com
 - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
 scheduling:
   dag_name: bqetl_monitoring

--- a/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_flow_monitoring_aggregates_v1.metadata.yaml
@@ -5,6 +5,7 @@ owners:
 - akomar@mozilla.com
 - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
 scheduling:
   dag_name: bqetl_monitoring

--- a/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_monitoring_aggregates_v1.metadata.yaml
@@ -6,7 +6,8 @@ owners:
 - ascholtz@mozilla.com
 - akomar@mozilla.com
 labels:
-  incremental: true 
+  sql_generator: glean_usage
+  incremental: true
 scheduling:
   dag_name: bqetl_monitoring
   # Use backfill-3 project for on-demand query billing

--- a/sql_generators/glean_usage/templates/event_monitoring_live.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_monitoring_live.metadata.yaml
@@ -4,3 +4,5 @@ description: |-
 owners:
 - ascholtz@mozilla.com
 - akomar@mozilla.com
+labels:
+  sql_generator: glean_usage

--- a/sql_generators/glean_usage/templates/event_monitoring_live_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/event_monitoring_live_v1.metadata.yaml
@@ -16,4 +16,5 @@ scheduling:
   - '--billing-project=moz-fx-data-backfill-3'
 {%- endif %}
 labels:
+  sql_generator: glean_usage
   materialized_view: true

--- a/sql_generators/glean_usage/templates/events_first_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_first_seen.metadata.yaml
@@ -5,3 +5,5 @@ description: |-
 owners:
   - kbammarito@mozilla.com
   - vsabino@mozilla.com
+labels:
+  sql_generator: glean_usage

--- a/sql_generators/glean_usage/templates/events_first_seen_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_first_seen_v1.metadata.yaml
@@ -5,6 +5,7 @@ owners:
   - kbammarito@mozilla.com
   - vsabino@mozilla.com
 labels:
+  sql_generator: glean_usage
   schedule: daily
   table_type: client_level
 scheduling:

--- a/sql_generators/glean_usage/templates/events_stream.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_stream.metadata.yaml
@@ -8,3 +8,5 @@ description: |-
 owners:
   - jrediger@mozilla.com
   - wstuckey@mozilla.com
+labels:
+  sql_generator: glean_usage

--- a/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
+++ b/sql_generators/glean_usage/templates/events_stream_v1.metadata.yaml
@@ -9,6 +9,7 @@ owners:
   - jrediger@mozilla.com
   - wstuckey@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_daily.metadata.yaml
@@ -5,6 +5,7 @@ description: |-
 owners:
   - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
+++ b/sql_generators/glean_usage/templates/metrics_clients_last_seen.metadata.yaml
@@ -10,6 +10,7 @@ description: |-
 owners:
   - ascholtz@mozilla.com
 labels:
+  sql_generator: glean_usage
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/attribution_clients.metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   table_type: client_level

--- a/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/engagement.metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activation_clients.metadata.yaml
@@ -16,6 +16,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_activations.metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profile_clients.metadata.yaml
@@ -19,6 +19,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/new_profiles.metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
+++ b/sql_generators/mobile_kpi_support_metrics/templates/retention.metadata.yaml
@@ -20,6 +20,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/sql_generators/nimbus_feature_monitoring/templates/nimbus_feature_monitoring_v1/metadata.yaml
+++ b/sql_generators/nimbus_feature_monitoring/templates/nimbus_feature_monitoring_v1/metadata.yaml
@@ -4,6 +4,7 @@ description: >-
 owners:
   - project-nimbus@mozilla.com
 labels:
+  sql_generator: nimbus_feature_monitoring
   dag: bqetl_nimbus_feature_monitoring
   schedule: daily
   owner1: project-nimbus@mozilla.com

--- a/sql_generators/rust_component_metrics/templates/metadata.yaml
+++ b/sql_generators/rust_component_metrics/templates/metadata.yaml
@@ -2,6 +2,7 @@ friendly_name: {{ ping }}.{{ category }}.{{ metric.name }} aggregates
 description:
   Aggregated metric data derived from {{ ping }}.{{ category }}.{{ metric.name }}
 labels:
+  sql_generator: rust_component_metrics
   incremental: true
 owners:
   - sync-team@mozilla.com

--- a/sql_generators/search_v2/templates/mobile_search_clients_engines_sources_daily.metadata.yaml
+++ b/sql_generators/search_v2/templates/mobile_search_clients_engines_sources_daily.metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - cmorales@mozilla.com
   - akommasani@mozilla.com
 labels:
+  sql_generator: search_v2
   schedule: daily
   table_type: client_level
 scheduling:

--- a/sql_generators/serp_events_v2/templates/metadata.yaml
+++ b/sql_generators/serp_events_v2/templates/metadata.yaml
@@ -12,6 +12,7 @@ owners:
 - kbammarito@mozilla.com
 - betling@mozilla.com
 labels:
+  sql_generator: serp_events_v2
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/stable_tables_monitoring/templates/metadata.yaml.jinja
+++ b/sql_generators/stable_tables_monitoring/templates/metadata.yaml.jinja
@@ -6,7 +6,8 @@ description: |-
   However, there is a potential for duplicate entries in this dataset which is why once a day copy_deduplicate DAG performs de-duplication of this data
   and saves the result in the corresponding _stable namespace (which also acts as long term storage of this raw data).
   These BigEye checks add freshness and volume checks to these stable tables.
-
+labels:
+  sql_generator: stable_tables_monitoring
 monitoring:
   enabled: {{ enable_monitoring }}
   collection: {{ bigeye_collection }}

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -83,9 +83,7 @@ VIEW_METADATA_HEADER = """\
 ---
 """
 
-VIEW_METADATA_TEMPLATE = (
-    VIEW_METADATA_HEADER
-    + """\
+VIEW_METADATA_TEMPLATE = VIEW_METADATA_HEADER + """\
 friendly_name: Historical Pings for `{document_namespace}/{document_type}`
 description: |-
   A historical view of pings sent for the
@@ -98,7 +96,6 @@ description: |-
 
   Clustering fields: `normalized_channel`, `sample_id`
 """
-)
 
 
 def write_dataset_metadata_if_not_exists(
@@ -380,7 +377,7 @@ def write_view_if_not_exists(
         document_namespace=schema.document_namespace,
         document_type=schema.document_type,
     )
-    labels = {}
+    labels: dict = {"sql_generator": "stable_views"}
     # Add a `legacy` label to stable views that select from legacy telemetry ping tables.
     if schema.bq_dataset_family == "telemetry":
         labels["legacy"] = True
@@ -393,17 +390,14 @@ def write_view_if_not_exists(
             existing_metadata = yaml.safe_load(f) or {}
         template_metadata = yaml.safe_load(metadata_content) or {}
         merged = {**template_metadata, **existing_metadata}
-        if labels:
-            merged["labels"] = {
-                **(merged.get("labels") or {}),
-                **labels,
-            }
+        merged["labels"] = {
+            **labels,
+            **(existing_metadata.get("labels") or {}),
+        }
         if merged != existing_metadata:
             should_write_metadata = True
-            metadata_content = VIEW_METADATA_HEADER + yaml.dump(
-                merged, sort_keys=False
-            )
-    elif labels:
+            metadata_content = VIEW_METADATA_HEADER + yaml.dump(merged, sort_keys=False)
+    else:
         metadata_content += yaml.dump({"labels": labels})
 
     if not metadata_file.exists() or should_write_metadata:

--- a/sql_generators/stable_views_redacted/__init__.py
+++ b/sql_generators/stable_views_redacted/__init__.py
@@ -35,7 +35,8 @@ description: |-
 
   See the full (access-restricted) data in `{source_table_short}` and `{source_view_short}`.
 labels:
-    authorized: true
+  sql_generator: stable_views_redacted
+  authorized: true
 """
 
 # Metrics with these data_sensitivity categories are excluded from redacted views.

--- a/sql_generators/table_partition_expirations/templates/metadata.yaml
+++ b/sql_generators/table_partition_expirations/templates/metadata.yaml
@@ -4,6 +4,7 @@ description: |-
 owners:
 - bewu@mozilla.cam
 labels:
+  sql_generator: table_partition_expirations
   incremental: true
   owner1: benwu
 scheduling:

--- a/sql_generators/telemetry_health/templates/telemetry_health_glean_errors_v1/metadata.yaml
+++ b/sql_generators/telemetry_health/templates/telemetry_health_glean_errors_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: |
 owners:
   - tlong@mozilla.com
 labels:
+  sql_generator: telemetry_health
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/telemetry_health/templates/telemetry_health_ping_latency_v1/metadata.yaml
+++ b/sql_generators/telemetry_health/templates/telemetry_health_ping_latency_v1/metadata.yaml
@@ -6,6 +6,7 @@ description: |
 owners:
   - tlong@mozilla.com
 labels:
+  sql_generator: telemetry_health
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/telemetry_health/templates/telemetry_health_ping_volume_p80_v1/metadata.yaml
+++ b/sql_generators/telemetry_health/templates/telemetry_health_ping_volume_p80_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: |
 owners:
   - tlong@mozilla.com
 labels:
+  sql_generator: telemetry_health
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/telemetry_health/templates/telemetry_health_sequence_holes_v1/metadata.yaml
+++ b/sql_generators/telemetry_health/templates/telemetry_health_sequence_holes_v1/metadata.yaml
@@ -5,6 +5,7 @@ description: |
 owners:
   - tlong@mozilla.com
 labels:
+  sql_generator: telemetry_health
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/terms_of_use/templates/terms_of_use_events_v1/metadata.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_events_v1/metadata.yaml.jinja
@@ -9,6 +9,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: terms_of_use
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/terms_of_use/templates/terms_of_use_messages_v1/metadata.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_messages_v1/metadata.yaml.jinja
@@ -9,6 +9,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: terms_of_use
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/terms_of_use/templates/terms_of_use_status_v1/metadata.yaml.jinja
+++ b/sql_generators/terms_of_use/templates/terms_of_use_status_v1/metadata.yaml.jinja
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: terms_of_use
   incremental: false
   schedule: daily
   table_type: client_level

--- a/sql_generators/urlbar_events/templates/metadata.yaml
+++ b/sql_generators/urlbar_events/templates/metadata.yaml
@@ -9,6 +9,7 @@ owners:
 - rburwei@mozilla.com
 - dzeber@mozilla.com
 labels:
+  sql_generator: urlbar_events
   incremental: true
   schedule: daily
   table_type: client_level

--- a/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_active_users_aggregates_v1.metadata.yaml.jinja
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_daily_v1.metadata.yaml.jinja
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_first_seen_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_first_seen_v1.metadata.yaml.jinja
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.metadata.yaml.jinja
+++ b/sql_generators/usage_reporting/templates/usage_reporting_clients_last_seen_v1.metadata.yaml.jinja
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/sql_generators/use_counters/templates/metadata.yaml
+++ b/sql_generators/use_counters/templates/metadata.yaml
@@ -4,6 +4,7 @@ description: |-
 owners:
 - lmcfall@mozilla.com
 labels:
+  sql_generator: use_counters
   incremental: true
   public_bigquery: true
   public_json: true

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/attribution_clients_v1/metadata.yaml
@@ -14,6 +14,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   table_type: client_level

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/engagement_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/engagement_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profile_activation_clients_v1/metadata.yaml
@@ -12,6 +12,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profile_activations_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profile_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profile_clients_v1/metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/new_profiles_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/retention_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/fenix_derived/retention_v1/metadata.yaml
@@ -16,6 +16,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/attribution_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/attribution_clients_v1/metadata.yaml
@@ -12,6 +12,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   table_type: client_level

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/engagement_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/engagement_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activation_clients_v1/metadata.yaml
@@ -12,6 +12,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_activations_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profile_clients_v1/metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profiles_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/new_profiles_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/firefox_ios_derived/retention_v1/metadata.yaml
@@ -16,6 +16,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/attribution_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/attribution_clients_v1/metadata.yaml
@@ -12,6 +12,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   table_type: client_level

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/engagement_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/engagement_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profile_activation_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profile_activation_clients_v1/metadata.yaml
@@ -12,6 +12,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profile_activations_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profile_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profile_clients_v1/metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profiles_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/new_profiles_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/retention_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/focus_android_derived/retention_v1/metadata.yaml
@@ -16,6 +16,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/attribution_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/attribution_clients_v1/metadata.yaml
@@ -12,6 +12,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   table_type: client_level

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/engagement_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/engagement_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profile_activation_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profile_activation_clients_v1/metadata.yaml
@@ -12,6 +12,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profile_activations_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profile_clients_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profile_clients_v1/metadata.yaml
@@ -15,6 +15,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profiles_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/new_profiles_v1/metadata.yaml
@@ -11,6 +11,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/retention_v1/metadata.yaml
+++ b/tests/sql_generators/mobile_kpi_support_metrics/expected/moz-fx-data-shared-prod/klar_android_derived/retention_v1/metadata.yaml
@@ -16,6 +16,7 @@ owners:
   - mozilla/kpi_table_reviewers
   - kik@mozilla.com
 labels:
+  sql_generator: mobile_kpi_support_metrics
   schedule: daily
   incremental: true
   shredder_mitigation: false

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/fenix_derived/terms_of_use_events_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/fenix_derived/terms_of_use_events_v1/metadata.yaml
@@ -9,6 +9,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: terms_of_use
   incremental: true
   schedule: daily
   table_type: client_level

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_messages_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_messages_v1/metadata.yaml
@@ -9,6 +9,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: terms_of_use
   incremental: true
   schedule: daily
   table_type: client_level

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_desktop_derived/terms_of_use_status_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: terms_of_use
   incremental: false
   schedule: daily
   table_type: client_level

--- a/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/metadata.yaml
+++ b/tests/sql_generators/terms_of_use/expected/moz-fx-data-shared-prod/firefox_ios_derived/terms_of_use_status_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: terms_of_use
   incremental: false
   schedule: daily
   table_type: client_level

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/fenix_derived/usage_reporting_active_users_aggregates_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_active_users_aggregates_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_daily_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_daily_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_desktop_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/firefox_ios_derived/usage_reporting_active_users_aggregates_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_daily_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_daily_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_beta_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_daily_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_daily_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_firefox_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_daily_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_daily_v1/metadata.yaml
@@ -8,6 +8,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_first_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:

--- a/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
+++ b/tests/sql_generators/usage_reporting/expected/moz-fx-data-shared-prod/org_mozilla_ios_firefoxbeta_derived/usage_reporting_clients_last_seen_v1/metadata.yaml
@@ -7,6 +7,7 @@ description: |-
 owners:
   - kik@mozilla.com
 labels:
+  sql_generator: usage_reporting
   incremental: true
   schedule: daily
 scheduling:


### PR DESCRIPTION
## Description
To make generated ETLs/views easier to discern, both in the generated SQL output and in the deployed tables/views.

Note that this is just best effort and not entirely comprehensive, as current SQL generators often aren't outputting `metadata.yaml` files for generated views, and I'm not attempting to address that situation this PR.

## Related Tickets & Documents
* https://github.com/mozilla/private-bigquery-etl/pull/1476

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
