### PR TITLE
Run Test bqetl CI task on SQL changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,7 +308,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, decide-runs]
     if: |
-      (needs.decide-runs.outputs.validate-bqetl == 'true' || needs.decide-runs.outputs.deploy == 'true')
+      (needs.decide-runs.outputs.validate-bqetl == 'true' ||
+       needs.decide-runs.outputs.validate-sql == 'true' ||
+       needs.decide-runs.outputs.deploy == 'true')
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Description

Follow-up to https://github.com/mozilla/bigquery-etl/pull/9824

Run Test bqetl CI task when changes are made to `sql/`. The test bqetl CI step was meant to run when tooling changes were made. But over time query tests are no longer just in `tests/sql/` but got added directly under `tests/` , so those tests aren't actually running without this change. 

See: https://mozilla.slack.com/archives/C01E8GDG80N/p1788986168051969

<!--
Please reference related Jira tickets, GitHub issues or Bugzilla. This repo has been
configured to automatically insert hyperlinks for DSRE and DENG tickets.
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-autolinks-to-reference-external-resources
-->

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
