### PR TITLE
feat(data_governance): expose column classifications without sample values

### DIFF
--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/column_classifications/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/column_classifications/metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Column Classifications
+description: |-
+  An authorized view on top of the
+  `data_governance_metadata_derived.column_classifications_v1` table that
+  leaves out the sample values.
+
+  One row per classified column: the Mozilla data taxonomy label the model
+  chose, its confidence and reasoning, and the profiling statistics it was
+  shown.
+owners:
+- akomarzewski@mozilla.com
+- cmorales@mozilla.com
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/column_classifications/view.sql
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/column_classifications/view.sql
@@ -1,8 +1,38 @@
+-- Everything in column_classifications_v1 except evidence.sanitized_samples.
+-- Columns are listed rather than wildcarded so that a new column in the
+-- restricted table is not exposed to mozilla-confidential until someone adds
+-- it here on purpose.
 CREATE OR REPLACE VIEW
   `moz-fx-data-shared-prod.data_governance_metadata.column_classifications`
 AS
 SELECT
-  * EXCEPT (evidence),
-  (SELECT AS STRUCT evidence.* EXCEPT (sanitized_samples)) AS evidence,
+  classified_at,
+  run_id,
+  source_project,
+  source_dataset,
+  source_table,
+  column_name,
+  data_type,
+  primary_label,
+  secondary_labels,
+  confidence,
+  reasoning,
+  needs_review,
+  matched_probe,
+  data_sensitivity,
+  model,
+  taxonomy_version,
+  input_hash,
+  IF(
+    evidence IS NULL,
+    NULL,
+    STRUCT(
+      evidence.null_rate,
+      evidence.distinct_count,
+      evidence.is_high_cardinality,
+      evidence.column_tier,
+      evidence.existing_description
+    )
+  ) AS evidence,
 FROM
   `moz-fx-data-shared-prod.data_governance_metadata_derived.column_classifications_v1`

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/column_classifications/view.sql
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/column_classifications/view.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.data_governance_metadata.column_classifications`
+AS
+SELECT
+  * EXCEPT (evidence),
+  (SELECT AS STRUCT evidence.* EXCEPT (sanitized_samples)) AS evidence,
+FROM
+  `moz-fx-data-shared-prod.data_governance_metadata_derived.column_classifications_v1`

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/dataset_metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/dataset_metadata.yaml
@@ -1,0 +1,14 @@
+friendly_name: Data Governance Metadata
+description: |-
+  Views for accessing Mozilla data governance metadata.
+
+  Contains views to selected tables and columns from the
+  `data_governance_metadata_derived` dataset that are safe to expose to
+  mozilla-confidential.
+dataset_base_acl: view
+user_facing: true
+labels: {}
+workgroup_access:
+- role: roles/bigquery.dataViewer
+  members:
+  - workgroup:mozilla-confidential/data-viewers


### PR DESCRIPTION
Add an authorized view over column_classifications_v1 in a new user-facing data_governance_metadata dataset readable by mozilla-confidential. The view leaves out evidence.sanitized_samples to minimize risk of samples of sensitive data being accessible wider than by specific workgroups.

## Related Tickets & Documents
* DENG-11453