### PR TITLE
Add user-facing person_api_staff_members view

### DIFF
--- a/sql/moz-fx-data-shared-prod/mozcloud/person_api_staff_members/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/mozcloud/person_api_staff_members/metadata.yaml
@@ -1,0 +1,10 @@
+friendly_name: Person API Staff Members
+description: |-
+  Mozilla staff members exported from mozilla-person-api (CIS) via the
+  moz-fx-platform-mgmt-global project. Each row represents one active Mozilla
+  staff member, including their email, name, title, team, manager, worker type,
+  cost center, GitHub and Slack identifiers, and LDAP and mozillians.org group
+  memberships. This is the same data as https://phonebook.mozilla.org/.
+owners:
+- jbuckley@mozilla.com
+- wdawson@mozilla.com

--- a/sql/moz-fx-data-shared-prod/mozcloud/person_api_staff_members/view.sql
+++ b/sql/moz-fx-data-shared-prod/mozcloud/person_api_staff_members/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.mozcloud.person_api_staff_members`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.mozcloud_workgroups_syndicate.person_api_staff_members`


### PR DESCRIPTION
## Description

/CC @jbuck @quiiver 

This data is seeing active use in a non-user-facing capacity e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=2068320. I've talked to Cloud Eng about the stability of the underlying data and we're comfortable owning this data in a user-facing capacity, though see https://mozilla-hub.atlassian.net/browse/DENG-10894 for related work DE has done to support similar.

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/MZCLD-3946
* https://bugzilla.mozilla.org/show_bug.cgi?id=2068320
* DENG-10894

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
