### PR TITLE
feat(DENG-11579): added extract_params_from_url and url_decode UDFs

### DIFF
--- a/sql/mozfun/utils/extract_params_from_url/README.md
+++ b/sql/mozfun/utils/extract_params_from_url/README.md
@@ -1,0 +1,15 @@
+This UDF extracts every parameter from a URL or bare query string.
+
+Unlike `utils.extract_utm_from_url` there is no fixed key list and no leading `?` is
+required, so unanticipated parameters are still returned. Read a single parameter out of
+the result with `mozfun.map.get_key`.
+
+Each result carries a `depth`, describing how deeply encoded the parameter was:
+
+- `0` — a plain `key=value` pair, or a keyless token such as a bare click id
+- `1` — a query string nested inside one parameter's value
+- `2` — a whole string that was percent-encoded, containing no literal `=`
+
+Where a key appears at more than one depth the shallowest occurrence wins, so
+`mozfun.map.get_key` is deterministic. Values are percent-decoded. A keyless token is
+returned as a key with a `NULL` value, so test for it by matching the key.

--- a/sql/mozfun/utils/extract_params_from_url/README.md
+++ b/sql/mozfun/utils/extract_params_from_url/README.md
@@ -10,6 +10,11 @@ Each result carries a `depth`, describing how deeply encoded the parameter was:
 - `1` — a query string nested inside one parameter's value
 - `2` — a whole string that was percent-encoded, containing no literal `=`
 
-Where a key appears at more than one depth the shallowest occurrence wins, so
+Where a key repeats, the shallowest occurrence wins, then the first, so
 `mozfun.map.get_key` is deterministic. Values are percent-decoded. A keyless token is
 returned as a key with a `NULL` value, so test for it by matching the key.
+
+Keys are lowercased and must match `[a-z0-9_.-]`, 1–60 characters, so anything else is
+dropped — including an encoded key such as `utm%5Fsource`. Values keep their case. A
+keyless token needs an `_`. A `#` ends the parameter before it, though parameters after
+it are still returned.

--- a/sql/mozfun/utils/extract_params_from_url/metadata.yaml
+++ b/sql/mozfun/utils/extract_params_from_url/metadata.yaml
@@ -1,0 +1,4 @@
+description: |-
+  Extracts every parameter in a URL or query string as key/value/depth structs.
+  Handles nested and wholly encoded forms; read one with mozfun.map.get_key.
+friendly_name: Extract Params From URL

--- a/sql/mozfun/utils/extract_params_from_url/udf.sql
+++ b/sql/mozfun/utils/extract_params_from_url/udf.sql
@@ -1,0 +1,208 @@
+CREATE OR REPLACE FUNCTION utils.extract_params_from_url(url STRING)
+RETURNS ARRAY<STRUCT<key STRING, value STRING, depth INT64>> AS (
+  -- Extracts every parameter, not one regex per parameter we want. Unlike
+  -- utils.extract_utm_from_url, no fixed key list and no leading '?' required.
+  ARRAY(
+    SELECT AS STRUCT
+      key,
+      mozfun.utils.url_decode(value) AS value,
+      depth
+    FROM
+      (
+        -- One row per key
+        SELECT
+          key,
+          ANY_VALUE(value HAVING MIN depth) AS value,
+          MIN(depth) AS depth
+        FROM
+          (
+            -- depth 0 as-is; depth 2 wholly encoded ('clid%3DAbc123...'), which a
+            -- depth-0 split misses. Same split over a separator-decoded copy.
+            SELECT
+              LOWER(TRIM(REGEXP_EXTRACT(kv, r'^([^=]+)'))) AS key,
+              REGEXP_EXTRACT(kv, r'^[^=]+=(.*)$') AS value,
+              lvl.depth AS depth
+            FROM
+              UNNEST(
+                [
+                  STRUCT(url AS s, 0 AS depth),
+                  STRUCT(
+                    REGEXP_REPLACE(
+                      REGEXP_REPLACE(IFNULL(url, ''), r'(?i)%3D', '='),
+                      r'(?i)%26',
+                      '&'
+                    ) AS s,
+                    2 AS depth
+                  )
+                ]
+              ) AS lvl,
+              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(lvl.s, ''), r'[^?&]+')) AS kv
+            WHERE
+              REGEXP_CONTAINS(kv, r'=')
+            UNION ALL
+            -- depth 1: a query string nested in one value, the partner preload surface.
+            -- Per-value, not whole-string: decoding first loses the leading nested key,
+            -- and the encoded-value guard stops base64 click ids being re-split.
+            SELECT
+              LOWER(TRIM(REGEXP_EXTRACT(nested_kv, r'^([^=]+)'))) AS key,
+              REGEXP_EXTRACT(nested_kv, r'^[^=]+=(.*)$') AS value,
+              1 AS depth
+            FROM
+              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(url, ''), r'[^?&]+')) AS kv,
+              UNNEST(
+                REGEXP_EXTRACT_ALL(
+                  REGEXP_REPLACE(
+                    REGEXP_REPLACE(
+                      IFNULL(REGEXP_EXTRACT(kv, r'^[^=]+=(.*)$'), ''),
+                      r'(?i)%3D',
+                      '='
+                    ),
+                    r'(?i)%26',
+                    '&'
+                  ),
+                  r'[^?&]+'
+                )
+              ) AS nested_kv
+            WHERE
+              REGEXP_CONTAINS(kv, r'(?i)%3D|%26')
+              AND REGEXP_CONTAINS(nested_kv, r'=')
+            UNION ALL
+            -- depth 0, keyless: some referrers are a bare click id with no 'key='
+            -- at all. The token is the signal, so it is emitted as the key with a
+            -- NULL value; test for it with a key match, not mozfun.map.get_key.
+            -- An underscore is required so a bare package name or word stays unparsed.
+            SELECT
+              LOWER(TRIM(kv)) AS key,
+              CAST(NULL AS STRING) AS value,
+              0 AS depth
+            FROM
+              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(url, ''), r'[^?&]+')) AS kv
+            WHERE
+              NOT REGEXP_CONTAINS(kv, r'=')
+              AND REGEXP_CONTAINS(kv, r'_')
+          )
+        WHERE
+          -- Drop junk keys from splitting a non-query-string. A keyless token is the
+          -- signal itself, so it is kept whole and the 60-char cap does not apply.
+          REGEXP_CONTAINS(key, r'^[a-z0-9_.\-]{2,60}$')
+          OR (value IS NULL AND REGEXP_CONTAINS(key, r'^[a-z0-9_.\-]{2,300}$'))
+        GROUP BY
+          key
+      )
+    ORDER BY
+      depth,
+      key
+  )
+);
+
+-- Tests
+SELECT
+  -- depth 0. Note the first parameter is found without a leading '?' or '&'.
+  mozfun.assert.map_equals(
+    [STRUCT('utm_source' AS key, 'example-store' AS value), ('utm_medium', 'organic')],
+    utils.extract_params_from_url('utm_source=example-store&utm_medium=organic')
+  ),
+  -- a bare click id with no 'key=' becomes a key with a NULL value
+  mozfun.assert.equals(
+    'vendor_c_i_abc123',
+    (SELECT p.key FROM UNNEST(utils.extract_params_from_url('vendor_c_i_abc123')) AS p)
+  ),
+  mozfun.assert.null(
+    (SELECT p.value FROM UNNEST(utils.extract_params_from_url('vendor_c_i_abc123')) AS p)
+  ),
+  -- depth 1: the partner preload shape
+  mozfun.assert.equals(
+    'partner-preinstall',
+    mozfun.map.get_key(
+      utils.extract_params_from_url(
+        'utm_source=partner-installs&utm_medium=preload&utm_campaign=tracker_id%3Dtrk123%26partner_click_id%3D1%26partner_campaign%3Dpartner-preinstall'
+      ),
+      'partner_campaign'
+    )
+  ),
+  mozfun.assert.equals(
+    'trk123',
+    mozfun.map.get_key(
+      utils.extract_params_from_url(
+        'utm_source=partner-installs&utm_medium=preload&utm_campaign=tracker_id%3Dtrk123%26partner_click_id%3D1%26partner_campaign%3Dpartner-preinstall'
+      ),
+      'tracker_id'
+    )
+  ),
+  -- the container survives, decoded, rather than being filtered away
+  mozfun.assert.equals(
+    'tracker_id=trk123&partner_click_id=1&partner_campaign=partner-preinstall',
+    mozfun.map.get_key(
+      utils.extract_params_from_url(
+        'utm_source=partner-installs&utm_medium=preload&utm_campaign=tracker_id%3Dtrk123%26partner_click_id%3D1%26partner_campaign%3Dpartner-preinstall'
+      ),
+      'utm_campaign'
+    )
+  ),
+  -- depth 2: whole string encoded, no literal '=' anywhere
+  mozfun.assert.equals(
+    'example.com',
+    mozfun.map.get_key(
+      utils.extract_params_from_url(
+        'utm_source%3Dexample.com%26utm_medium%3Dcontent%26utm_campaign%3Ddownload'
+      ),
+      'utm_source'
+    )
+  ),
+  mozfun.assert.equals(
+    'c_i_abc123',
+    mozfun.map.get_key(
+      utils.extract_params_from_url('external_click_id%3Dc_i_abc123'),
+      'external_click_id'
+    )
+  ),
+  -- ad_campaign_id, which the partner campaign id leaves unidentified
+  mozfun.assert.equals(
+    '123456',
+    mozfun.map.get_key(
+      utils.extract_params_from_url('utm_source=vendor_a&ad_campaign_id=123456&ad_source=1'),
+      'ad_campaign_id'
+    )
+  ),
+  -- the shallowest occurrence of a key wins, so get_key is deterministic
+  mozfun.assert.equals(
+    'shallow',
+    mozfun.map.get_key(
+      utils.extract_params_from_url('clid=shallow&utm_campaign=clid%3Ddeep'),
+      'clid'
+    )
+  ),
+  -- percent-encoded values are decoded, so one campaign is one campaign
+  mozfun.assert.equals(
+    'Summer Promo',
+    mozfun.map.get_key(utils.extract_params_from_url('utm_campaign=Summer%20Promo'), 'utm_campaign')
+  ),
+  -- split on the first '=' only, so base64 padding survives and is not re-split
+  mozfun.assert.equals(
+    'c_i_abc==',
+    mozfun.map.get_key(
+      utils.extract_params_from_url('external_click_id=c_i_abc=='),
+      'external_click_id'
+    )
+  ),
+  mozfun.assert.equals(
+    1,
+    ARRAY_LENGTH(utils.extract_params_from_url('external_click_id=c_i_abc=='))
+  ),
+  -- full-URL form: the scheme/host token carries no '=' and is dropped
+  mozfun.assert.equals(
+    2,
+    ARRAY_LENGTH(utils.extract_params_from_url('https://example.com/store?utm_source=x&utm_term=y'))
+  ),
+  -- an unsubstituted ad-server macro is a value like any other, not a crash
+  mozfun.assert.equals(
+    '{clid}',
+    mozfun.map.get_key(utils.extract_params_from_url('clid%3D%7Bclid%7D'), 'clid')
+  ),
+  -- bare tokens are not query strings and correctly yield nothing
+  -- a keyless token is only kept when it carries an underscore, so a bare package
+  -- name is still not a parameter
+  mozfun.assert.equals(0, ARRAY_LENGTH(utils.extract_params_from_url('com.example.app'))),
+  mozfun.assert.equals(0, ARRAY_LENGTH(utils.extract_params_from_url('referral'))),
+  mozfun.assert.equals(0, ARRAY_LENGTH(utils.extract_params_from_url(''))),
+  mozfun.assert.equals(0, ARRAY_LENGTH(utils.extract_params_from_url(NULL)));

--- a/sql/mozfun/utils/extract_params_from_url/udf.sql
+++ b/sql/mozfun/utils/extract_params_from_url/udf.sql
@@ -9,10 +9,11 @@ RETURNS ARRAY<STRUCT<key STRING, value STRING, depth INT64>> AS (
       depth
     FROM
       (
-        -- One row per key
+        -- One row per key. Shallowest wins, then first occurrence, so a key
+        -- repeated at the same depth still resolves the same way every run.
         SELECT
           key,
-          ANY_VALUE(value HAVING MIN depth) AS value,
+          ARRAY_AGG(value ORDER BY depth, off LIMIT 1)[SAFE_OFFSET(0)] AS value,
           MIN(depth) AS depth
         FROM
           (
@@ -21,7 +22,8 @@ RETURNS ARRAY<STRUCT<key STRING, value STRING, depth INT64>> AS (
             SELECT
               LOWER(TRIM(REGEXP_EXTRACT(kv, r'^([^=]+)'))) AS key,
               REGEXP_EXTRACT(kv, r'^[^=]+=(.*)$') AS value,
-              lvl.depth AS depth
+              lvl.depth AS depth,
+              off
             FROM
               UNNEST(
                 [
@@ -36,19 +38,21 @@ RETURNS ARRAY<STRUCT<key STRING, value STRING, depth INT64>> AS (
                   )
                 ]
               ) AS lvl,
-              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(lvl.s, ''), r'[^?&]+')) AS kv
+              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(lvl.s, ''), r'[^?&#]+')) AS kv
+              WITH OFFSET AS off
             WHERE
               REGEXP_CONTAINS(kv, r'=')
             UNION ALL
             -- depth 1: a query string nested in one value, the partner preload surface.
-            -- Per-value, not whole-string: decoding first loses the leading nested key,
-            -- and the encoded-value guard stops base64 click ids being re-split.
+            -- Per-value, not whole-string: decoding first loses the leading nested key.
             SELECT
               LOWER(TRIM(REGEXP_EXTRACT(nested_kv, r'^([^=]+)'))) AS key,
               REGEXP_EXTRACT(nested_kv, r'^[^=]+=(.*)$') AS value,
-              1 AS depth
+              1 AS depth,
+              off
             FROM
-              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(url, ''), r'[^?&]+')) AS kv,
+              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(url, ''), r'[^?&#]+')) AS kv
+              WITH OFFSET AS off,
               UNNEST(
                 REGEXP_EXTRACT_ALL(
                   REGEXP_REPLACE(
@@ -60,12 +64,14 @@ RETURNS ARRAY<STRUCT<key STRING, value STRING, depth INT64>> AS (
                     r'(?i)%26',
                     '&'
                   ),
-                  r'[^?&]+'
+                  r'[^?&#]+'
                 )
               ) AS nested_kv
             WHERE
               REGEXP_CONTAINS(kv, r'(?i)%3D|%26')
-              AND REGEXP_CONTAINS(nested_kv, r'=')
+              -- Require a non-'=' after the separator, so encoded base64
+              -- padding ('%3D%3D') does not fabricate a key.
+              AND REGEXP_CONTAINS(nested_kv, r'^[^=]+=[^=]')
             UNION ALL
             -- depth 0, keyless: some referrers are a bare click id with no 'key='
             -- at all. The token is the signal, so it is emitted as the key with a
@@ -74,9 +80,11 @@ RETURNS ARRAY<STRUCT<key STRING, value STRING, depth INT64>> AS (
             SELECT
               LOWER(TRIM(kv)) AS key,
               CAST(NULL AS STRING) AS value,
-              0 AS depth
+              0 AS depth,
+              off
             FROM
-              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(url, ''), r'[^?&]+')) AS kv
+              UNNEST(REGEXP_EXTRACT_ALL(IFNULL(url, ''), r'[^?&#]+')) AS kv
+              WITH OFFSET AS off
             WHERE
               NOT REGEXP_CONTAINS(kv, r'=')
               AND REGEXP_CONTAINS(kv, r'_')
@@ -84,7 +92,7 @@ RETURNS ARRAY<STRUCT<key STRING, value STRING, depth INT64>> AS (
         WHERE
           -- Drop junk keys from splitting a non-query-string. A keyless token is the
           -- signal itself, so it is kept whole and the 60-char cap does not apply.
-          REGEXP_CONTAINS(key, r'^[a-z0-9_.\-]{2,60}$')
+          REGEXP_CONTAINS(key, r'^[a-z0-9_.\-]{1,60}$')
           OR (value IS NULL AND REGEXP_CONTAINS(key, r'^[a-z0-9_.\-]{2,300}$'))
         GROUP BY
           key
@@ -198,6 +206,35 @@ SELECT
   mozfun.assert.equals(
     '{clid}',
     mozfun.map.get_key(utils.extract_params_from_url('clid%3D%7Bclid%7D'), 'clid')
+  ),
+  -- encoded base64 padding is not a nested pair, so no key is fabricated
+  mozfun.assert.equals(1, ARRAY_LENGTH(utils.extract_params_from_url('clid=YWJjZA%3D%3D'))),
+  mozfun.assert.equals(
+    'YWJjZA==',
+    mozfun.map.get_key(utils.extract_params_from_url('clid=YWJjZA%3D%3D'), 'clid')
+  ),
+  -- a fragment ends the preceding value rather than being absorbed into it
+  mozfun.assert.equals(
+    'y',
+    mozfun.map.get_key(
+      utils.extract_params_from_url('https://example.com/store?utm_source=x&utm_term=y#section'),
+      'utm_term'
+    )
+  ),
+  -- parameters after a fragment are still returned
+  mozfun.assert.equals(
+    'abc',
+    mozfun.map.get_key(utils.extract_params_from_url('utm_source=x&ie=utf-8#sbfbu=1&pi=abc'), 'pi')
+  ),
+  -- a key repeated at the same depth resolves to the first occurrence
+  mozfun.assert.equals(
+    'a',
+    mozfun.map.get_key(utils.extract_params_from_url('utm_source=a&utm_source=b'), 'utm_source')
+  ),
+  -- single-character keys are kept
+  mozfun.assert.equals(
+    '1',
+    mozfun.map.get_key(utils.extract_params_from_url('q=1&utm_source=x'), 'q')
   ),
   -- bare tokens are not query strings and correctly yield nothing
   -- a keyless token is only kept when it carries an underscore, so a bare package

--- a/sql/mozfun/utils/url_decode/README.md
+++ b/sql/mozfun/utils/url_decode/README.md
@@ -1,0 +1,7 @@
+This UDF percent-decodes a string. BigQuery has no native URL decode, so escapes are
+tokenised and converted with `FROM_HEX`.
+
+Consecutive escapes are grouped into a single run before decoding, so a multi-byte UTF-8
+sequence such as `%C3%A9` becomes `é` rather than two invalid bytes. A stray `%` that
+begins no valid escape is kept as it arrived, and `+` is left as a literal `+` rather
+than decoded to a space, so base64 values survive intact.

--- a/sql/mozfun/utils/url_decode/metadata.yaml
+++ b/sql/mozfun/utils/url_decode/metadata.yaml
@@ -1,0 +1,4 @@
+description: |-
+  Percent-decodes a string. A stray '%' is kept as it arrived, and '+' is
+  not treated as a space.
+friendly_name: URL Decode

--- a/sql/mozfun/utils/url_decode/udf.sql
+++ b/sql/mozfun/utils/url_decode/udf.sql
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION utils.url_decode(s STRING) AS (
+  IFNULL(
+    (
+      SELECT
+        -- Reassemble in original order; UNNEST does not preserve it.
+        STRING_AGG(
+          IF(
+            -- Length guard: a lone '%' is not an escape.
+            STARTS_WITH(tok, '%')
+            AND LENGTH(tok) > 1,
+            -- '%C3%A9' -> 'C3A9' -> bytes -> 'é'.
+            -- Bad bytes give U+FFFD. SAFE_CAST would NULL, and
+            -- STRING_AGG skips NULLs, dropping the token silently.
+            SAFE_CONVERT_BYTES_TO_STRING(FROM_HEX(REPLACE(tok, '%', ''))),
+            tok
+          ),
+          ''
+          ORDER BY
+            off
+        )
+      FROM
+        -- Three token types: escape run, stray '%', plain text.
+        -- Runs stay whole so multi-byte UTF-8 decodes as one unit.
+        -- '+' is plain text, so never becomes a space.
+        UNNEST(REGEXP_EXTRACT_ALL(s, r'(?:%[0-9a-fA-F]{2})+|%|[^%]+')) AS tok
+        WITH OFFSET AS off
+    ),
+    -- STRING_AGG over no rows is NULL, so '' and NULL both fall through here.
+    s
+  )
+);
+
+-- Tests
+SELECT
+  mozfun.assert.null(utils.url_decode(NULL)),
+  mozfun.assert.equals('', utils.url_decode('')),
+  mozfun.assert.equals('plain_token', utils.url_decode('plain_token')),
+  -- one campaign arriving as two spellings is the reason this exists
+  mozfun.assert.equals('Summer Promo', utils.url_decode('Summer%20Promo')),
+  mozfun.assert.equals('a b', utils.url_decode('a%20b')),
+  -- lowercase escapes decode too
+  mozfun.assert.equals('a+b', utils.url_decode('a%2bb')),
+  -- multi-byte UTF-8 survives: the run decodes as one unit, not per byte
+  mozfun.assert.equals('café', utils.url_decode('caf%C3%A9')),
+  -- adjacent escapes are one run and still decode individually
+  mozfun.assert.equals('=&', utils.url_decode('%3D%26')),
+  -- '+' is not decoded to a space: base64 click ids carry a literal '+'
+  mozfun.assert.equals('c_i_a+b', utils.url_decode('c_i_a+b')),
+  -- a stray '%' is not an escape and is kept rather than dropped
+  mozfun.assert.equals('100%', utils.url_decode('100%')),
+  mozfun.assert.equals('50%off', utils.url_decode('50%off')),
+  mozfun.assert.equals('%', utils.url_decode('%')),
+  -- too few digits, or non-hex digits, is not an escape either
+  mozfun.assert.equals('%2', utils.url_decode('%2')),
+  mozfun.assert.equals('%GG', utils.url_decode('%GG')),
+  -- one pass only, so an encoded '%' is not decoded twice
+  mozfun.assert.equals('a%20b', utils.url_decode('a%2520b')),
+  -- a truncated sequence gives U+FFFD, making the loss visible not silent
+  mozfun.assert.equals('caf�x', utils.url_decode('caf%C3x')),
+  -- separators decode like any other escape
+  mozfun.assert.equals(
+    'tracker_id=abc&partner_campaign=partner-preinstall',
+    utils.url_decode('tracker_id%3Dabc%26partner_campaign%3Dpartner-preinstall')
+  );


### PR DESCRIPTION
## Description
Adds two `mozfun` UDFs for pulling the individual fields out of a URL or an app store install referrer.

`utils.extract_params_from_url` takes a string like `utm_source=store&utm_campaign=summer` and returns each field name and value separately, so any field can be looked up by name. The existing `utils.extract_utm_from_url` only recognises five fixed field names, and it misses the first field unless the string starts with a `?` — which install referrers usually don't. The new UDF accepts any field name, and it also finds fields hidden inside another field's value, or sent with their `=` and `&` characters escaped. If the same name appears twice, the outer one wins, so results are predictable.

`utils.url_decode` converts escape codes such as `%20` back into the characters they stand for, which BigQuery cannot do on its own. Without it, a single campaign can show up under two different names — `Summer%20Promo` and `Summer Promo`. Accented and non-Latin text converts correctly instead of turning into question marks, a lone `%` is left as it arrived, and a `+` stays a `+` so click ids containing one are not damaged.

## Related Tickets & Documents
* https://mozilla-hub.atlassian.net/browse/DENG-11579

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
