### PR TITLE
fix(deploy): pull routine dependencies into isolated deploys

### DIFF
--- a/bigquery_etl/cli/deploy.py
+++ b/bigquery_etl/cli/deploy.py
@@ -50,6 +50,7 @@ from bigquery_etl.util.target import (
     QUERY_SCRIPT,
     VIEW_FILE,
     Target,
+    collect_routine_dependencies,
     collect_target_dependencies,
     ensure_dataset_exists,
     prepare_target_files,
@@ -353,6 +354,22 @@ def deploy(
         isolated_routine_deps = _collect_isolated_dependencies(
             artifacts, sql_dir, target
         )
+
+        if routines:
+            deployed_routines = {
+                f
+                for f in paths_matching_name_pattern(
+                    paths if paths else None,
+                    sql_dir,
+                    None,
+                    list(ROUTINE_FILES),
+                    file_regex=ROUTINE_FILE_RE,
+                )
+                if f.name in ROUTINE_FILES
+            }
+            isolated_routine_deps.extend(
+                collect_routine_dependencies(deployed_routines)
+            )
 
     # publish routines first since tables/views may depend on them
     routine_results = {}

--- a/bigquery_etl/cli/deploy.py
+++ b/bigquery_etl/cli/deploy.py
@@ -344,6 +344,22 @@ def deploy(
         include_materialized_views=isolated,
     )
 
+    # routine files being deployed; used both to collect their dependencies for
+    # --isolated and to group routines by source project for publishing below
+    deployed_routine_files: List[Path] = []
+    if routines:
+        deployed_routine_files = [
+            f
+            for f in paths_matching_name_pattern(
+                paths if paths else None,
+                sql_dir,
+                None,
+                list(ROUTINE_FILES),
+                file_regex=ROUTINE_FILE_RE,
+            )
+            if f.name in ROUTINE_FILES
+        ]
+
     # For --isolated, collect dependencies up front so we can feed any
     # discovered UDFs into the routine publish step below (otherwise the
     # schema-resolver dry-run sees a stale or missing target UDF). Stubs for
@@ -355,21 +371,9 @@ def deploy(
             artifacts, sql_dir, target
         )
 
-        if routines:
-            deployed_routines = {
-                f
-                for f in paths_matching_name_pattern(
-                    paths if paths else None,
-                    sql_dir,
-                    None,
-                    list(ROUTINE_FILES),
-                    file_regex=ROUTINE_FILE_RE,
-                )
-                if f.name in ROUTINE_FILES
-            }
-            isolated_routine_deps.extend(
-                collect_routine_dependencies(deployed_routines)
-            )
+        isolated_routine_deps.extend(
+            collect_routine_dependencies(set(deployed_routine_files))
+        )
 
     # publish routines first since tables/views may depend on them
     routine_results = {}
@@ -394,16 +398,8 @@ def deploy(
         # logic stays correct — refs to unpublished UDFs need to be qualified
         # with the *source* project they belong to.
         routines_by_source: Dict[str, Set[Path]] = defaultdict(set)
-        if routines:
-            for f in paths_matching_name_pattern(
-                paths if paths else None,
-                sql_dir,
-                None,
-                list(ROUTINE_FILES),
-                file_regex=ROUTINE_FILE_RE,
-            ):
-                if f.name in ROUTINE_FILES:
-                    routines_by_source[f.parent.parent.parent.name].add(f)
+        for f in deployed_routine_files:
+            routines_by_source[f.parent.parent.parent.name].add(f)
         for p in isolated_routine_deps:
             routines_by_source[p.parent.parent.parent.name].add(p)
 

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -867,6 +867,15 @@ def collect_target_dependencies(
     return artifact_dependencies
 
 
+def collect_routine_dependencies(routine_files: Set[Path]) -> Set[Path]:
+    """Transitively collect routine paths referenced by `routine_files`.
+
+    Returns the referenced routine paths (transitive), excluding the inputs.
+    """
+    routine_names = [f"{f.parent.parent.name}.{f.parent.name}" for f in routine_files]
+    return _udf_dep_paths(routine_names) - set(routine_files)
+
+
 def target_ref_for_source(
     target: "Target",
     target_project: str,

--- a/tests/util/test_target.py
+++ b/tests/util/test_target.py
@@ -1220,3 +1220,31 @@ class TestShouldGrantImpersonationAccess:
         monkeypatch.setenv(ENV, "1")  # would grant for a human; ignored for agents
         target_module.set_grant_impersonation_access(None)
         assert _should_grant_impersonation_access("sa@p.iam") is False
+
+
+class TestCollectRoutineDependencies:
+    def _write_udf(self, sql_dir, dataset, name, body):
+        udf_dir = sql_dir / "proj" / dataset / name
+        udf_dir.mkdir(parents=True)
+        (udf_dir / "udf.sql").write_text(
+            f"CREATE OR REPLACE FUNCTION {dataset}.{name}() AS ({body});\n"
+        )
+        return udf_dir / "udf.sql"
+
+    def test_transitive_deps_excluding_inputs(self, tmp_path, monkeypatch):
+        from bigquery_etl.routine import parse_routine
+        from bigquery_etl.util.target import collect_routine_dependencies
+
+        sql_dir = tmp_path / "sql"
+        # udf_a -> udf_b -> udf_c
+        path_a = self._write_udf(sql_dir, "udf", "udf_a", "udf.udf_b()")
+        path_b = self._write_udf(sql_dir, "udf", "udf_b", "udf.udf_c()")
+        path_c = self._write_udf(sql_dir, "udf", "udf_c", "1")
+
+        raw = parse_routine.read_routine_dir(str(sql_dir))
+        monkeypatch.setattr(target_module, "read_routine_dir", lambda *a, **k: raw)
+
+        # deploying only udf_a should pull in b and c, not a itself
+        assert collect_routine_dependencies({path_a}) == {path_b, path_c}
+        # deploying a leaf pulls in nothing
+        assert collect_routine_dependencies({path_c}) == set()


### PR DESCRIPTION
## Description

`bqetl deploy --isolated` only walked table/view bodies for dependencies, so a routine that calls another routine left the callee's reference pointing at the source (prod) routine and creating the caller then requires invoke permission on it, which the stage-deploy SA lacks (causing 403s on routine-only changes). This walks the routines being deployed for their transitive routine dependencies too, publishing them into the target dataset so the references get rewritten to the isolated copies.
See https://github.com/mozilla/private-bigquery-etl/actions/runs/33562395371/job/100038262706?pr=1479

## Related Tickets & Documents
* https://github.com/mozilla/private-bigquery-etl/actions/runs/33562395371/job/100038262706?pr=1479

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
