### PR TITLE
Fix experimenter_experiments query for experiments without metric configs

### DIFF
--- a/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
@@ -90,8 +90,11 @@ def main():
         args.project, args.destination_dataset, args.metric_config_table
     )
     for row in blob:
-        row["metric_config"] = metric_configs.get(row["normandy_slug"])[0]
-        row["metric_config_computed_at"] = metric_configs.get(row["normandy_slug"])[1]
+        # not every experiment has a metric config (and the config table read
+        # may have been skipped entirely), so default both fields to None
+        metric_config = metric_configs.get(row["normandy_slug"])
+        row["metric_config"] = metric_config[0] if metric_config else None
+        row["metric_config_computed_at"] = metric_config[1] if metric_config else None
 
     client = bigquery.Client(args.project)
     client.load_table_from_json(blob, destination_table, job_config=job_config).result()

--- a/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
+++ b/sql/moz-fx-data-experiments/monitoring/experimenter_experiments_v1/query.py
@@ -59,6 +59,19 @@ def read_metric_configs(project: str, dataset: str, table: str) -> dict:
         return {}
 
 
+def attach_metric_configs(blob: list, metric_configs: dict) -> None:
+    """Attach metric config fields to each experiment row, in place.
+
+    Not every experiment has a metric config (and the config table read may have
+    been skipped entirely), so default both fields to None when the slug is
+    absent from ``metric_configs``.
+    """
+    for row in blob:
+        metric_config = metric_configs.get(row["normandy_slug"])
+        row["metric_config"] = metric_config[0] if metric_config else None
+        row["metric_config_computed_at"] = metric_config[1] if metric_config else None
+
+
 def main():
     """Run."""
     args = parser.parse_args()
@@ -89,12 +102,7 @@ def main():
     metric_configs = read_metric_configs(
         args.project, args.destination_dataset, args.metric_config_table
     )
-    for row in blob:
-        # not every experiment has a metric config (and the config table read
-        # may have been skipped entirely), so default both fields to None
-        metric_config = metric_configs.get(row["normandy_slug"])
-        row["metric_config"] = metric_config[0] if metric_config else None
-        row["metric_config_computed_at"] = metric_config[1] if metric_config else None
+    attach_metric_configs(blob, metric_configs)
 
     client = bigquery.Client(args.project)
     client.load_table_from_json(blob, destination_table, job_config=job_config).result()

--- a/tests/experimenter_experiments/test_experimenter_experiments.py
+++ b/tests/experimenter_experiments/test_experimenter_experiments.py
@@ -100,3 +100,24 @@ class TestReadMetricConfigs:
         )
         assert metric_config["overrides"]["start_date"] == "2024-06-01"
         assert metric_config_computed_at == "2024-01-01T00:00:00+00:00"
+
+
+class TestAttachMetricConfigs:
+    def test_attaches_config_when_slug_present(self, query):
+        blob = [{"normandy_slug": "slug-a"}]
+        metric_configs = {"slug-a": ({"has_external_config": True}, "2024-01-01")}
+
+        query.attach_metric_configs(blob, metric_configs)
+
+        assert blob[0]["metric_config"] == {"has_external_config": True}
+        assert blob[0]["metric_config_computed_at"] == "2024-01-01"
+
+    def test_missing_slug_defaults_to_none(self, query):
+        # regression: a slug absent from metric_configs must not raise
+        # `'NoneType' object is not subscriptable`
+        blob = [{"normandy_slug": "no-config-slug"}]
+
+        query.attach_metric_configs(blob, {})
+
+        assert blob[0]["metric_config"] is None
+        assert blob[0]["metric_config_computed_at"] is None


### PR DESCRIPTION
## Description

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2067895

```
[2026-08-31, 19:01:27 UTC] {pod_manager.py:496} INFO - [base] TypeError: 'NoneType' object is not subscriptable
```



<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
