### PR TITLE
fix: remove --date argument from nimbus_sizing_clients_v1 metadata template

### DIFF
--- a/sql_generators/experiment_monitoring/templates/nimbus_sizing_clients_v1/metadata.yaml
+++ b/sql_generators/experiment_monitoring/templates/nimbus_sizing_clients_v1/metadata.yaml
@@ -25,7 +25,6 @@ labels:
   owner1: nimbus
 scheduling:
   dag_name: bqetl_experiments_daily
-  arguments: ["--date", "{% raw %}{{ ds }}{% endraw %}"]
   referenced_tables:
     - ['moz-fx-data-shared-prod', '{{ source_dataset }}', '{{ source_table }}']
 bigquery:


### PR DESCRIPTION
## Summary

- `--date` is not a valid `bq query` CLI flag — only valid for Python scripts with argparse
- bqetl already auto-adds `--parameter=submission_date:DATE` from `@submission_date` in the SQL
- The spurious `--date` arg was causing all three `nimbus_sizing_clients_v1` Airflow tasks to fail with `Unknown command line flag 'date'`
- Followup fix to #9824

Jira: [EXP-7366](https://mozilla-hub.atlassian.net/browse/EXP-7366)

[EXP-7366]: https://mozilla-hub.atlassian.net/browse/EXP-7366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ