### PR TITLE
chore(schema): add base schema for search_derived

### DIFF
--- a/sql/moz-fx-data-shared-prod/search_derived/dataset_schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/dataset_schema.yaml
@@ -194,3 +194,82 @@ fields:
   description: The date the browser profile was created, encoded as the number of days since the Unix epoch (January 1, 1970). This can be converted
     to a calendar date for profile cohort analysis.
   type: INT64
+- name: profile_group_id
+  description: A UUID that identifies a group of Firefox profiles belonging to the same user across installations. Used to associate activity
+    across multiple profiles on the same device or account.
+  type: STRING
+- name: sample_id
+  description: A stable integer bucket (0–99) derived from the client ID, used to sample a reproducible subset of the population for analysis
+    or experimentation.
+  type: INT64
+- name: sap
+  description: The count of Search Access Point (SAP) searches initiated by the user, where a SAP search is one that originates directly from
+    a Firefox-provided search entry point such as the address bar or search bar.
+  type: INT64
+- name: search_cohort
+  description: An identifier for the search experiment or cohort group the client was assigned to, used to track targeted search configuration
+    rollouts or experiments. Null for clients not enrolled in any cohort.
+  type: STRING
+- name: search_count
+  description: The total number of searches performed by the client, aggregated across all search access points and engines for the reporting
+    period.
+  type: INT64
+- name: search_with_ads
+  description: The count of search result pages that contained advertisements, as observed through SAP-tagged searches. This represents monetizable
+    search activity where ads were served alongside results.
+  type: INT64
+- name: search_with_ads_organic
+  description: The count of search result pages containing advertisements that originated from organic (non-SAP) navigation, such as follow-on
+    searches initiated outside of Firefox-provided entry points.
+  type: INT64
+- name: sessions_started_on_this_day
+  description: The number of browser sessions that were started by the client on the reporting day. A value of zero indicates the client was active
+    but did not start a new session on that day.
+  type: INT64
+- name: source
+  description: A string identifying the origin or entry point of a search event, such as the address bar, a suggestion, an in-content SAP, or
+    other Firefox UI surface. It may include partner and channel tagging information.
+  type: STRING
+- name: state
+  description: The two-letter US state abbreviation derived from the client's inferred geographic location. Null for clients whose location cannot
+    be resolved to a US state.
+  type: STRING
+- name: submission_date
+  description: The date on which the telemetry ping was received by Mozilla's data pipeline. Used as the primary partitioning and filtering dimension
+    for time-based analysis.
+- name: subsession_hours_sum
+  description: The total number of active browser hours accumulated across all subsessions within the reporting period. Represents the sum of
+    time the browser was open and active.
+  type: FLOAT64
+- name: tab_open_event_count_sum
+  description: The total number of tab-open events recorded for the client during the reporting period. Null when this metric was not collected
+    or is unavailable for the client.
+  type: INT64
+- name: tagged_follow_on
+  description: The count of follow-on searches that were tagged with a partner code, meaning they were triggered as a continuation of an initial
+    SAP search and are attributable to a search partner agreement.
+  type: INT64
+- name: tagged_sap
+  description: The count of SAP searches that carried a partner attribution tag, indicating they are attributable to a specific search partner
+    deal and are eligible for revenue reporting.
+  type: INT64
+- name: tagged_searches
+  description: The total count of searches — across all access points — that were tagged with a partner attribution code, combining tagged SAP
+    and tagged follow-on searches.
+  type: INT64
+- name: total_searches
+  description: The aggregate count of all searches performed by the client regardless of source, tag status, or engine. Serves as the broadest
+    measure of search volume for a client.
+  type: INT64
+- name: total_uri_count
+  description: The total number of URIs visited by the client during the reporting period, used as a proxy for overall browsing activity. Null
+    when this metric was not reported by the client.
+  type: INT64
+- name: unknown
+  description: The count of search events whose source or classification could not be determined and did not map to any known search access point
+    or category. A value of zero indicates all searches were successfully classified.
+  type: INT64
+- name: user_pref_browser_search_region
+  description: The region code stored in the client's browser search region preference, typically an ISO 3166-1 alpha-2 country code. This value
+    reflects the user's configured or detected region used to determine default search engine settings.
+  type: STRING

--- a/sql/moz-fx-data-shared-prod/search_derived/dataset_schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/dataset_schema.yaml
@@ -92,8 +92,8 @@ fields:
     This URL is used to identify the search partner and attribution parameters.
   type: STRING
 - name: default_search_engine_submission_url
-  description: The submission URL for the default search engine as reported through an alternative telemetry path. This field is currently always
-    null and is retained for schema compatibility.
+  description: The submission URL for the default search engine as reported through an alternative telemetry path. This is the base URL used to
+    submit search queries to the engine, including any partner or channel-specific query parameters.
   type: STRING
 - name: device
   description: The device form factor of the client, either 'desktop' or 'mobile'. This distinguishes between browser usage on traditional computers
@@ -111,19 +111,24 @@ fields:
   description: A nested array of search activity broken down by search engine key, containing arrays of per-engine counts for total searches,
     tagged searches, searches with ads, and ad clicks.
   type: RECORD
-- name: engine_searches_key
-  description: The identifier of a search engine within the engine_searches nested structure, such as 'google-b-m' or 'none'. This key links search
-    activity counts to a specific search engine.
+  fields:
+  - name: key
+    description: The identifier of a search engine within the engine_searches nested structure, such as 'google-b-m' or 'none'. This key links
+      search activity counts to a specific search engine.
+    type: STRING
 - name: experiments
   description: A nested array of key-value pairs representing the Nimbus or legacy experiments the client was enrolled in at the time of data
     collection. The key is the experiment slug and the value is the branch name.
   type: RECORD
-- name: experiments_key
-  description: The slug identifier of an experiment that the client was enrolled in, such as a Nimbus experiment name. This key is used to look
-    up experiment enrollment within the experiments array.
-- name: experiments_value
-  description: The branch name of the experiment the client was assigned to, such as 'control', 'treatment', or 'rollout'. This indicates which
-    variant of the experiment the client experienced.
+  fields:
+  - name: key
+    description: The slug identifier of an experiment that the client was enrolled in, such as a Nimbus experiment name. This key is used to look
+      up experiment enrollment within the experiments array.
+    type: STRING
+  - name: value
+    description: The branch name of the experiment the client was assigned to, such as 'control', 'treatment', or 'rollout'. This indicates which
+      variant of the experiment the client experienced.
+    type: STRING
 - name: forecast_trained_at
   description: The UTC timestamp at which the forecasting model used to generate a prediction row was trained. This is used to identify the model
     version and training recency associated with a forecast.
@@ -175,9 +180,9 @@ fields:
 - name: os_version_major
   description: The major version number component of the client's operating system version. This is an integer extracted from the full OS version
     string for easier numeric filtering and aggregation.
+  type: INTEGER
 - name: os_version_minor
-  description: The minor version or descriptive label of the client's operating system, such as 'Windows 11', 'Windows 10', or a numeric minor
-    version string. This provides finer-grained OS segmentation beyond the major version.
+  description: The minor version component of the client's operating system version. E.g. for version "100.9.11", the minor is 9.
 - name: partner
   description: The name of the search partner associated with an agreement or revenue relationship, such as 'Google', 'DuckDuckGo', or 'Bing'.
     This identifies the commercial search partner for attribution and reporting.
@@ -237,6 +242,7 @@ fields:
 - name: submission_date
   description: The date on which the telemetry ping was received by Mozilla's data pipeline. Used as the primary partitioning and filtering dimension
     for time-based analysis.
+  type: DATE
 - name: subsession_hours_sum
   description: The total number of active browser hours accumulated across all subsessions within the reporting period. Represents the sum of
     time the browser was open and active.

--- a/sql/moz-fx-data-shared-prod/search_derived/dataset_schema.yaml
+++ b/sql/moz-fx-data-shared-prod/search_derived/dataset_schema.yaml
@@ -1,0 +1,196 @@
+fields:
+- name: active_addons_count_mean
+  description: The mean number of active browser add-ons installed for a client over the aggregation period. A higher value indicates the client
+    has more extensions or plugins enabled on average.
+  type: FLOAT64
+- name: active_hours_sum
+  description: The total number of hours the browser was actively in use during the aggregation period. This is a sum across all sessions and
+    excludes idle time.
+  type: FLOAT64
+- name: ad_click
+  description: The count of ad clicks that originated from a Search Access Point (SAP) during the aggregation period. A value of 0 means no ads
+    were clicked.
+  type: INT64
+- name: ad_click_organic
+  description: The count of ad clicks that originated from organic (non-SAP) searches during the aggregation period. A value of 0 means no organic
+    ad clicks were recorded.
+  type: INT64
+- name: addon_version
+  description: The version string of the search-related browser add-on, if one is installed and active. This field is null for clients that do
+    not have the add-on installed.
+  type: STRING
+- name: app_name
+  description: The name of the Mozilla application submitting the data, such as Fenix, Fennec, or Firefox Preview. This identifies the specific
+    browser or product variant.
+  type: STRING
+- name: app_version
+  description: The version of the Mozilla application at the time of data collection, represented as a version number string. This can be used
+    to segment data by release version.
+  type: STRING
+- name: channel
+  description: The release channel of the Mozilla application, such as release, beta, esr, or aurora. This indicates which update channel the
+    client is subscribed to.
+  type: STRING
+- name: client_count
+  description: The number of distinct clients contributing to an aggregated row. A value of 1 indicates data from a single client, while higher
+    values reflect aggregations across multiple clients.
+  type: INT64
+- name: client_id
+  description: A unique identifier for a Firefox client installation, represented as a UUID. This is used to track activity for a specific browser
+    profile over time.
+  type: STRING
+- name: country
+  description: The two-letter ISO 3166-1 alpha-2 country code indicating the country from which the client submitted data. This is derived from
+    the client's IP address at the time of submission.
+  type: STRING
+- name: dau_engaged_w_sap
+  description: The count of daily active users who performed at least one search through a Search Access Point (SAP) on the given day. A value
+    of 0 indicates no users were engaged with SAP searches.
+  type: INT64
+- name: dau_w_engine_as_default
+  description: The count of daily active users who had a particular search engine set as their default on the given day. A value of 0 indicates
+    no users had that engine as their default.
+  type: INT64
+- name: days_clicked_ads_bytes
+  description: A bit-packed BYTES field representing the set of days within the analysis window on which the client clicked at least one search
+    ad. Each bit corresponds to a specific day, with a set bit indicating an ad click occurred.
+  type: BYTES
+- name: days_created_profile_bytes
+  description: A bit-packed BYTES field indicating the day or days within the analysis window on which the client's browser profile was created.
+    Each bit corresponds to a specific day in the window.
+  type: BYTES
+- name: days_searched_bytes
+  description: A bit-packed BYTES field representing the set of days within the analysis window on which the client performed at least one search.
+    Each bit corresponds to a specific day, with a set bit indicating a search occurred.
+  type: BYTES
+- name: days_searched_with_ads_bytes
+  description: A bit-packed BYTES field representing the set of days within the analysis window on which the client performed a search that returned
+    ad results. Each bit corresponds to a specific day, with a set bit indicating an ad-bearing search occurred.
+  type: BYTES
+- name: days_seen_bytes
+  description: A bit-packed BYTES field representing the set of days within the analysis window on which the client was active and submitted telemetry.
+    Each bit corresponds to a specific day, with a set bit indicating the client was seen.
+  type: BYTES
+- name: days_tagged_searched_bytes
+  description: A bit-packed BYTES field representing the set of days within the analysis window on which the client performed at least one tagged
+    (SAP-attributed) search. Each bit corresponds to a specific day, with a set bit indicating a tagged search occurred.
+  type: BYTES
+- name: default_private_search_engine
+  description: The identifier of the search engine set as the default for private browsing mode, such as 'ddg' for DuckDuckGo. This field is null
+    when no distinct private browsing default engine is configured.
+  type: STRING
+- name: default_search_engine
+  description: The identifier of the client's default search engine, such as 'google-b-m' or 'ddg'. This reflects the engine that will be used
+    when the client performs a search from the browser's address or search bar.
+  type: STRING
+- name: default_search_engine_data_load_path
+  description: The load path indicating how the default search engine was installed or configured, for example '[app]google' for a built-in engine
+    or '[addon]google@search.mozilla.org' for one installed via an add-on.
+  type: STRING
+- name: default_search_engine_data_submission_url
+  description: The base URL used to submit search queries to the default search engine, including any partner or channel-specific query parameters.
+    This URL is used to identify the search partner and attribution parameters.
+  type: STRING
+- name: default_search_engine_submission_url
+  description: The submission URL for the default search engine as reported through an alternative telemetry path. This field is currently always
+    null and is retained for schema compatibility.
+  type: STRING
+- name: device
+  description: The device form factor of the client, either 'desktop' or 'mobile'. This distinguishes between browser usage on traditional computers
+    versus mobile devices.
+  type: STRING
+- name: distribution_id
+  description: An identifier for the Firefox distribution or partner build, such as 'canonical-002' or 'mint-001'. This is null for standard Mozilla
+    builds with no third-party distribution agreement.
+  type: STRING
+- name: engine
+  description: The identifier of the search engine associated with a specific search event or aggregation, such as 'google', 'ddg', or 'custom'.
+    This identifies which engine was used to perform the search.
+  type: STRING
+- name: engine_searches
+  description: A nested array of search activity broken down by search engine key, containing arrays of per-engine counts for total searches,
+    tagged searches, searches with ads, and ad clicks.
+  type: RECORD
+- name: engine_searches_key
+  description: The identifier of a search engine within the engine_searches nested structure, such as 'google-b-m' or 'none'. This key links search
+    activity counts to a specific search engine.
+- name: experiments
+  description: A nested array of key-value pairs representing the Nimbus or legacy experiments the client was enrolled in at the time of data
+    collection. The key is the experiment slug and the value is the branch name.
+  type: RECORD
+- name: experiments_key
+  description: The slug identifier of an experiment that the client was enrolled in, such as a Nimbus experiment name. This key is used to look
+    up experiment enrollment within the experiments array.
+- name: experiments_value
+  description: The branch name of the experiment the client was assigned to, such as 'control', 'treatment', or 'rollout'. This indicates which
+    variant of the experiment the client experienced.
+- name: forecast_trained_at
+  description: The UTC timestamp at which the forecasting model used to generate a prediction row was trained. This is used to identify the model
+    version and training recency associated with a forecast.
+  type: TIMESTAMP
+- name: geo
+  description: A geographic grouping used for aggregation, representing either a specific country code (e.g., 'US', 'GB') or the category 'non-Tier1'
+    for countries outside the primary tier. This is used for high-level geographic segmentation.
+  type: STRING
+- name: is_default_browser
+  description: A boolean indicating whether Firefox is set as the operating system's default browser. True means Firefox is the default browser;
+    false means another browser is set as default.
+  type: BOOLEAN
+- name: is_sap_monetizable
+  description: A boolean indicating whether the client's search activity is eligible for monetization through a Search Access Point (SAP) partnership.
+    True means the client meets the criteria for SAP revenue attribution; false means it does not.
+  type: BOOLEAN
+- name: locale
+  description: The BCP 47 language and region tag representing the client's browser locale, such as 'en-US' or 'fr-FR'. This reflects the language
+    and regional settings configured in the browser.
+  type: STRING
+- name: max_concurrent_tab_count_max
+  description: The maximum number of browser tabs open simultaneously at any point during the aggregation period. This represents the peak tab
+    concurrency observed for the client.
+  type: INT64
+- name: normalized_app_name
+  description: A standardized form of the application name, consolidating variant-specific names into canonical groupings such as 'Fenix', 'Fennec',
+    or 'Focus'. This makes it easier to aggregate across related app variants.
+  type: STRING
+- name: normalized_default_search_engine
+  description: A standardized, human-readable label for the client's default search engine, such as 'Google', 'DuckDuckGo', or 'Bing'. Minor engine
+    variants are collapsed into their canonical names; null indicates an engine outside the recognized set.
+  type: STRING
+- name: normalized_engine
+  description: A standardized, human-readable label for a search engine, such as 'Google', 'DuckDuckGo', or 'Bing'. This collapses engine identifier
+    variants into their canonical partner name for reporting purposes.
+  type: STRING
+- name: organic
+  description: The count of organic searches — searches performed directly without attribution to a Search Access Point — during the aggregation
+    period. A value of 0 indicates no organic searches were recorded.
+  type: INT64
+- name: os
+  description: The operating system on which the browser is running, such as 'Windows', 'Mac', 'Linux', or 'Other'. This is used for platform-level
+    segmentation of search activity.
+  type: STRING
+- name: os_version
+  description: The full version string of the client's operating system, which may include major, minor, and patch components. The format varies
+    by platform.
+  type: STRING
+- name: os_version_major
+  description: The major version number component of the client's operating system version. This is an integer extracted from the full OS version
+    string for easier numeric filtering and aggregation.
+- name: os_version_minor
+  description: The minor version or descriptive label of the client's operating system, such as 'Windows 11', 'Windows 10', or a numeric minor
+    version string. This provides finer-grained OS segmentation beyond the major version.
+- name: partner
+  description: The name of the search partner associated with an agreement or revenue relationship, such as 'Google', 'DuckDuckGo', or 'Bing'.
+    This identifies the commercial search partner for attribution and reporting.
+  type: STRING
+- name: policies_is_enterprise
+  description: A boolean indicating whether the browser is running under enterprise policy management. True means enterprise policies are applied;
+    false means the browser is not enterprise-managed; null indicates the policy status is unknown.
+  type: BOOLEAN
+- name: profile_age_in_days
+  description: The age of the browser profile in days at the time of data collection, calculated as the number of days since the profile was created.
+    A value of 0 indicates a newly created profile.
+  type: INT64
+- name: profile_creation_date
+  description: The date the browser profile was created, encoded as the number of days since the Unix epoch (January 1, 1970). This can be converted
+    to a calendar date for profile cohort analysis.
+  type: INT64


### PR DESCRIPTION
## Base Schema

Generated `search_derived.yaml` with descriptions for 70 shared fields.

Shared fields: active_addons_count_mean, active_hours_sum, ad_click, ad_click_organic, addon_version, app_name, app_version, channel, client_count, client_id, country, dau_engaged_w_sap, dau_w_engine_as_default, days_clicked_ads_bytes, days_created_profile_bytes, days_searched_bytes, days_searched_with_ads_bytes, days_seen_bytes, days_tagged_searched_bytes, default_private_search_engine, default_search_engine, default_search_engine_data_load_path, default_search_engine_data_submission_url, default_search_engine_submission_url, device, distribution_id, engine, engine_searches, engine_searches.key, experiments, experiments.key, experiments.value, forecast_trained_at, geo, is_default_browser, is_sap_monetizable, locale, max_concurrent_tab_count_max, normalized_app_name, normalized_default_search_engine, normalized_engine, organic, os, os_version, os_version_major, os_version_minor, partner, policies_is_enterprise, profile_age_in_days, profile_creation_date, profile_group_id, sample_id, sap, search_cohort, search_count, search_with_ads, search_with_ads_organic, sessions_started_on_this_day, source, state, submission_date, subsession_hours_sum, tab_open_event_count_sum, tagged_follow_on, tagged_sap, tagged_searches, total_searches, total_uri_count, unknown, user_pref_browser_search_region

## Related Ticket
[DENG-11544](https://mozilla-hub.atlassian.net/browse/DENG-11544)

[DENG-11544]: https://mozilla-hub.atlassian.net/browse/DENG-11544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ