### PR TITLE
[DENG-11525] Add observability tables for agent runs, spans, and source coverage

### DIFF
--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/schema_source_coverage/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/schema_source_coverage/metadata.yaml
@@ -1,0 +1,9 @@
+friendly_name: Schema Source Coverage
+description: |-
+  One row per resolved source table per scanned bqetl table. Records whether
+  a schema.yaml is defined for each table and whether its upstream source
+  schema is fully described. Query the latest scan per dataset using
+  MAX(scan_timestamp).
+owners:
+- cbeck@mozilla.com
+- phlee@mozilla.com

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/schema_source_coverage/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/schema_source_coverage/metadata.yaml
@@ -7,3 +7,5 @@ description: |-
 owners:
 - cbeck@mozilla.com
 - phlee@mozilla.com
+labels:
+  authorized: true

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata/schema_source_coverage/view.sql
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata/schema_source_coverage/view.sql
@@ -1,0 +1,7 @@
+CREATE OR REPLACE VIEW
+  `moz-fx-data-shared-prod.data_governance_metadata.schema_source_coverage`
+AS
+SELECT
+  *
+FROM
+  `moz-fx-data-shared-prod.data_governance_metadata_derived.schema_source_coverage_v1`

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_runs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_runs_v1/metadata.yaml
@@ -1,0 +1,23 @@
+friendly_name: Agent Runs
+description: |-
+  One row per LLM agent run executed by the schema enrichment tooling. Written
+  by BQObservabilitySink in mozilla/data-shared-llm-agents; tracks the prompt, model,
+  token usage, cost, and outcome of each agent invocation.
+
+  Not scheduled; populated at runtime by the agent application.
+
+  Source:
+  https://github.com/mozilla/data-shared-llm-agents/blob/main/packages/observability/src/data_agents_observability/sink.py
+owners:
+- cbeck@mozilla.com
+- phlee@mozilla.com
+bigquery:
+  time_partitioning:
+    type: day
+    field: started_at
+    require_partition_filter: false
+    expiration_days: 90
+  clustering:
+    fields:
+    - agent_name
+    - status

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_runs_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_runs_v1/metadata.yaml
@@ -16,7 +16,7 @@ bigquery:
     type: day
     field: started_at
     require_partition_filter: false
-    expiration_days: 90
+    expiration_days: 180
   clustering:
     fields:
     - agent_name

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_runs_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_runs_v1/schema.yaml
@@ -1,0 +1,61 @@
+fields:
+- name: run_id
+  type: STRING
+  mode: REQUIRED
+  description: Unique identifier for the agent run.
+- name: agent_name
+  type: STRING
+  mode: REQUIRED
+  description: Name of the agent that executed this run (e.g. schema_enricher).
+- name: model_id
+  type: STRING
+  mode: REQUIRED
+  description: LLM model identifier used for this run.
+- name: prompt
+  type: STRING
+  mode: REQUIRED
+  description: The prompt or task description provided to the agent.
+- name: final_output
+  type: STRING
+  mode: NULLABLE
+  description: Final text output produced by the agent; null on error.
+- name: status
+  type: STRING
+  mode: REQUIRED
+  description: Run outcome; one of success or error.
+- name: error_message
+  type: STRING
+  mode: NULLABLE
+  description: Error detail when status is error; null on success.
+- name: input_tokens
+  type: INTEGER
+  mode: NULLABLE
+  description: Total input tokens consumed across all LLM calls in the run.
+- name: output_tokens
+  type: INTEGER
+  mode: NULLABLE
+  description: Total output tokens produced across all LLM calls in the run.
+- name: total_tokens
+  type: INTEGER
+  mode: NULLABLE
+  description: Sum of input and output tokens for the run.
+- name: cost_usd
+  type: FLOAT
+  mode: NULLABLE
+  description: Estimated cost in USD for all LLM calls in the run.
+- name: started_at
+  type: TIMESTAMP
+  mode: REQUIRED
+  description: UTC timestamp when the run started. This is the table's partition column.
+- name: finished_at
+  type: TIMESTAMP
+  mode: REQUIRED
+  description: UTC timestamp when the run finished.
+- name: duration_seconds
+  type: FLOAT
+  mode: REQUIRED
+  description: Wall-clock duration of the run in seconds.
+- name: run_source
+  type: STRING
+  mode: NULLABLE
+  description: Source or trigger of the run (e.g. ui, api); null when not specified.

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/metadata.yaml
@@ -15,7 +15,7 @@ owners:
 bigquery:
   time_partitioning:
     type: day
-    field: start_time
+    field: started_at
     require_partition_filter: false
     expiration_days: 180
   clustering:

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/metadata.yaml
@@ -4,7 +4,7 @@ description: |-
   Written by BQObservabilitySink in data-shared-llm-agents. Provides granular observability
   into individual steps: tool names, LLM turn durations, and JSON-encoded attributes;
   including token counts and output previews.
-
+  Not scheduled; populated at runtime. Foreign key: run_id joins to schema_agent_runs_v1.
   Not scheduled; populated at runtime. Foreign key: run_id joins to agent_runs_v1.
 
   Source:

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/metadata.yaml
@@ -1,0 +1,24 @@
+friendly_name: Agent Spans
+description: |-
+  One row per LLM call or tool invocation within an agent run for the schema enrichment agent.
+  Written by BQObservabilitySink in data-shared-llm-agents. Provides granular observability
+  into individual steps: tool names, LLM turn durations, and JSON-encoded attributes;
+  including token counts and output previews.
+
+  Not scheduled; populated at runtime. Foreign key: run_id joins to agent_runs_v1.
+
+  Source:
+  https://github.com/mozilla/data-shared-llm-agents/blob/main/packages/observability/src/data_agents_observability/sink.py
+owners:
+- cbeck@mozilla.com
+- phlee@mozilla.com
+bigquery:
+  time_partitioning:
+    type: day
+    field: start_time
+    require_partition_filter: false
+    expiration_days: 180
+  clustering:
+    fields:
+    - span_kind
+    - span_name

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/schema.yaml
@@ -6,7 +6,7 @@ fields:
 - name: run_id
   type: STRING
   mode: REQUIRED
-  description: Foreign key to agent_runs_v1.run_id.
+  description: Foreign key to schema_agent_runs_v1.run_id.
 - name: parent_span_id
   type: STRING
   mode: NULLABLE

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_agent_spans_v1/schema.yaml
@@ -1,0 +1,41 @@
+fields:
+- name: span_id
+  type: STRING
+  mode: REQUIRED
+  description: Unique identifier for the span.
+- name: run_id
+  type: STRING
+  mode: REQUIRED
+  description: Foreign key to agent_runs_v1.run_id.
+- name: parent_span_id
+  type: STRING
+  mode: NULLABLE
+  description: Parent span identifier for nested spans; null for top-level spans.
+- name: span_kind
+  type: STRING
+  mode: REQUIRED
+  description: Category of span; one of llm, tool, or node.
+- name: span_name
+  type: STRING
+  mode: REQUIRED
+  description: Name of the LLM step, tool call, or pipeline node.
+- name: started_at
+  type: TIMESTAMP
+  mode: REQUIRED
+  description: UTC timestamp when the span started. This is the table's partition column.
+- name: finished_at
+  type: TIMESTAMP
+  mode: REQUIRED
+  description: UTC timestamp when the span ended.
+- name: duration_seconds
+  type: FLOAT
+  mode: REQUIRED
+  description: Wall-clock duration of the span in seconds.
+- name: status
+  type: STRING
+  mode: NULLABLE
+  description: Span status; null when not explicitly set.
+- name: attributes_json
+  type: STRING
+  mode: NULLABLE
+  description: JSON-encoded span attributes such as token counts, tool arguments, or content previews.

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/README.md
@@ -77,8 +77,8 @@ WHERE dataset = 'my_dataset'
 ## Partitioning & retention
 
 - **Partitioned** by `scan_timestamp` (TIMESTAMP, daily granularity).
-- **Retained** for **180 days** — set as the default partition expiration on the
-  table outside this script. Old scans expire automatically; only the most recent
+- **Retained** for **180 days** via `expiration_days` in this table's
+  `metadata.yaml`. Old scans expire automatically; only the most recent
   scan per dataset is operationally relevant.
 
 ## Key columns

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/README.md
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/README.md
@@ -1,0 +1,115 @@
+# Schema Source Coverage
+
+Per-table schema coverage scan for bqetl datasets. For each table directory in
+`sql/<project>/<dataset>/`, records whether a `schema.yaml` exists, which
+upstream source table(s) the query pulls from, and whether those source schemas
+have complete field descriptions. The schema enricher reads this table to decide
+which tables to enrich and where to find source descriptions to propagate via
+`!include-field-description` tags.
+
+## Architecture
+
+This table is **not populated by a bqetl query**. It is written externally by
+the [schema enricher scanner](https://github.com/mozilla/data-shared-llm-agents/tree/main/agents/schema_enricher/src/schema_enricher/scanner.py),
+which walks the `bigquery-etl` and `private-bigquery-etl` filesystems, traces
+each table's `query.sql` or `view.sql` upstream through views to reach versioned
+(`_vN`) or raw (`_live`/`_stable`) leaf tables, and looks up `sql_generator`
+labels from `INFORMATION_SCHEMA.TABLE_OPTIONS`.
+
+```mermaid
+flowchart LR
+    BQETL[("<b>bigquery-etl</b><br/>sql/ filesystem")]
+    PRIVATE[("<b>private-bigquery-etl</b><br/>sql/ filesystem<br/>(optional)")]
+    INFOSCHEMA[("INFORMATION_SCHEMA<br/>TABLE_OPTIONS<br/>(sql_generator labels)")]
+    SCANNER{{"<b>scanner.py</b><br/>(external)"}}
+    TBL[("<b>schema_source_coverage_v1</b><br/>partition: scan_timestamp<br/>retention: 180 days")]
+    ENRICHER{{"<b>schema_enricher</b><br/>agent (external)"}}
+    PR["schema.yaml PR<br/>(bigquery-etl)"]
+
+    BQETL --> SCANNER
+    PRIVATE --> SCANNER
+    INFOSCHEMA --> SCANNER
+    SCANNER --> TBL --> ENRICHER --> PR
+
+    classDef source fill:#e3f2fd,stroke:#1565c0,color:#0d47a1;
+    classDef agent fill:#fff3e0,stroke:#e65100,color:#bf360c;
+    classDef store fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20;
+    classDef consumer fill:#f3e5f5,stroke:#6a1b9a,color:#4a148c;
+    class BQETL source
+    class PRIVATE source
+    class INFOSCHEMA source
+    class SCANNER agent
+    class ENRICHER agent
+    class TBL store
+    class PR consumer
+```
+
+## Source tracing
+
+For each table, the scanner reads `query.sql` or `view.sql` and extracts
+backtick-quoted 3-part table references. References that are not versioned
+(`_vN`) or raw (`_live`/`_stable`) are recursively traced through their own SQL
+files until a leaf is reached. Each leaf produces one output row. Tables with
+multiple sources in their `FROM` clause produce multiple rows (one per resolved
+leaf).
+
+When all upstream references are raw (`_live`/`_stable`) tables with no bqetl
+directory, the most upstream bqetl-managed directory is reported as the source —
+this is the table the enricher should enrich directly.
+
+## Write model
+
+Each scanner run **appends** rows with a new `scan_timestamp`. Multiple dataset
+scans accumulate. To read the current state for a dataset, filter to the latest
+`scan_timestamp`:
+
+```sql
+SELECT *
+FROM `moz-fx-data-shared-prod.data_governance_metadata_derived.schema_source_coverage_v1`
+WHERE dataset = 'my_dataset'
+  AND scan_timestamp = (
+    SELECT MAX(scan_timestamp)
+    FROM `moz-fx-data-shared-prod.data_governance_metadata_derived.schema_source_coverage_v1`
+    WHERE dataset = 'my_dataset'
+  )
+```
+
+## Partitioning & retention
+
+- **Partitioned** by `scan_timestamp` (TIMESTAMP, daily granularity).
+- **Retained** for **180 days** — set as the default partition expiration on the
+  table outside this script. Old scans expire automatically; only the most recent
+  scan per dataset is operationally relevant.
+
+## Key columns
+
+| Column | Description |
+|---|---|
+| `project` / `dataset` / `table` | Identity of the scanned table |
+| `is_view` | True when the table directory contains `view.sql` |
+| `sql_generator` | Name of the sql_generator label if the table was generated (e.g. `glean_usage`); null for hand-written tables |
+| `schema_defined_in_bqetl` | True when a `schema.yaml` exists for this table |
+| `source_schema_directory` | Filesystem path to the resolved upstream source directory; null when no source was found |
+| `source_schema_fully_described` | True when every field in the source `schema.yaml` has a description |
+| `source_schema_is_private` | True when the source lives in `private-bigquery-etl` |
+
+## Example: find tables ready for enrichment
+
+Tables that have a `schema.yaml` but whose source schema is not fully described
+— these are candidates for the enricher to process:
+
+```sql
+SELECT project, dataset, table, source_schema_directory, source_schema_is_private
+FROM `moz-fx-data-shared-prod.data_governance_metadata_derived.schema_source_coverage_v1`
+WHERE dataset = 'telemetry_derived'
+  AND schema_defined_in_bqetl = TRUE
+  AND is_view = FALSE
+  AND sql_generator IS NULL
+  AND (source_schema_fully_described = FALSE OR source_schema_directory IS NULL)
+  AND scan_timestamp = (
+    SELECT MAX(scan_timestamp)
+    FROM `moz-fx-data-shared-prod.data_governance_metadata_derived.schema_source_coverage_v1`
+    WHERE dataset = 'telemetry_derived'
+  )
+ORDER BY table
+```

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/metadata.yaml
@@ -17,14 +17,13 @@ description: |-
   https://github.com/mozilla/data-shared-llm-agents/blob/main/agents/schema_enricher/src/schema_enricher/scanner.py
 owners:
 - cbeck@mozilla.com
-- gkatre@mozilla.com
 - phlee@mozilla.com
 bigquery:
   time_partitioning:
     type: day
     field: scan_timestamp
     require_partition_filter: false
-    expiration_days: 90
+    expiration_days: 180
   clustering:
     fields:
     - project

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/metadata.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/metadata.yaml
@@ -1,0 +1,31 @@
+friendly_name: Schema Source Coverage
+description: |-
+  One row per resolved source table per scanned bqetl table. Written by the
+  schema coverage scanner in mozilla/data-shared-llm-agents. Records whether a
+  schema.yaml is defined for each table and whether its upstream source
+  schema is fully described.
+
+  Source tables are traced recursively through views until a versioned (_vN)
+  or raw (_live/_stable) table is reached. Multiple rows per target table are
+  produced when it references more than one leaf source. Each scan appends rows
+  tagged with scan_timestamp; query the latest scan per dataset using
+  MAX(scan_timestamp).
+
+  Not scheduled; populated on demand by the schema enricher pipeline.
+
+  Source:
+  https://github.com/mozilla/data-shared-llm-agents/blob/main/agents/schema_enricher/src/schema_enricher/scanner.py
+owners:
+- cbeck@mozilla.com
+- gkatre@mozilla.com
+- phlee@mozilla.com
+bigquery:
+  time_partitioning:
+    type: day
+    field: scan_timestamp
+    require_partition_filter: false
+    expiration_days: 90
+  clustering:
+    fields:
+    - project
+    - dataset

--- a/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/schema.yaml
+++ b/sql/moz-fx-data-shared-prod/data_governance_metadata_derived/schema_source_coverage_v1/schema.yaml
@@ -1,0 +1,41 @@
+fields:
+- name: project
+  type: STRING
+  mode: REQUIRED
+  description: GCP project of the scanned table.
+- name: dataset
+  type: STRING
+  mode: REQUIRED
+  description: BigQuery dataset of the scanned table.
+- name: table
+  type: STRING
+  mode: REQUIRED
+  description: Table name (without project or dataset).
+- name: sql_generator
+  type: STRING
+  mode: NULLABLE
+  description: The name of the SQL generator label from the deployed BigQuery table (labels.sql_generator); null for hand-written tables.
+- name: source_schema_directory
+  type: STRING
+  mode: NULLABLE
+  description: Filesystem path to the resolved source schema directory in bigquery-etl or private-bigquery-etl; null when no source could be resolved.
+- name: source_schema_fully_described
+  type: BOOLEAN
+  mode: NULLABLE
+  description: True when every field in the resolved source schema.yaml has a non-empty description; null when no source schema was found.
+- name: is_view
+  type: BOOLEAN
+  mode: REQUIRED
+  description: True when the scanned table directory contains a view.sql file (i.e. the table is a BigQuery view rather than a materialized table).
+- name: source_schema_is_private
+  type: BOOLEAN
+  mode: NULLABLE
+  description: True when the resolved source directory lives under private-bigquery-etl; null when no source was resolved.
+- name: schema_defined_in_bqetl
+  type: BOOLEAN
+  mode: REQUIRED
+  description: True when a schema.yaml exists for this table in bigquery-etl.
+- name: scan_timestamp
+  type: TIMESTAMP
+  mode: REQUIRED
+  description: UTC timestamp when this scan row was written. This is the table's partition column.


### PR DESCRIPTION
## Description

This PR adds three new tables to `data_governance_metadata_derived`; Two observability tables for agent runs and `schema_source_coverage_v1` that agent writes to as a helper for discovering which source schema to pull `!include` statements from

<!--
Please do not leave this blank
This PR [adds/removes/fixes/replaces] the [feature/bug/etc].
-->

## Related Tickets & Documents
* DENG-11525

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
