### PR TITLE
feat: upgrade base docker image to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG PYTHON_VERSION=3.11
 ARG GOOGLE_CLOUD_SDK_VERSION=552.0.0
 
 # --platform=linux/amd64 added to prevent pulling ARM images when run on Apple Silicon
-FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-bullseye AS base
+FROM --platform=linux/amd64 python:${PYTHON_VERSION}-slim-bookworm AS base
 WORKDIR /app
 
 # build typed-ast in separate stage because it requires gcc and libc-dev
@@ -20,7 +20,7 @@ FROM base
 # add bash for entrypoint
 RUN mkdir -p /usr/share/man/man1 && apt-get update -qqy && apt-get install -qqy bash git jq
 COPY --from=google-cloud-sdk /google-cloud-sdk /google-cloud-sdk
-ENV PATH /google-cloud-sdk/bin:$PATH
+ENV PATH=/google-cloud-sdk/bin:$PATH
 COPY --from=python-deps /usr/local /usr/local
 COPY .bigqueryrc /root/
 COPY . .


### PR DESCRIPTION
# feat: upgrade base docker image to bookworm

Currently the base image we use fails to build. This resolves that problem.