### PR TITLE
monitoring(ads): add desktop-specific volume monitor to ads_client_operations_and_errors_hourly_v1

### DIFF
--- a/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/bigconfig.yml
+++ b/sql/moz-fx-data-shared-prod/ads_derived/ads_client_operations_and_errors_hourly_v1/bigconfig.yml
@@ -64,3 +64,29 @@ tag_deployments:
             metric_schedule:
               named_schedule:
                 name: Default Schedule - 13:00 UTC
+      # Desktop rollout is still thin (single-digit pings/day), so a table-wide FRESHNESS
+      # or SUM check can't tell a desktop-specific gap from normal noise - mobile volume
+      # masks it. This counts rows for surface = 'Desktop' specifically over a rolling
+      # 3-day window, catching a multi-day silence like the 2026-08-26 to 2026-08-31
+      # gap that nothing else here would have flagged. Revisit the threshold/window once
+      # desktop volume is high enough for a statistically meaningful check.
+      - column_selectors:
+          - name: moz-fx-data-shared-prod.moz-fx-data-shared-prod.ads_derived.ads_client_operations_and_errors_hourly_v1.*
+        metrics:
+          - metric_name: DESKTOP_ROW_COUNT
+            metric_type:
+              type: PREDEFINED
+              predefined_metric: COUNT_ROWS
+            conditions:
+              - surface = 'Desktop'
+            threshold:
+              type: CONSTANT
+              lower_bound: 1
+            lookback:
+              lookback_type: DATA_TIME
+              lookback_window:
+                interval_type: DAYS
+                interval_value: 3
+            metric_schedule:
+              named_schedule:
+                name: Default Schedule - 13:00 UTC


### PR DESCRIPTION
## Description

Adds a Bigeye monitor scoped specifically to `surface = 'Desktop'` on `ads_derived.ads_client_operations_and_errors_hourly_v1`, as a follow-up to the desktop rollout support added in #9810.

### Why

The table's existing monitors (`FRESHNESS`, and `SUM` on ops/errors) are all table-wide. Desktop's ads_client volume is tiny relative to mobile (single-digit pings/day today), so a desktop-specific gap is invisible to them — mobile traffic keeps the table "fresh" and keeps the SUMs non-zero regardless of what desktop is doing.

We found this the hard way: desktop's ads_client metrics went completely silent for five days (2026-08-26 to 2026-08-31) and nothing alerted on it — I only noticed by querying the raw ping table by hand.

### What this adds

A `COUNT_ROWS` metric filtered to `surface = 'Desktop'` via bigConfig's `conditions` field — the same mechanism already used in [`firefoxdotcom_derived/www_site_hits_v1/bigconfig.yml`](https://github.com/mozilla/bigquery-etl/blob/main/sql/moz-fx-data-shared-prod/firefoxdotcom_derived/www_site_hits_v1/bigconfig.yml#L14-L15) (`conditions` maps 1:1 to Bigeye's `MetricConfiguration.filters` — confirmed by reading the `bigeye_sdk` model directly, since this isn't called out in `docs/reference/bigconfig.md`). Threshold is `lower_bound: 1` over a rolling 3-day `DATA_TIME` lookback, so it fires only on a multi-day gap rather than normal day-to-day sparseness at current volume.

### What this deliberately does NOT add

Desktop-specific error-rate monitors (`client_error_*`, `build_cache_error_*`, etc. filtered to desktop). At 1-2 ops/day there isn't enough volume for a `SUM` threshold — AUTO or CONSTANT — to mean anything statistically; it would just page on noise. Redash is the right place to eyeball desktop error trends in the interim (separate, non-code change). Revisit adding Bigeye error monitors once desktop volume grows enough for a meaningful threshold.

### Verification

- `bqetl monitoring validate` passes.
- Loaded the file directly through `bigeye_sdk.model.big_config.BigConfig` (not just the validate CLI) and printed the parsed `DESKTOP_ROW_COUNT` metric to confirm `conditions`, `threshold`, and `lookback` all parsed as intended rather than being silently dropped by a lenient parser.
- `yamllint -c .yamllint.yaml` clean.

## Related Tickets & Documents
* Bug 2058567

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**