### PR TITLE
Fix sql generation hanging on macOS

### DIFF
--- a/bigquery_etl/cli/__init__.py
+++ b/bigquery_etl/cli/__init__.py
@@ -34,7 +34,11 @@ from ..docs import docs_
 from ..glam.cli import glam
 from ..stripe import stripe_
 from ..subplat.apple import apple
-from ..util.common import enable_impersonation, set_resolved_target_project
+from ..util.common import (
+    IMPERSONATE_ENV_VAR,
+    enable_impersonation,
+    set_resolved_target_project,
+)
 from ..util.target import (
     get_default_target_name,
     get_target,
@@ -129,9 +133,8 @@ def cli(prog_name=None):
         # --no-impersonate opts out for this process, even if the env var was
         # exported externally. The agent gate refuses write/deploy/backfill
         # without impersonation.
-        env_var = "CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT"
         if no_impersonate:
-            os.environ.pop(env_var, None)
+            os.environ.pop(IMPERSONATE_ENV_VAR, None)
 
         try:
             if not target and not no_target:
@@ -152,11 +155,11 @@ def cli(prog_name=None):
             # Impersonate the target's SA (explicit env var wins): env var for
             # `bq`/`gcloud` shell-outs, enable_impersonation for Python clients.
             if not no_impersonate:
-                sa = os.environ.get(env_var) or (
+                sa = os.environ.get(IMPERSONATE_ENV_VAR) or (
                     parsed_target.impersonate_service_account if parsed_target else None
                 )
                 if sa:
-                    os.environ[env_var] = sa
+                    os.environ[IMPERSONATE_ENV_VAR] = sa
                     enable_impersonation(sa)
                     click.echo(f"ℹ️  Impersonating service account: {sa}")
         except Exception as e:

--- a/bigquery_etl/util/common.py
+++ b/bigquery_etl/util/common.py
@@ -512,13 +512,19 @@ def set_resolved_target_project(project_id: Optional[str]) -> None:
 
 _CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
+# Set by the CLI when a target impersonates a service account, and unset by
+# --no-impersonate, so it records whether this invocation wants impersonation.
+# Child processes inherit it, which is how spawned pool workers know to install
+# the `enable_impersonation` wrapper for themselves.
+IMPERSONATE_ENV_VAR = "CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT"
+
 
 def enable_impersonation(target_principal: str) -> None:
     """Impersonate `target_principal` for all google-cloud clients in this process.
 
     `google.auth.default()` (used by every `bigquery.Client()`) ignores the
-    gcloud `CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT` env var, so we wrap it to
-    return impersonated credentials built from the caller's ADC.
+    gcloud `IMPERSONATE_ENV_VAR` env var, so we wrap it to return impersonated
+    credentials built from the caller's ADC.
     """
     current = google.auth.default
     # Unwrap if already wrapped so re-targeting doesn't stack/recurse.
@@ -571,7 +577,7 @@ def exit_if_running_under_coding_agent():
     Coding agents may run otherwise-blocked commands only when both hold:
     the invocation is scoped to an allow-listed non-prod `--target` (managed in
     `bqetl_project.yaml`, see `get_dev_project_allowlist`), and a service account
-    is being impersonated (`CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT` set).
+    is being impersonated (`IMPERSONATE_ENV_VAR` set).
 
     IMPORTANT: these checks are advisory guardrails, NOT the write boundary.
     They only inspect the resolved `--target`, but `deploy` / `query backfill`
@@ -598,7 +604,7 @@ def exit_if_running_under_coding_agent():
             err=True,
         )
         sys.exit(1)
-    if not os.environ.get("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT"):
+    if not os.environ.get(IMPERSONATE_ENV_VAR):
         click.echo(
             "Coding agents must impersonate the sandbox service account to run "
             "this command (its IAM is what prevents production writes). Set "

--- a/bigquery_etl/util/process_pool.py
+++ b/bigquery_etl/util/process_pool.py
@@ -10,15 +10,82 @@ from uuid import uuid4
 from pathos.helpers import mp
 from pathos.multiprocessing import ProcessingPool
 
-IMPERSONATE_ENV_VAR = "CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT"
+
+class _SerialResult:
+    """Stand-in for the async result `amap` and `apipe` return."""
+
+    def __init__(self, func):
+        self._value = None
+        self._exception = None
+        try:
+            self._value = func()
+        except Exception as e:
+            # Async maps report failures from `get()`, not from the call that
+            # dispatched the work, so hold the exception until then.
+            self._exception = e
+
+    def get(self, timeout=None):
+        """Return the result, or raise the exception the work raised."""
+        if self._exception is not None:
+            raise self._exception
+        return self._value
+
+    def ready(self):
+        """Return whether the work is done, which it always is here."""
+        return True
+
+    def wait(self, timeout=None):
+        """Do nothing, since the work already ran."""
+
+    def successful(self):
+        """Return whether the work completed without raising."""
+        return self._exception is None
 
 
 class _SerialPool:
-    """Stand-in for a pool when there isn't enough work to justify one."""
+    """Stand-in for a pool when there isn't enough work to justify one.
+
+    Implements the map and pipe interfaces of `ProcessingPool` so that callers
+    behave the same either way. Note that `ProcessingPool` has no `starmap`;
+    pass tuples to `map` and unpack them in the mapped function.
+    """
 
     def map(self, func, *iterables):
         """Apply `func` in this process, matching `ProcessingPool.map`."""
         return list(map(func, *iterables))
+
+    def imap(self, func, *iterables):
+        """Apply `func` lazily, matching `ProcessingPool.imap`."""
+        return map(func, *iterables)
+
+    def uimap(self, func, *iterables):
+        """Apply `func` lazily, matching `ProcessingPool.uimap`.
+
+        Results stay in order, which callers of an unordered map must tolerate
+        anyway.
+        """
+        return map(func, *iterables)
+
+    def amap(self, func, *iterables):
+        """Apply `func` now, returning a result object like `ProcessingPool.amap`."""
+        return _SerialResult(lambda: list(map(func, *iterables)))
+
+    def pipe(self, func, *args, **kwargs):
+        """Call `func` in this process, matching `ProcessingPool.pipe`."""
+        return func(*args, **kwargs)
+
+    def apipe(self, func, *args, **kwargs):
+        """Call `func` now, returning a result object like `ProcessingPool.apipe`."""
+        return _SerialResult(lambda: func(*args, **kwargs))
+
+    def __getattr__(self, name):
+        """Fail with the name of the method that this stand-in is missing."""
+        raise AttributeError(
+            f"{type(self).__name__} does not implement '{name}'. It stands in for "
+            "a process pool when there is at most one task, so anything a caller "
+            "uses has to be implemented here too. Add it to "
+            f"{__name__}.{type(self).__name__}."
+        )
 
 
 def init_worker(log_level: int):
@@ -30,10 +97,8 @@ def init_worker(log_level: int):
     """
     # Imported here so `bigquery_etl.util.common` isn't pulled in by callers
     # that only need the pool.
-    from bigquery_etl.util.common import enable_impersonation
+    from bigquery_etl.util.common import IMPERSONATE_ENV_VAR, enable_impersonation
 
-    # The env var is inherited across spawn, and `--no-impersonate` unsets it,
-    # so it reflects whether this invocation wants impersonation.
     service_account = os.environ.get(IMPERSONATE_ENV_VAR)
     if service_account:
         enable_impersonation(service_account)
@@ -41,7 +106,7 @@ def init_worker(log_level: int):
 
 
 @contextmanager
-def process_pool(parallelism: int, task_count: int, pool_id: str = None):
+def process_pool(parallelism: int, task_count: int):
     """Create a pathos process pool for `task_count` tasks.
 
     Created as a workaround for process pools crashing and getting stuck on macOS
@@ -62,10 +127,11 @@ def process_pool(parallelism: int, task_count: int, pool_id: str = None):
     point's `__main__`, so a script that creates the pool at module level
     instead of under `if __name__ == "__main__":` will deadlock.
 
-    pathos caches its pools, keyed by `pool_id`. Each call gets a unique id so
-    that pools are never shared: reusing one would run the tasks on workers
-    that were created before the start method was set, or with a different
-    initializer. Pass `pool_id` only to reuse a pool on purpose.
+    pathos caches its pools in a module global keyed by an id. Each call here
+    gets a unique id and drops the pool on the way out, so pools are never
+    shared between call sites: a shared pool would run tasks on workers that
+    were created before the start method was set, or with a different
+    initializer.
     """
     if sys.platform == "darwin":
         mp.set_start_method("spawn", force=True)
@@ -73,12 +139,15 @@ def process_pool(parallelism: int, task_count: int, pool_id: str = None):
 
     nodes = min(parallelism, task_count)
     if nodes <= 1:
+        # A single task isn't worth the few seconds a spawned worker spends
+        # re-importing the CLI. Staying in-process also means `-p 1` reports
+        # failures with a normal traceback for debugging.
         yield _SerialPool()
         return
 
     pool = ProcessingPool(
         nodes,
-        id=pool_id if pool_id is not None else uuid4().hex,
+        id=uuid4().hex,
         initializer=init_worker,
         initargs=(logging.root.level,),
     )

--- a/bigquery_etl/util/process_pool.py
+++ b/bigquery_etl/util/process_pool.py
@@ -133,10 +133,6 @@ def process_pool(parallelism: int, task_count: int):
     were created before the start method was set, or with a different
     initializer.
     """
-    if sys.platform == "darwin":
-        mp.set_start_method("spawn", force=True)
-        multiprocessing.set_start_method("spawn", force=True)
-
     nodes = min(parallelism, task_count)
     if nodes <= 1:
         # A single task isn't worth the few seconds a spawned worker spends
@@ -144,6 +140,10 @@ def process_pool(parallelism: int, task_count: int):
         # failures with a normal traceback for debugging.
         yield _SerialPool()
         return
+
+    if sys.platform == "darwin":
+        mp.set_start_method("spawn", force=True)
+        multiprocessing.set_start_method("spawn", force=True)
 
     pool = ProcessingPool(
         nodes,

--- a/bigquery_etl/util/process_pool.py
+++ b/bigquery_etl/util/process_pool.py
@@ -1,0 +1,92 @@
+"""Process pool creation for SQL generators."""
+
+import logging
+import multiprocessing
+import os
+import sys
+from contextlib import contextmanager
+from uuid import uuid4
+
+from pathos.helpers import mp
+from pathos.multiprocessing import ProcessingPool
+
+IMPERSONATE_ENV_VAR = "CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT"
+
+
+class _SerialPool:
+    """Stand-in for a pool when there isn't enough work to justify one."""
+
+    def map(self, func, *iterables):
+        """Apply `func` in this process, matching `ProcessingPool.map`."""
+        return list(map(func, *iterables))
+
+
+def init_worker(log_level: int):
+    """Re-establish parent process state that spawned workers don't inherit.
+
+    Forked workers inherited the impersonation wrapper `bqetl` installs over
+    `google.auth.default`; spawned workers import `google.auth` fresh and would
+    otherwise fall back to the caller's own ADC.
+    """
+    # Imported here so `bigquery_etl.util.common` isn't pulled in by callers
+    # that only need the pool.
+    from bigquery_etl.util.common import enable_impersonation
+
+    # The env var is inherited across spawn, and `--no-impersonate` unsets it,
+    # so it reflects whether this invocation wants impersonation.
+    service_account = os.environ.get(IMPERSONATE_ENV_VAR)
+    if service_account:
+        enable_impersonation(service_account)
+    logging.root.setLevel(log_level)
+
+
+@contextmanager
+def process_pool(parallelism: int, task_count: int, pool_id: str = None):
+    """Create a pathos process pool for `task_count` tasks.
+
+    Created as a workaround for process pools crashing and getting stuck on macOS
+    in some cases. See https://github.com/mozilla/bigquery-etl/issues/9821 and
+    https://github.com/python/cpython/issues/75999.
+
+    Uses at most `parallelism` workers, and runs the tasks in this process
+    when there is at most one of them. Workers are started eagerly, and under
+    spawn each one re-imports `bqetl`, so sizing the pool to the work matters.
+
+    On macOS, workers that make an HTTP request after the parent process has
+    made one segfault in the fork-unsafe parts of CoreFoundation (DNS
+    resolution, proxy lookup), and the pool then waits forever on the task the
+    dead worker was holding. Spawn avoids this, at the cost of slower worker
+    startup and cold caches in the workers.
+
+    Callers must be import-safe: with spawn the workers re-import the entry
+    point's `__main__`, so a script that creates the pool at module level
+    instead of under `if __name__ == "__main__":` will deadlock.
+
+    pathos caches its pools, keyed by `pool_id`. Each call gets a unique id so
+    that pools are never shared: reusing one would run the tasks on workers
+    that were created before the start method was set, or with a different
+    initializer. Pass `pool_id` only to reuse a pool on purpose.
+    """
+    if sys.platform == "darwin":
+        mp.set_start_method("spawn", force=True)
+        multiprocessing.set_start_method("spawn", force=True)
+
+    nodes = min(parallelism, task_count)
+    if nodes <= 1:
+        yield _SerialPool()
+        return
+
+    pool = ProcessingPool(
+        nodes,
+        id=pool_id if pool_id is not None else uuid4().hex,
+        initializer=init_worker,
+        initargs=(logging.root.level,),
+    )
+    try:
+        yield pool
+    except BaseException:
+        pool.terminate()
+        raise
+    finally:
+        # pathos caches pools and doesn't release them when the context exits
+        pool.clear()

--- a/bigquery_etl/util/target.py
+++ b/bigquery_etl/util/target.py
@@ -39,6 +39,7 @@ from ..schema import SCHEMA_FILE, Schema
 from ..view import View
 from . import extract_from_query_path
 from .common import (
+    IMPERSONATE_ENV_VAR,
     get_bqetl_project_root,
     get_unimpersonated_credentials,
     is_running_under_coding_agent,
@@ -1377,7 +1378,7 @@ def ensure_dataset_exists(
     # When impersonating, the SA is the writer but isn't an owner, so it can't
     # write into this human-owned dataset. Ask whether to grant it access —
     # granting makes the dataset readable by everyone who can impersonate the SA.
-    impersonated_sa = os.environ.get("CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT")
+    impersonated_sa = os.environ.get(IMPERSONATE_ENV_VAR)
     if impersonated_sa and _should_grant_impersonation_access(impersonated_sa):
         access_entries.append(
             bigquery.AccessEntry(

--- a/sql_generators/derived_view_schemas/__init__.py
+++ b/sql_generators/derived_view_schemas/__init__.py
@@ -4,10 +4,10 @@ from functools import partial
 from pathlib import Path
 
 import click
-from pathos.multiprocessing import ProcessingPool
 
 from bigquery_etl.cli.utils import use_cloud_function_option
 from bigquery_etl.dryrun import get_id_token
+from bigquery_etl.util.process_pool import process_pool
 
 NON_USER_FACING_DATASET_SUBSTRINGS = (
     "_derived",
@@ -251,7 +251,7 @@ def generate(target_project, output_dir, parallelism, use_cloud_function):
             if path.is_dir() and (path / VIEW_FILE).exists()
         ]
 
-    with ProcessingPool(parallelism) as pool:
+    with process_pool(parallelism, task_count=len(view_directories)) as pool:
         pool.map(
             partial(_generate_view_schema, Path(output_dir), id_token=id_token),
             view_directories,

--- a/sql_generators/glean_usage/__init__.py
+++ b/sql_generators/glean_usage/__init__.py
@@ -4,7 +4,6 @@ from functools import cache, partial
 from pathlib import Path
 
 import click
-from pathos.multiprocessing import ProcessingPool
 
 from bigquery_etl.cli.utils import (
     is_valid_project,
@@ -13,6 +12,7 @@ from bigquery_etl.cli.utils import (
 )
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.dryrun import get_id_token
+from bigquery_etl.util.process_pool import process_pool
 from sql_generators.glean_usage import (
     baseline_clients_daily,
     baseline_clients_first_seen,
@@ -212,8 +212,7 @@ def generate(
         for table in GLEAN_TABLES
     ]
 
-    with ProcessingPool(parallelism) as pool:
-        pool.map(
-            lambda f: f(),
-            generate_per_app_id + generate_per_app + generate_across_apps,
-        )
+    tasks = generate_per_app_id + generate_per_app + generate_across_apps
+
+    with process_pool(parallelism, task_count=len(tasks)) as pool:
+        pool.map(lambda f: f(), tasks)

--- a/sql_generators/stable_tables_monitoring/stable_tables_monitoring.py
+++ b/sql_generators/stable_tables_monitoring/stable_tables_monitoring.py
@@ -1,12 +1,13 @@
 """Generate metadata and bigconfig files for stable tables."""
 
-from multiprocessing import Pool
+from functools import partial
 from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.schema import SCHEMA_FILE, Schema
+from bigquery_etl.util.process_pool import process_pool
 
 
 def write_file(content, file_path):
@@ -23,15 +24,15 @@ def parse_config_name(config):
 
 
 def _generate_table_files(
+    dataset_and_table,
     target_project,
-    dataset_name,
-    table,
     templates_dir,
     bigeye_collection,
     bigeye_slack_channel,
     enable_monitoring,
     sql_base_dir,
 ):
+    dataset_name, table = dataset_and_table
     env = Environment(loader=FileSystemLoader(str(templates_dir)))
     name_part, version_part = parse_config_name(table)
 
@@ -75,20 +76,22 @@ def generate_stable_table_bigconfig_files(target_project, output_dir, enable_mon
 
     stable_table_bigconfigs = ConfigLoader.get("monitoring", "stable_tables_monitoring")
 
-    args = [
-        (
-            target_project,
-            dataset_name,
-            table,
-            templates_dir,
-            bigeye_collection,
-            bigeye_slack_channel,
-            enable_monitoring,
-            sql_base_dir,
-        )
+    tables = [
+        (dataset_name, table)
         for dataset_name, table_names in stable_table_bigconfigs.items()
         for table in table_names
     ]
 
-    with Pool(parallelism) as pool:
-        pool.starmap(_generate_table_files, args)
+    with process_pool(parallelism, task_count=len(tables)) as pool:
+        pool.map(
+            partial(
+                _generate_table_files,
+                target_project=target_project,
+                templates_dir=templates_dir,
+                bigeye_collection=bigeye_collection,
+                bigeye_slack_channel=bigeye_slack_channel,
+                enable_monitoring=enable_monitoring,
+                sql_base_dir=sql_base_dir,
+            ),
+            tables,
+        )

--- a/sql_generators/stable_views/__init__.py
+++ b/sql_generators/stable_views/__init__.py
@@ -16,12 +16,12 @@ from pathlib import Path
 
 import click
 import yaml
-from pathos.multiprocessing import ProcessingPool
 
 from bigquery_etl.cli.utils import use_cloud_function_option
 from bigquery_etl.config import ConfigLoader
 from bigquery_etl.dryrun import get_id_token
 from bigquery_etl.schema.stable_table_schema import SchemaFile, get_stable_table_schemas
+from bigquery_etl.util.process_pool import process_pool
 
 BOT_GENERATED = (
     'LOWER(IFNULL(metadata.isp.name, "")) = "browserstack" AS is_bot_generated'
@@ -494,7 +494,7 @@ def generate(target_project, output_dir, log_level, parallelism, use_cloud_funct
 
     id_token = get_id_token()
 
-    with ProcessingPool(parallelism) as pool:
+    with process_pool(parallelism, task_count=len(schemas)) as pool:
         pool.map(
             partial(
                 write_view_if_not_exists,

--- a/tests/util/test_common.py
+++ b/tests/util/test_common.py
@@ -17,7 +17,7 @@ from bigquery_etl.util.common import (
     render,
 )
 
-IMPERSONATE_ENV = "CLOUDSDK_AUTH_IMPERSONATE_SERVICE_ACCOUNT"
+IMPERSONATE_ENV = common.IMPERSONATE_ENV_VAR
 
 
 class TestUtilCommon:

--- a/tests/util/test_process_pool.py
+++ b/tests/util/test_process_pool.py
@@ -1,4 +1,5 @@
 import logging
+import multiprocessing
 import os
 import sys
 
@@ -86,6 +87,15 @@ class TestProcessPool:
                 assert mp.get_start_method() == "spawn"
             else:
                 assert mp.get_start_method() == start_method
+
+    def test_start_method_untouched_without_workers(self):
+        # the serial path spawns nothing, so it must not reconfigure the
+        # start method for the rest of the process
+        start_method = mp.get_start_method()
+        stdlib_start_method = multiprocessing.get_start_method()
+        with process_pool(8, 1):
+            assert mp.get_start_method() == start_method
+            assert multiprocessing.get_start_method() == stdlib_start_method
 
     def test_pools_are_not_shared(self):
         # pools with the same worker count must stay separate, otherwise a

--- a/tests/util/test_process_pool.py
+++ b/tests/util/test_process_pool.py
@@ -9,11 +9,8 @@ from google.auth import impersonated_credentials
 from pathos.helpers import mp
 from pathos.multiprocessing import ProcessingPool
 
-from bigquery_etl.util.process_pool import (
-    IMPERSONATE_ENV_VAR,
-    init_worker,
-    process_pool,
-)
+from bigquery_etl.util.common import IMPERSONATE_ENV_VAR
+from bigquery_etl.util.process_pool import init_worker, process_pool
 
 # pathos keeps its pools in a module-level dict keyed by the pool id
 POOL_STATE = pathos.multiprocessing._ProcessPool__STATE
@@ -48,6 +45,39 @@ class TestProcessPool:
         with process_pool(8, 1) as pool:
             assert not isinstance(pool, ProcessingPool)
             assert pool.map(square, [1, 2, 3]) == [1, 4, 9]
+
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda pool: pool.map(square, [1, 2, 3]),
+            lambda pool: list(pool.imap(square, [1, 2, 3])),
+            lambda pool: sorted(pool.uimap(square, [1, 2, 3])),
+            lambda pool: pool.amap(square, [1, 2, 3]).get(),
+            lambda pool: pool.pipe(square, 3),
+            lambda pool: pool.apipe(square, 3).get(),
+        ],
+        ids=["map", "imap", "uimap", "amap", "pipe", "apipe"],
+    )
+    def test_serial_pool_matches_real_pool(self, call):
+        # the serial stand-in is only used when there's at most one task, the
+        # path least likely to be hit while developing, so it has to behave
+        # like the pool it replaces
+        with process_pool(8, 1) as serial:
+            serial_result = call(serial)
+        with process_pool(2, 4) as pool:
+            assert call(pool) == serial_result
+
+    def test_serial_pool_names_missing_method(self):
+        with process_pool(8, 1) as pool:
+            with pytest.raises(AttributeError, match="does not implement 'starmap'"):
+                pool.starmap
+
+    def test_serial_pool_amap_defers_exception(self):
+        with process_pool(8, 1) as pool:
+            result = pool.amap(square, ["not a number"])
+            assert not result.successful()
+            with pytest.raises(TypeError):
+                result.get()
 
     def test_start_method(self):
         start_method = mp.get_start_method()

--- a/tests/util/test_process_pool.py
+++ b/tests/util/test_process_pool.py
@@ -1,0 +1,123 @@
+import logging
+import os
+import sys
+
+import google.auth
+import pathos.multiprocessing
+import pytest
+from google.auth import impersonated_credentials
+from pathos.helpers import mp
+from pathos.multiprocessing import ProcessingPool
+
+from bigquery_etl.util.process_pool import (
+    IMPERSONATE_ENV_VAR,
+    init_worker,
+    process_pool,
+)
+
+# pathos keeps its pools in a module-level dict keyed by the pool id
+POOL_STATE = pathos.multiprocessing._ProcessPool__STATE
+
+
+class _FakeSourceCreds:
+    # impersonated_credentials.Credentials reads universe_domain at construction;
+    # `valid` short-circuits the pre-refresh so no network call is made.
+    universe_domain = "googleapis.com"
+    valid = True
+
+
+def square(x):
+    return x * x
+
+
+def observe_worker_auth(_):
+    """Report the auth state a worker sees."""
+    return (
+        hasattr(google.auth.default, "_bqetl_original_default"),
+        os.environ.get(IMPERSONATE_ENV_VAR),
+        logging.root.level,
+    )
+
+
+class TestProcessPool:
+    def test_map(self):
+        with process_pool(2, 4) as pool:
+            assert pool.map(square, [1, 2, 3]) == [1, 4, 9]
+
+    def test_single_task_runs_without_workers(self):
+        with process_pool(8, 1) as pool:
+            assert not isinstance(pool, ProcessingPool)
+            assert pool.map(square, [1, 2, 3]) == [1, 4, 9]
+
+    def test_start_method(self):
+        start_method = mp.get_start_method()
+        with process_pool(2, 4):
+            if sys.platform == "darwin":
+                assert mp.get_start_method() == "spawn"
+            else:
+                assert mp.get_start_method() == start_method
+
+    def test_pools_are_not_shared(self):
+        # pools with the same worker count must stay separate, otherwise a
+        # caller could get workers that were created before the start method
+        # was set, or with a different initializer
+        with process_pool(2, 4) as first:
+            with process_pool(2, 4) as second:
+                assert first._id != second._id
+                assert POOL_STATE[first._id] is not POOL_STATE[second._id]
+
+    def test_pool_released_on_exit(self):
+        with process_pool(2, 4) as pool:
+            pool_id = pool._id
+            assert pool_id in POOL_STATE
+        assert pool_id not in POOL_STATE
+
+    def test_pool_released_on_error(self):
+        with pytest.raises(ValueError):
+            with process_pool(2, 4) as pool:
+                pool_id = pool._id
+                raise ValueError("boom")
+        assert pool_id not in POOL_STATE
+
+
+class TestInitWorker:
+    def test_installs_impersonation_from_env(self, monkeypatch):
+        monkeypatch.setattr(
+            google.auth, "default", lambda *a, **k: (_FakeSourceCreds(), "proj")
+        )
+        # recorded so monkeypatch restores it after init_worker changes it
+        monkeypatch.setattr(logging.root, "level", logging.root.level)
+        monkeypatch.setenv(IMPERSONATE_ENV_VAR, "sa@p.iam.gserviceaccount.com")
+
+        init_worker(logging.DEBUG)
+
+        creds, _ = google.auth.default()
+        assert isinstance(creds, impersonated_credentials.Credentials)
+        assert creds._target_principal == "sa@p.iam.gserviceaccount.com"
+        assert logging.root.level == logging.DEBUG
+
+    def test_no_impersonation_without_env(self, monkeypatch):
+        # `--no-impersonate` unsets the env var, and workers must not
+        # impersonate in that case
+        def unimpersonated(*args, **kwargs):
+            return (_FakeSourceCreds(), "proj")
+
+        monkeypatch.setattr(google.auth, "default", unimpersonated)
+        monkeypatch.setattr(logging.root, "level", logging.root.level)
+        monkeypatch.delenv(IMPERSONATE_ENV_VAR, raising=False)
+
+        init_worker(logging.INFO)
+
+        assert google.auth.default is unimpersonated
+
+    def test_pool_workers_impersonate(self, monkeypatch):
+        # spawned workers import google.auth fresh, so the pool has to
+        # re-install the impersonation wrapper in each one
+        monkeypatch.setenv(IMPERSONATE_ENV_VAR, "sa@p.iam.gserviceaccount.com")
+
+        with process_pool(2, 4) as pool:
+            observed = pool.map(observe_worker_auth, range(4))
+
+        assert all(wrapped for wrapped, _, _ in observed)
+        assert {sa for _, sa, _ in observed} == {"sa@p.iam.gserviceaccount.com"}
+        assert {level for _, _, level in observed} == {logging.root.level}


### PR DESCRIPTION
## Description

fixes #9821

This fixes an issue where child processes can crash and cause the parent to hang when making HTTP requests in some cases. This was consistently causing sql generation to get stuck for some of the generators. There should be no impact on non-macOS builds.

## Related Tickets & Documents
* #9821

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
