### PR TITLE
fix(config): Avoid adding duplicate items when merging config lists

### DIFF
--- a/bigquery_etl/config.py
+++ b/bigquery_etl/config.py
@@ -64,7 +64,9 @@ class _ConfigLoader:
                     self._update_config(current_value, extra_value, current_path_keys)
             elif current_type is list:
                 if extra_value:
-                    current_value.extend(extra_value)
+                    current_value.extend(
+                        [item for item in extra_value if item not in current_value]
+                    )
             else:
                 config[extra_key] = extra_value
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,7 @@ class TestConfig:
             dry_run:
               function: override
               skip:
+              - sql/moz-fx-data-shared-prod/test_derived/another_query_v1/query.sql
               - sql/moz-fx-data-shared-prod/test_derived/yet_another_query_v1/query.sql
 
             another_section:


### PR DESCRIPTION
## Description
Now that `bqetl` automatically merges a local `bqetl_project.yaml` config with a root `bqetl_project.yaml` config from an editable `bigquery-etl` install (https://github.com/mozilla/bigquery-etl/pull/9851), some config list items that are present in both [bigquery-etl/bqetl_project.yaml](https://github.com/mozilla/bigquery-etl/blob/main/bqetl_project.yaml) and [private-bigquery-etl/bqetl_project.yaml](https://github.com/mozilla/private-bigquery-etl/blob/main/bqetl_project.yaml) are getting duplicated when `bqetl` is run in the `private-bigquery-etl` repo (e.g. both configs have `sql_generators/**/*.sql` and `tests/**/*.sql` in the `format.skip` list).

## Related Tickets & Documents
* https://github.com/mozilla/bigquery-etl/pull/9851

**Reviewer, please follow [this checklist](https://github.com/mozilla/bigquery-etl/blob/main/.github/reviewer_checklist.md)**
