### PR TITLE
chore(DENG-11380): complete Plausible backfill

### DIFF
--- a/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/events_v1/backfill.yaml
@@ -7,7 +7,7 @@
     partitions are replaced idempotently.
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false

--- a/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
+++ b/sql/moz-fx-data-shared-prod/plausible_external/sessions_v1/backfill.yaml
@@ -7,7 +7,7 @@
     partitions are replaced idempotently.
   watchers:
   - phlee@mozilla.com
-  status: Initiate
+  status: Complete
   shredder_mitigation: false
   override_retention_limit: false
   override_depends_on_past_end_date: false


### PR DESCRIPTION
[DENG-11380](https://mozilla-hub.atlassian.net/browse/DENG-11380). Completes the backfill initiated in #9827 — flips both entries to `Complete` so the staging tables are copied into production.

Verified in `backfills_staging_derived` first:

- **32 partitions** per table, `20260730`–`20260830`, no gaps. 87.1M events, 36.7M sessions.
- **Row counts match the source parquet exactly** on all six dates measured independently, and match the two partitions the DAG had already loaded into prod (`20260825`, `20260830`) to the row.
- `max(session_id)` = `18446744040699026215`, past the INT64 range, so the uint64 re-encode round-tripped losslessly. Same value in both tables, so joins line up.
- One `site_id` (86997652), zero duplicate `session_id`s, no leftover empty strings, `is_bounce` splits exactly.

Two non-blocking notes: `scroll_depth` reaches 255 on 5 rows of 87.1M (uint8 sentinel from the vendor; schema says 0–100, worth a description tweak later), and there is a real traffic spike 08-18→08-25 peaking at 4.2M sessions with a 94% bounce rate at ~1.1 pageviews/session — source data loaded faithfully, but worth validating with whoever owns firefox.com analytics before it is read as real visits.


[DENG-11380]: https://mozilla-hub.atlassian.net/browse/DENG-11380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ